### PR TITLE
Persist Hive metastore on docker container restart

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@
 __pycache__/
 # emacs backup files
 *~
+
+# Hive metastore
+.hive_metastore/

--- a/presto/docker/docker-compose.common.yml
+++ b/presto/docker/docker-compose.common.yml
@@ -2,6 +2,7 @@ services:
   presto-base-volumes:
     volumes:
       - ./config/etc_common:/opt/presto-server/etc
+      - ./.hive_metastore:/var/lib/presto/data/hive/metastore
       - ../testing/integration_tests/data:/var/lib/presto/data/hive/data/integration_test
 
   presto-base-coordinator:


### PR DESCRIPTION
Executing the `run_integ_test.sh` script with the `--keep-tables` option ensures that created tables are persisted after the integration tests are run. However, these tables are removed whenever the presto server containers are restarted. This update ensures that the tables are kept after container restarts.