### PR TITLE
Misiug/min python

### DIFF
--- a/benchmark_data_tools/generate_data_files.py
+++ b/benchmark_data_tools/generate_data_files.py
@@ -93,7 +93,7 @@ def rearrange_directory(raw_data_path, num_partitions):
     tables = []
     for p_file in parquet_files:
         tables.append(p_file.replace(".parquet", ""))
-    
+
     for table in tables:
         Path(f"{raw_data_path}/{table}").mkdir(parents=True, exist_ok=True)
 
@@ -131,7 +131,7 @@ def get_select_query(table_name, convert_decimals_to_floats):
             get_column_projection(column_metadata, convert_decimals_to_floats)
             for column_metadata in column_metadata_rows
         ]
-        query = f"SELECT {",".join(column_projections)} FROM {table_name}"
+        query = f"SELECT {','.join(column_projections)} FROM {table_name}"
     else:
         query = f"SELECT * FROM {table_name}"
     return query
@@ -145,8 +145,8 @@ def get_column_projection(column_metadata, convert_decimals_to_floats):
     return projection
 
 if __name__ == "__main__":
-    if (sys.version_info < (3, 12)):
-        sys.exit(f"Error: generate_data_files.py requires minimum Python 3.12")
+    if (sys.version_info < (3, 10)):
+        sys.exit(f"Error: generate_data_files.py requires minimum Python 3.10")
 
     parser = argparse.ArgumentParser(
         description="Generate benchmark parquet data files for a given scale factor. "

--- a/benchmark_data_tools/generate_data_files.py
+++ b/benchmark_data_tools/generate_data_files.py
@@ -145,9 +145,6 @@ def get_column_projection(column_metadata, convert_decimals_to_floats):
     return projection
 
 if __name__ == "__main__":
-    if (sys.version_info < (3, 10)):
-        sys.exit(f"Error: generate_data_files.py requires minimum Python 3.10")
-
     parser = argparse.ArgumentParser(
         description="Generate benchmark parquet data files for a given scale factor. "
                     "Only the TPC-H and TPC-DS benchmarks are currently supported.")

--- a/benchmark_data_tools/generate_data_files.py
+++ b/benchmark_data_tools/generate_data_files.py
@@ -5,6 +5,7 @@ import subprocess
 import os
 import shutil
 import math
+import sys
 
 from duckdb_utils import init_benchmark_tables, is_decimal_column
 from pathlib import Path
@@ -144,6 +145,9 @@ def get_column_projection(column_metadata, convert_decimals_to_floats):
     return projection
 
 if __name__ == "__main__":
+    if (sys.version_info < (3, 12)):
+        sys.exit(f"Error: generate_data_files.py requires minimum Python 3.12")
+
     parser = argparse.ArgumentParser(
         description="Generate benchmark parquet data files for a given scale factor. "
                     "Only the TPC-H and TPC-DS benchmarks are currently supported.")

--- a/benchmark_data_tools/generate_data_files.py
+++ b/benchmark_data_tools/generate_data_files.py
@@ -5,7 +5,6 @@ import subprocess
 import os
 import shutil
 import math
-import sys
 
 from duckdb_utils import init_benchmark_tables, is_decimal_column
 from pathlib import Path

--- a/benchmark_data_tools/generate_table_schemas.py
+++ b/benchmark_data_tools/generate_table_schemas.py
@@ -23,8 +23,7 @@ def get_table_schema(benchmark_type, table_name, schema_name, convert_decimals_t
         f"{' ' * 4}{get_column_definition(column_metadata, convert_decimals_to_floats)}"
         for column_metadata in column_metadata_rows
     ]
-    nl = '\n'
-    columns_text = f"{',{nl}'.join(columns_ddl_list)}"
+    columns_text = ",\n".join(columns_ddl_list)
     schema = f"CREATE TABLE hive.{schema_name}.{table_name} \
     (\n{columns_text}\n) \
     WITH (FORMAT = 'PARQUET', EXTERNAL_LOCATION = 'file:{{file_path}}')"

--- a/benchmark_data_tools/generate_table_schemas.py
+++ b/benchmark_data_tools/generate_table_schemas.py
@@ -24,8 +24,9 @@ def get_table_schema(benchmark_type, table_name, schema_name, convert_decimals_t
         for column_metadata in column_metadata_rows
     ]
     nl = '\n'
+    columns_text = f"{',{nl}'.join(columns_ddl_list)}"
     schema = f"CREATE TABLE hive.{schema_name}.{table_name} \
-    ({nl}{',{nl}'.join(columns_ddl_list)}{nl}) \
+    (\n{columns_text}\n) \
     WITH (FORMAT = 'PARQUET', EXTERNAL_LOCATION = 'file:{{file_path}}')"
     return schema
 

--- a/benchmark_data_tools/generate_table_schemas.py
+++ b/benchmark_data_tools/generate_table_schemas.py
@@ -23,9 +23,10 @@ def get_table_schema(benchmark_type, table_name, schema_name, convert_decimals_t
         f"{' ' * 4}{get_column_definition(column_metadata, convert_decimals_to_floats)}"
         for column_metadata in column_metadata_rows
     ]
-    schema = (f"CREATE TABLE hive.{schema_name}.{table_name} "
-              f"(\n{",\n".join(columns_ddl_list)}\n) "
-              f"WITH (FORMAT = 'PARQUET', EXTERNAL_LOCATION = 'file:{{file_path}}')")
+    nl = '\n'
+    schema = f"CREATE TABLE hive.{schema_name}.{table_name} \
+    ({nl}{',{nl}'.join(columns_ddl_list)}{nl}) \
+    WITH (FORMAT = 'PARQUET', EXTERNAL_LOCATION = 'file:{{file_path}}')"
     return schema
 
 

--- a/presto/testing/integration_tests/scripts/generate_test_files.sh
+++ b/presto/testing/integration_tests/scripts/generate_test_files.sh
@@ -87,6 +87,12 @@ else
   BENCHMARK_TYPES_TO_GENERATE=($BENCHMARK_TYPE)
 fi
 
+PYTHON_VERSION=$(python3 -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')
+if (( $(echo "$PYTHON_VERSION < 3.12" | bc -l) )); then
+    echo "Error: Minimum required python version is 3.12."
+    exit 1
+fi
+
 rm -rf .venv
 python3 -m venv .venv
 source .venv/bin/activate

--- a/presto/testing/integration_tests/scripts/generate_test_files.sh
+++ b/presto/testing/integration_tests/scripts/generate_test_files.sh
@@ -87,12 +87,6 @@ else
   BENCHMARK_TYPES_TO_GENERATE=($BENCHMARK_TYPE)
 fi
 
-PYTHON_VERSION=$(python3 -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')
-if (( $(echo "$PYTHON_VERSION < 3.10" | bc -l) )); then
-    echo "Error: Minimum required python version is 3.10."
-    exit 1
-fi
-
 rm -rf .venv
 python3 -m venv .venv
 source .venv/bin/activate

--- a/presto/testing/integration_tests/scripts/generate_test_files.sh
+++ b/presto/testing/integration_tests/scripts/generate_test_files.sh
@@ -88,8 +88,8 @@ else
 fi
 
 PYTHON_VERSION=$(python3 -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')
-if (( $(echo "$PYTHON_VERSION < 3.12" | bc -l) )); then
-    echo "Error: Minimum required python version is 3.12."
+if (( $(echo "$PYTHON_VERSION < 3.10" | bc -l) )); then
+    echo "Error: Minimum required python version is 3.10."
     exit 1
 fi
 


### PR DESCRIPTION
Some features in `generate_data_files.py` requires python 3.12, but no formal requirement was put in the scripts.

Presumably we can automatically add python 3.12 to the environment, but I figured we should add the requirements here first in case anyone else runs into this issue.