### PR TITLE
Add support for running integration tests against existing schemas

### DIFF
--- a/presto/scripts/common_functions.sh
+++ b/presto/scripts/common_functions.sh
@@ -4,9 +4,13 @@ function wait_for_worker_node_registration() {
   trap "rm -rf node_response.json" RETURN
 
   echo "Waiting for a worker node to be registered..."
+  HOSTNAME=${1:-localhost}
+  PORT=${2:-8080}
+  COORDINATOR_URL=http://${HOSTNAME}:${PORT}
+  echo "Coordinator URL: $COORDINATOR_URL"
   local -r MAX_RETRIES=5
   local retry_count=0
-  until curl -s -f -o node_response.json http://localhost:8080/v1/node && \
+  until curl -s -f -o node_response.json ${COORDINATOR_URL}/v1/node && \
         (( $(jq length node_response.json) > 0 )); do
     if (( $retry_count >= $MAX_RETRIES )); then
       echo "Error: Worker node not registered"

--- a/presto/scripts/run_integ_test.sh
+++ b/presto/scripts/run_integ_test.sh
@@ -143,10 +143,6 @@ if [[ -n ${SCHEMA_NAME} ]]; then
   PYTEST_ARGS+=("--schema-name ${SCHEMA_NAME}")
 fi
 
-source ./common_functions.sh
-
-wait_for_worker_node_registration "$HOST_NAME" "$PORT"
-
 source ../../scripts/py_env_functions.sh
 
 trap delete_python_virtual_env EXIT
@@ -154,5 +150,9 @@ trap delete_python_virtual_env EXIT
 init_python_virtual_env
 
 pip install -q -r ${INTEGRATION_TEST_DIR}/requirements.txt
+
+source ./common_functions.sh
+
+wait_for_worker_node_registration "$HOST_NAME" "$PORT"
 
 pytest -v ${INTEGRATION_TEST_DIR}/${BENCHMARK_TYPE}_test.py ${PYTEST_ARGS[*]}

--- a/presto/scripts/run_integ_test.sh
+++ b/presto/scripts/run_integ_test.sh
@@ -2,12 +2,6 @@
 
 set -e
 
-function cleanup() {
-  rm -rf .venv
-}
-
-trap cleanup EXIT
-
 print_help() {
   cat << EOF
 
@@ -121,13 +115,7 @@ if [[ -z ${BENCHMARK_TYPE} || ! ${BENCHMARK_TYPE} =~ ^tpc(h|ds)$ ]]; then
   exit 1
 fi
 
-rm -rf .venv
-python3 -m venv .venv
-source .venv/bin/activate
-
 INTEGRATION_TEST_DIR=$(readlink -f ../testing/integration_tests)
-
-pip install -q -r ${INTEGRATION_TEST_DIR}/requirements.txt
 
 PYTEST_ARGS=()
 
@@ -158,5 +146,13 @@ fi
 source ./common_functions.sh
 
 wait_for_worker_node_registration "$HOST_NAME" "$PORT"
+
+source ../../scripts/py_env_functions.sh
+
+trap delete_python_virtual_env EXIT
+
+init_python_virtual_env
+
+pip install -q -r ${INTEGRATION_TEST_DIR}/requirements.txt
 
 pytest -v ${INTEGRATION_TEST_DIR}/${BENCHMARK_TYPE}_test.py ${PYTEST_ARGS[*]}

--- a/presto/testing/integration_tests/common_fixtures.py
+++ b/presto/testing/integration_tests/common_fixtures.py
@@ -8,8 +8,12 @@ from . import test_utils
 @pytest.fixture(scope="module")
 def presto_cursor(request):
     benchmark_type = request.node.obj.BENCHMARK_TYPE
-    conn = prestodb.dbapi.connect(host="localhost", port=8080, user="test_user", catalog="hive",
-                                  schema=f"{benchmark_type}_test")
+    hostname = request.config.getoption("--hostname")
+    port = request.config.getoption("--port")
+    user = request.config.getoption("--user")
+    schema = request.config.getoption("--schema-name")
+    schema = schema if schema else f"{benchmark_type}_test"
+    conn = prestodb.dbapi.connect(host=hostname, port=port, user=user, catalog="hive", schema=schema)
     return conn.cursor()
 
 
@@ -18,13 +22,16 @@ def setup_and_teardown(request, presto_cursor):
     benchmark_type = request.node.obj.BENCHMARK_TYPE
     test_utils.init_duckdb_tables(benchmark_type)
 
-    schema_name = f"{benchmark_type}_test"
-    schemas_dir = test_utils.get_abs_file_path(f"schemas/{benchmark_type}")
-    data_sub_directory = f"integration_test/{benchmark_type}"
-    create_hive_tables.create_tables(presto_cursor, schema_name, schemas_dir, data_sub_directory)
+    should_create_tables = False if request.config.getoption("--schema-name") else True
+    if should_create_tables:
+        schema_name = f"{benchmark_type}_test"
+        schemas_dir = test_utils.get_abs_file_path(f"schemas/{benchmark_type}")
+        data_sub_directory = f"integration_test/{benchmark_type}"
+        create_hive_tables.create_tables(presto_cursor, schema_name, schemas_dir, data_sub_directory)
 
     yield
 
-    keep_tables = request.config.getoption("--keep-tables")
-    if not keep_tables:
-        create_hive_tables.drop_schema(presto_cursor, schema_name)
+    if should_create_tables:
+        keep_tables = request.config.getoption("--keep-tables")
+        if not keep_tables:
+            create_hive_tables.drop_schema(presto_cursor, schema_name)

--- a/presto/testing/integration_tests/conftest.py
+++ b/presto/testing/integration_tests/conftest.py
@@ -5,6 +5,7 @@ def pytest_addoption(parser):
     parser.addoption("--port", default=8080)
     parser.addoption("--user", default="test_user")
     parser.addoption("--schema-name")
+    parser.addoption("--scale-factor")
 
 
 def pytest_generate_tests(metafunc):

--- a/presto/testing/integration_tests/conftest.py
+++ b/presto/testing/integration_tests/conftest.py
@@ -1,6 +1,10 @@
 def pytest_addoption(parser):
     parser.addoption("--queries")
     parser.addoption("--keep-tables", action="store_true", default=False)
+    parser.addoption("--hostname", default="localhost")
+    parser.addoption("--port", default=8080)
+    parser.addoption("--user", default="test_user")
+    parser.addoption("--schema-name")
 
 
 def pytest_generate_tests(metafunc):

--- a/presto/testing/integration_tests/test_utils.py
+++ b/presto/testing/integration_tests/test_utils.py
@@ -51,8 +51,8 @@ def compare_results(presto_rows, duckdb_rows, types, is_sorted_query):
     assert presto_rows == duckdb_rows
 
 
-def init_duckdb_tables(benchmark_type):
-    init_benchmark_tables(benchmark_type, get_scale_factor(benchmark_type))
+def init_duckdb_tables(benchmark_type, scale_factor):
+    init_benchmark_tables(benchmark_type, scale_factor)
 
 
 def execute_duckdb_query(query):


### PR DESCRIPTION
* Extend integration test script to allow testing against different hostnames, port numbers, usernames, and schemas.

* Update integration test script to use functions in py_env_functions.sh.