### PR TITLE
Changed tests to build duckdb tables from parquet files if they exist

### DIFF
--- a/benchmark_data_tools/duckdb_utils.py
+++ b/benchmark_data_tools/duckdb_utils.py
@@ -13,5 +13,21 @@ def init_benchmark_tables(benchmark_type, scale_factor):
 
     duckdb.sql(f"INSTALL {benchmark_type}; LOAD {benchmark_type}; CALL {function_name}(sf = {scale_factor});")
 
+def init_benchmark_tables_from_parquet(benchmark_type, scale_factor, data_path):
+    tables = duckdb.sql("SHOW TABLES").fetchall()
+    assert len(tables) == 0
+
+    if benchmark_type == "tpch":
+        duckdb.sql(f"CREATE TABLE customer AS SELECT * FROM '{data_path}/customer/*.parquet';")
+        duckdb.sql(f"CREATE TABLE lineitem AS SELECT * FROM '{data_path}/lineitem/*.parquet';")
+        duckdb.sql(f"CREATE TABLE nation AS SELECT * FROM '{data_path}/nation/*.parquet';")
+        duckdb.sql(f"CREATE TABLE orders AS SELECT * FROM '{data_path}/orders/*.parquet';")
+        duckdb.sql(f"CREATE TABLE part AS SELECT * FROM '{data_path}/part/*.parquet';")
+        duckdb.sql(f"CREATE TABLE partsupp AS SELECT * FROM '{data_path}/partsupp/*.parquet';")
+        duckdb.sql(f"CREATE TABLE region AS SELECT * FROM '{data_path}/region/*.parquet';")
+        duckdb.sql(f"CREATE TABLE supplier AS SELECT * FROM '{data_path}/supplier/*.parquet';")
+    else:
+        init_benchmark_tables(benchmark_type, scale_factor)
+
 def is_decimal_column(column_type):
     return bool(re.match(r"^DECIMAL\(\d+,\d+\)$", column_type))

--- a/benchmark_data_tools/generate_data_files.py
+++ b/benchmark_data_tools/generate_data_files.py
@@ -92,7 +92,7 @@ def rearrange_directory(raw_data_path, num_partitions):
     tables = []
     for p_file in parquet_files:
         tables.append(p_file.replace(".parquet", ""))
-    
+
     for table in tables:
         Path(f"{raw_data_path}/{table}").mkdir(parents=True, exist_ok=True)
 
@@ -147,21 +147,21 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(
         description="Generate benchmark parquet data files for a given scale factor. "
                     "Only the TPC-H and TPC-DS benchmarks are currently supported.")
-    parser.add_argument("--benchmark-type", type=str, required=True, choices=["tpch", "tpcds"],
+    parser.add_argument("-b", "--benchmark-type", type=str, required=True, choices=["tpch", "tpcds"],
                         help="The type of benchmark to generate data for.")
-    parser.add_argument("--data-dir-path", type=str, required=True,
+    parser.add_argument("-d", "--data-dir-path", type=str, required=True,
                         help="The path to the directory that will contain the benchmark data files. "
                              "This directory will be created if it does not already exist.")
-    parser.add_argument("--scale-factor", type=str, required=True,
+    parser.add_argument("-s", "--scale-factor", type=str, required=True,
                         choices=["0.01", "0.1", "1", "10", "100", "1000"],
                         help="The scale factor of the generated dataset.")
-    parser.add_argument("--convert-decimals-to-floats", action="store_true", required=False,
+    parser.add_argument("-c", "--convert-decimals-to-floats", action="store_true", required=False,
                         default=False, help="Convert all decimal columns to float column type.")
     parser.add_argument("--use-duckdb", action="store_true", required=False,
                         default=False, help="Use duckdb instead of tpchgen")
-    parser.add_argument("--num-threads", type=int, required=False,
+    parser.add_argument("-j", "--num-threads", type=int, required=False,
                         default=4, help="Number of threads to generate data with tpchgen")
-    parser.add_argument("--verbose", action="store_true", required=False,
+    parser.add_argument("-v", "--verbose", action="store_true", required=False,
                         default=False, help="Extra verbose logging")
     parser.add_argument("--max-rows-per-file", type=int, required=False,
                         default=100_000_000, help="Limit number of rows in each file (creates more partitions)")

--- a/presto/scripts/run_integ_test.sh
+++ b/presto/scripts/run_integ_test.sh
@@ -32,7 +32,7 @@ EOF
 
 KEEP_TABLES=false
 
-parse_args() { 
+parse_args() {
   while [[ $# -gt 0 ]]; do
     case $1 in
       -h|--help)

--- a/presto/testing/integration_tests/test_utils.py
+++ b/presto/testing/integration_tests/test_utils.py
@@ -13,7 +13,7 @@ import json
 import pytest
 import sqlglot
 
-from duckdb_utils import init_benchmark_tables
+from duckdb_utils import init_benchmark_tables_from_parquet
 
 
 def get_queries(benchmark_type):
@@ -52,7 +52,7 @@ def compare_results(presto_rows, duckdb_rows, types, is_sorted_query):
 
 
 def init_duckdb_tables(benchmark_type):
-    init_benchmark_tables(benchmark_type, get_scale_factor(benchmark_type))
+    init_benchmark_tables_from_parquet(benchmark_type, get_scale_factor(benchmark_type), get_abs_file_path(f"data/{benchmark_type}"))
 
 
 def execute_duckdb_query(query):

--- a/presto/testing/integration_tests/tpch_test.py
+++ b/presto/testing/integration_tests/tpch_test.py
@@ -9,8 +9,11 @@ BENCHMARK_TYPE = "tpch"
 @pytest.fixture(scope="module")
 def tpch_queries():
     queries = test_utils.get_queries(BENCHMARK_TYPE)
+    scale_factor = test_utils.get_scale_factor(BENCHMARK_TYPE)
+    value_ratio = 0.0001 / float(scale_factor)
     # Referencing the CTE defined "supplier_no" alias in the parent query causes issues on presto.
     queries["Q15"] = queries["Q15"].replace(" AS supplier_no", "").replace("supplier_no", "l_suppkey")
+    queries["Q11"] = queries["Q11"].replace("0.0001000000", str(value_ratio))
     return queries
 
 


### PR DESCRIPTION
The existing integration tests created presto tables backed by parquet files in the `data` directory and ran the tpch queries against them.  These queries were also run against duckdb, where the tables were generated by duckdb's internal tpch generation tools.  The results of both queries were then compared.

This leads to incorrect comparisons when the source parquet files were generated using a different source than duckdb, as the random seed used, as well as the dictionary used to generate random content for the tables will not necessarily be the same.  Particularly the *_address and *_comment columns are almost completely different when generated via different tpch generation tools, therefore the comparison was failing.

This patch changes the integration tests so that the duckdb tables are generated by backing against the same parquet files that are used to back the presto tables, therefore guaranteeing the same data is used for both comparisons.  The query results now line up for larger scale factors.