### PR TITLE
Fixed issue with attempted conda deactivation breaking scripts

### DIFF
--- a/scripts/py_env_functions.sh
+++ b/scripts/py_env_functions.sh
@@ -42,6 +42,7 @@ function init_conda() {
     fi
   fi
   unset __conda_setup
+  LOCAL_CONDA_INIT=true # keep track of whether we set up the current conda environment
   echo "Conda initialization completed"
 }
 
@@ -65,7 +66,6 @@ function init_python_virtual_env() {
     fi
 
     init_conda
-    LOCAL_CONDA_INIT=true # keep track of whether we set up the current conda environment
 
     echo "Creating virtual environment using conda"
     conda create -q -y --prefix ".venv" python=3.12 > /dev/null


### PR DESCRIPTION
The current conda deactivation code attempts to deactivate the current conda environment as long as conda is installed on the system; there is no check, however, that the conda environment has been initialized.  Therefore we can run into the circumstance where we attempt to deactivate a conda environment that has never been initialized which leads to an error:
```
> conda deactivate
Deactivating conda environment
CondaError: Run 'conda init' before 'conda deactivate'
```
Since our scripts tend to run with "-e", this means we may end up aborting early, causing silent issues for scripts like `setup_benchmark_data_and_tables.sh` which expects to perform more tasks after invoking a python script and consequently shutting down the python environment.

This patch fixes the issue by checking if the conda environment has been activated using the local environment before calling `conda deactivate`.