### PR TITLE
Fix velox/scripts/benchmark_velox.sh

### DIFF
--- a/velox/scripts/benchmark_velox.sh
+++ b/velox/scripts/benchmark_velox.sh
@@ -29,6 +29,8 @@ NUM_REPEATS=2
 COMPOSE_FILE="../docker/docker-compose.adapters.benchmark.yml"
 CONTAINER_NAME="velox-benchmark"  # Uses dedicated benchmark service with pre-configured volumes
 
+# Source benchmark-specific libraries
+source "../benchmarks/tpch.sh"
 
 print_help() {
   cat <<EOF
@@ -303,9 +305,6 @@ create_docker_env_file
 
 # Get BUILD_TYPE from container environment
 export BUILD_TYPE=$(run_in_container "echo \$BUILD_TYPE")
-
-# Source benchmark-specific libraries
-source "../benchmarks/tpch.sh"
 
 # Check benchmark data 
 check_benchmark_data


### PR DESCRIPTION
This script was broken in #54 because the `source tpch.sh` was moved below new functions, one of which calls a function (`get_tpch_default_queries`) that it defines, this resulting in an immediate failure...
```
./benchmark_velox.sh: line 160: get_tpch_default_queries: command not found
```