### PR TITLE
Update S3 Fetch Script to allow use of simple personal/group AWS keys

### DIFF
--- a/scripts/fetch_docker_image_from_s3.sh
+++ b/scripts/fetch_docker_image_from_s3.sh
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -euo pipefail
+set -e
 
 #
 # fetch_docker_image_from_s3 <imagename> <subdir> <filename>
@@ -46,7 +46,7 @@ fetch_docker_image_from_s3() {
 
   # these env vars are required regardless of what creds are used
   echo "Validating incoming environment..."
-  if [ ! -v AWS_ACCESS_KEY_ID ] || [ ! -v AWS_SECRET_ACCESS_KEY ] || [ ! -v S3_BUCKET_NAME ] || [ ! -v S3_BUCKET_REGION ]; then
+  if [ -z "${AWS_ACCESS_KEY_ID}" ] || [ -z "${AWS_SECRET_ACCESS_KEY}" ] || [ -z "${S3_BUCKET_NAME}" ] || [ -z "${S3_BUCKET_REGION}" ]; then
     echo "ERROR: The following values must be set in the environment:"
     echo "  AWS_ARN_STRING (optional)"
     echo "  AWS_ACCESS_KEY_ID"
@@ -65,7 +65,7 @@ fetch_docker_image_from_s3() {
 
   # if AWS_ARN_STRING is set in the environment, use environment creds to request new
   # temporary rolling creds for the private bucket, otherwise use environment creds directly
-  if [ -v AWS_ARN_STRING ]; then
+  if [ ! -z "${AWS_ARN_STRING}" ]; then
     # ask for temporary credentials for file access
     echo "Requesting temporary S3 credentials..."
     local TEMP_CREDS_JSON=$(aws sts assume-role \


### PR DESCRIPTION
For the CI case, NV security policy obliges the use of an `assume-role` operation to obtain temporary rolling keys for the private bucket.

For the dev case, we allow use of static simple personal/group keys which have permanent bucket access.