### PR TITLE
Add libnvjitlink dependency for Velox builds with cuDF >= 25.10

### DIFF
--- a/velox/docker/adapters_build.dockerfile
+++ b/velox/docker/adapters_build.dockerfile
@@ -50,6 +50,9 @@ WORKDIR /workspace/velox
 # Print environment variables for debugging
 RUN printenv | sort
 
+# Install libnvjitlink which is needed for cuDF >= 25.10
+RUN dnf install -y libnvjitlink-devel-$(echo ${CUDA_VERSION} | tr '.' '-')
+
 # Install NVIDIA Nsight Systems (nsys) for profiling - only if benchmarks are enabled
 RUN if [ "$VELOX_ENABLE_BENCHMARKS" = "ON" ]; then \
       set -euxo pipefail && \


### PR DESCRIPTION
This is a simple PR to unblock people who hit this issue when compiling with cuDF >= 25.10.