### PR TITLE
Placeholder "Presto Nightly (Upstream)" workflow to allow testing from branch

### DIFF
--- a/.github/workflows/presto-nightly-upstream.yml
+++ b/.github/workflows/presto-nightly-upstream.yml
@@ -1,0 +1,10 @@
+name: Presto Nightly Test (Upstream)
+
+on:
+  workflow_dispatch:
+
+jobs:
+  dummy:
+    steps:
+      - name: dummy
+        run: echo dummy


### PR DESCRIPTION
A file of this name needs to exist in `main` to allow a branch version to be tested.