### PR TITLE
Extend Presto worker start-up timeout

### DIFF
--- a/presto/scripts/common_functions.sh
+++ b/presto/scripts/common_functions.sh
@@ -27,7 +27,7 @@ function wait_for_worker_node_registration() {
   until curl -s -f -o node_response.json ${COORDINATOR_URL}/v1/node && \
         (( $(jq length node_response.json) > 0 )); do
     if (( $retry_count >= $MAX_RETRIES )); then
-      echo "Error: Worker node not registered"
+      echo "Error: Worker node not registered after 60s. Exiting."
       exit 1
     fi
     sleep 5


### PR DESCRIPTION
The existing time-out is 25s, which doesn't seem long enough as workers regularly take 20-30s to start.

This PR just increases the retry count from 5 to 12, giving a maximum timeout of 60s, which should be plenty.

This was prompted by various intermittent failures in Presto CI whereby the Integration Tests fail because the worker doesn't start quickly enough.

e.g. https://github.com/rapidsai/velox-testing/actions/runs/18737251123/job/53446451448