### PR TITLE
Add cudf.enabled to native worker properties

### DIFF
--- a/presto/docker/config/template/etc_worker/config_native.properties
+++ b/presto/docker/config/template/etc_worker/config_native.properties
@@ -30,3 +30,6 @@ system-mem-shrink-gb=20
 
 # Optimize for single-node execution when the entire query can run locally.
 single-node-execution-enabled=true
+
+# Enable cuDF (CPU mode will ignore this setting)
+cudf.enabled=true


### PR DESCRIPTION
This is required to correctly activate the Velox cuDF back-end.

The config setting is ignored in CPU mode.