### PR TITLE
Add Velox Nightly Upstream CI job

### DIFF
--- a/.github/workflows/velox-nightly-upstream.yml
+++ b/.github/workflows/velox-nightly-upstream.yml
@@ -1,0 +1,15 @@
+name: Velox Nightly Test (Upstream)
+
+on:
+  schedule:
+    - cron: '0 4 * * *'  # daily at 04:00 UTC
+  workflow_dispatch:
+
+jobs:
+  nightly:
+    uses: ./.github/workflows/velox-test.yml
+    with:
+      repository: facebookincubator/velox
+      velox_commit: main
+      build_target: all
+    secrets: inherit


### PR DESCRIPTION
This PR adds another Velox Nightly job which targets the upstream Velox repo's `main` branch.