### PR TITLE
Presto: Use 32GB instance for Java CI variant

### DIFF
--- a/.github/workflows/presto-test.yml
+++ b/.github/workflows/presto-test.yml
@@ -63,7 +63,7 @@ jobs:
     uses: ./.github/workflows/presto-test-composite.yml
     with:      
       presto_worker_type: 'java'
-      node_label: 'linux-amd64-cpu4m'
+      node_label: 'linux-amd64-cpu8'
       presto_repository: ${{ inputs.presto_repository }}
       presto_commit: ${{ inputs.presto_commit }}
       velox_repository: ${{ inputs.velox_repository }}


### PR DESCRIPTION
The fixed Presto Java memory config in #105 still requires at least a 32GB machine to run.

This PR changes the GHA Runner for those variants from a `cpu4` (4/16) to a `cpu8` (8/32), which are more plentiful and also have the benefit of building faster.

Note that I tried a `cpu4m` (4/32) but those apparently require additional permissions to use.

This in conjunction with #105 will fix the Presto Nightly CI.