### PR TITLE
Generate duckdb schemas from parquet samples instead of entire files

### DIFF
--- a/benchmark_data_tools/duckdb_utils.py
+++ b/benchmark_data_tools/duckdb_utils.py
@@ -31,12 +31,19 @@ def create_table(table_name, data_path):
     duckdb.sql(f"DROP TABLE IF EXISTS {table_name}")
     duckdb.sql(f"CREATE TABLE {table_name} AS SELECT * FROM '{data_path}/*.parquet';")
 
-def create_not_null_table(table_name, data_path):
+# Generates a sample table with a small limit.
+# This is mainly used to extract the schema from the parquet files.
+def create_not_null_table_from_sample(table_name, data_path):
     duckdb.sql(f"DROP TABLE IF EXISTS {table_name}")
-    duckdb.sql(f"CREATE TABLE {table_name} AS SELECT * FROM '{data_path}/*.parquet';")
+    duckdb.sql(f"CREATE TABLE {table_name} AS SELECT * FROM '{data_path}/*.parquet' LIMIT 10;")
     ret = duckdb.sql(f"DESCRIBE TABLE {table_name}").fetchall()
     for row in ret:
         duckdb.sql(f"ALTER TABLE {table_name} ALTER COLUMN {row[0]} SET NOT NULL;")
+
+
+def create_table_from_sample(table_name, data_path):
+    duckdb.sql(f"DROP TABLE IF EXISTS {table_name}")
+    duckdb.sql(f"CREATE TABLE {table_name} AS SELECT * FROM '{data_path}/*.parquet' LIMIT 10;")
 
 
 def is_decimal_column(column_type):

--- a/benchmark_data_tools/generate_table_schemas.py
+++ b/benchmark_data_tools/generate_table_schemas.py
@@ -28,9 +28,9 @@ def generate_table_schemas(benchmark_type, schemas_dir_path, data_dir_name, verb
         if os.path.isdir(sub_dir):
             if benchmark_type == "tpch":
                 # For tpch we use the optional NOT NULL qualifier on all columns.
-                duck.create_not_null_table(os.path.basename(file), sub_dir)
+                duck.create_not_null_table_from_sample(os.path.basename(file), sub_dir)
             else:
-                duck.create_table(os.path.basename(file), sub_dir)
+                duck.create_table_from_sample(os.path.basename(file), sub_dir)
 
     Path(schemas_dir_path).mkdir(parents=True, exist_ok=True)
 


### PR DESCRIPTION
Quick fix to have our schema generation scripts use less memory.

Currently, we extract the schema from parquet files by using them to create a duckdb table and then do a `SHOW CREATE TABLE` on the duckdb table to get an SQL representation.  This also lets us alter the table schema if we need to while it exists in duckdb (we do this to apply NOT NULL to columns, which do not exist in the parquet schema).  This fix adds a limit on the duckdb CTAS used in this case so that we are not generating a gigantic table when using large parquet files, as we only need a small data sample to know the schema.