### PR TITLE
Presto: Fix for Java Automatic Memory Config (REPLACES #115)

### DIFF
--- a/presto/docker/config/template/etc_coordinator/config_java.properties
+++ b/presto/docker/config/template/etc_coordinator/config_java.properties
@@ -17,7 +17,13 @@ query-manager.required-workers=1
 query-manager.required-workers-max-wait=10s
 
 # Basic memory configuration settings for Java coordinator
-query.max-total-memory-per-node=16GB
-query.max-total-memory=32GB
-query.max-memory-per-node=16GB
-query.max-memory=32GB
+query.max-total-memory-per-node={{ .JavaQueryMaxTotalMemPerNodeGb }}GB
+query.max-total-memory={{ mul .JavaQueryMaxTotalMemPerNodeGb .NumberOfWorkers }}GB
+query.max-memory-per-node={{ .JavaQueryMaxMemPerNodeGb }}GB
+query.max-memory={{ mul .JavaQueryMaxMemPerNodeGb .NumberOfWorkers }}GB
+
+# Reserve heap headroom per node to reduce full GC and OOM risk.
+memory.heap-headroom-per-node={{ .HeadroomGb }}GB
+
+# Disable reserved memory pool to simplify test behavior.
+experimental.reserved-pool-enabled=false

--- a/presto/docker/docker-compose.java.yml
+++ b/presto/docker/docker-compose.java.yml
@@ -5,7 +5,7 @@ services:
       service: presto-base-coordinator
     volumes:
       - ./config/generated/java/etc_common:/opt/presto-server/etc
-      - ./config/generated/java/etc_coordinator/config_java.properties:/opt/presto-server/etc/config.
+      - ./config/generated/java/etc_coordinator/config_java.properties:/opt/presto-server/etc/config.properties
       - ./config/generated/java/etc_coordinator/node.properties:/opt/presto-server/etc/node.properties
 
   presto-java-worker:


### PR DESCRIPTION
Previous attempts at allowing automatic memory config for Java mode failed, with the Coordinator failing to start, with errors of the form...

This turns out to be because there are two additional memory-related configs that were in the Native Coordinator
config but not in the Java one which turn out to be essential, in order for the memory assignment math to be correct and not suffer from the overflow described in the error.

Thanks to @paul-aiyedun for finding the fix.

Also fixes the Java config.properties file container mapping broken accidentally in #109.

