### PR TITLE
Add Cluster Tag

### DIFF
--- a/presto/docker/config/template/etc_coordinator/config_java.properties
+++ b/presto/docker/config/template/etc_coordinator/config_java.properties
@@ -27,3 +27,6 @@ memory.heap-headroom-per-node={{ .HeadroomGb }}GB
 
 # Disable reserved memory pool to simplify test behavior.
 experimental.reserved-pool-enabled=false
+
+# Adds a cluster tag for java variant
+cluster-tag=java

--- a/presto/scripts/generate_presto_config.sh
+++ b/presto/scripts/generate_presto_config.sh
@@ -97,6 +97,17 @@ EOF
     # optimizer.default-filter-factor-enabled=true
     COORD_CONFIG="${CONFIG_DIR}/etc_coordinator/config_native.properties"
     sed -i 's/\#optimizer/optimizer/g' ${COORD_CONFIG}
+    
+    # Adds a cluster tag for gpu variant
+    WORKER_CONFIG="${CONFIG_DIR}/etc_coordinator/config_native.properties"
+    echo "cluster-tag=native-gpu" >> ${WORKER_CONFIG}
+  fi
+
+  # now perform other variant-specific modifications to the generated configs
+  if [[ "${VARIANT_TYPE}" == "cpu" ]]; then
+    # Adds a cluster tag for cpu variant
+    WORKER_CONFIG="${CONFIG_DIR}/etc_coordinator/config_native.properties"
+    echo "cluster-tag=native-cpu" >> ${WORKER_CONFIG}
   fi
 
   # success message


### PR DESCRIPTION
Adds cluster tag config to our velox-testing start scripts for java, cpu, gpu. 

Sister PR to https://github.com/prestodb/presto/pull/26485, which will display this tag in the UI so we can easily identify which type of cluster we have created. 