### PR TITLE
Fix Presto native worker build fail due to nsight-systems-install fail

### DIFF
--- a/presto/docker/native_build.dockerfile
+++ b/presto/docker/native_build.dockerfile
@@ -2,7 +2,7 @@ FROM presto/prestissimo-dependency:centos9
 
 RUN rpm --import https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/7fa2af80.pub && \
     dnf config-manager --add-repo "https://developer.download.nvidia.com/devtools/repos/rhel$(source /etc/os-release; echo ${VERSION_ID%%.*})/$(rpm --eval '%{_arch}' | sed s/aarch/arm/)/" && \
-    dnf install -y nsight-systems-cli-2025.5.1
+    dnf install -y nsight-systems-cli
 
 ARG GPU=ON
 ARG BUILD_TYPE=release


### PR DESCRIPTION
The package name for the latest `nsight-systems` appears to have changed in the last day or so. It is no longer installable with the full version number string. Removing the final version number resolves the issue.