### PR TITLE
Temporary fix for Presto builds pending upstream presto-function-server fixes

### DIFF
--- a/presto/scripts/build_presto_java_package.sh
+++ b/presto/scripts/build_presto_java_package.sh
@@ -31,6 +31,7 @@ docker run --rm \
     ./mvnw clean install --no-transfer-progress -DskipTests -pl \!presto-docs -pl \!presto-openapi -Dair.check.skip-all=true &&
     echo 'Copying artifacts with version $PRESTO_VERSION...' &&
     cp presto-server/target/presto-server-*.tar.gz docker/presto-server-$PRESTO_VERSION.tar.gz &&
+    cp presto-function-server/target/presto-function-server-*-executable.jar docker/presto-function-server-$PRESTO_VERSION-executable.jar &&
     cp presto-cli/target/presto-cli-*-executable.jar docker/presto-cli-$PRESTO_VERSION-executable.jar &&
     chmod +r docker/presto-cli-$PRESTO_VERSION-executable.jar &&
     echo 'Build complete! Artifacts copied with version $PRESTO_VERSION'


### PR DESCRIPTION
See https://github.com/prestodb/presto/issues/26705

A new Presto module (and associated JAR file) was added so our Java build script needs to deploy it.

This works with current `master` although it would not have worked a few days ago when I originally discovered this problem. They have landed a partial fix since then, with more fixes (for parts which don't affect us) still in PR.

However, another Velox update happened before that fix, so `rapidsai/velox` is now incompatible. However, I apparently missed the memo that we're once again suspending `rapidsai/velox` in favor of working in upstream (or personal forks, at least) as allegedly everything that was in `IBM-techpreview` has now been upstreamed (TO BE CONFIRMED!)