### PR TITLE
[HERC-228] Actions to delete old workflow runs and logs

### DIFF
--- a/.github/workflows/delete-workflow-runs-ondemand.yml
+++ b/.github/workflows/delete-workflow-runs-ondemand.yml
@@ -54,7 +54,7 @@ jobs:
       contents: read
     steps:
       - name: Delete workflow runs
-        uses: Mattraks/delete-workflow-runs@v2
+        uses: Mattraks/delete-workflow-runs@5bf9a1dac5c4d041c029f0a8370ddf0c5cb5aeb7
         with:
           token: ${{ github.token }}
           repository: ${{ github.repository }}

--- a/.github/workflows/delete-workflow-runs-weekly.yml
+++ b/.github/workflows/delete-workflow-runs-weekly.yml
@@ -10,7 +10,7 @@ jobs:
       contents: read
     steps:
       - name: Delete workflow runs
-        uses: Mattraks/delete-workflow-runs@v2
+        uses: Mattraks/delete-workflow-runs@5bf9a1dac5c4d041c029f0a8370ddf0c5cb5aeb7
         with:
           token: ${{ github.token }}
           repository: ${{ github.repository }}


### PR DESCRIPTION
Taken directly from https://github.com/marketplace/actions/delete-workflow-runs

The weekly one runs automatically on Sundays and deletes all runs of all jobs older than 30 days.

The on-demand one is intended to be run manually, and is completely configurable.

Discuss.

Unfortunately, they can't be tested unless landed in `main`.

Also, we need to check that the Action they use has been white-listed.