### PR TITLE
Improve stability of `sccache` latest download

### DIFF
--- a/velox/docker/adapters_build.dockerfile
+++ b/velox/docker/adapters_build.dockerfile
@@ -1,11 +1,11 @@
 ARG TARGETARCH
 
 # Install latest ninja
-FROM --platform=$TARGETPLATFORM alpine:latest AS ninja-amd64
+FROM alpine:latest AS ninja-amd64
 RUN apk add --no-cache unzip
 ADD https://github.com/ninja-build/ninja/releases/latest/download/ninja-linux.zip /tmp
 
-FROM --platform=$TARGETPLATFORM alpine:latest AS ninja-arm64
+FROM alpine:latest AS ninja-arm64
 RUN apk add --no-cache unzip
 ADD https://github.com/ninja-build/ninja/releases/latest/download/ninja-linux-aarch64.zip /tmp
 RUN mv /tmp/ninja-linux-aarch64.zip /tmp/ninja-linux.zip

--- a/velox/docker/sccache/sccache_setup.sh
+++ b/velox/docker/sccache/sccache_setup.sh
@@ -5,9 +5,7 @@ set -euo pipefail
 
 if test "${SCCACHE_VERSION:-latest}" = latest; then
     # Install the latest version
-    wget --no-hsts -q -O- https://api.github.com/repos/rapidsai/sccache/releases/latest \
-  | jq -r ".assets[] | select(.name | test(\"^sccache-v.*?-$(uname -m)-unknown-linux-musl.tar.gz\$\")) | .browser_download_url" \
-  | wget --no-hsts -q -O- -i- \
+    wget --no-hsts -q -O- "https://github.com/rapidsai/sccache/releases/latest/download/sccache-$(uname -m)-unknown-linux-musl.tar.gz" \
   | tar -C /usr/bin -vzf - --wildcards --strip-components=1 -x '*/sccache'
 else
     # Install pinned version

--- a/velox/scripts/setup_sccache_auth.sh
+++ b/velox/scripts/setup_sccache_auth.sh
@@ -81,6 +81,8 @@ docker run --rm -it \
   -v "$OUTPUT_DIR:/output" \
   sccache-auth \
   bash -c '
+    set -euo pipefail
+
     if [[ ! -f /output/github_token ]]; then
       echo "Error: GitHub token not found"
       exit 1


### PR DESCRIPTION
* Fix warning due to redundant use of --platform flag

* Force failure in `setup_sccache_auth.sh` when AWS credentials fail to complete