### PR TITLE
Fix for Presto build failures since airbase update

### DIFF
--- a/presto/scripts/build_presto_java_package.sh
+++ b/presto/scripts/build_presto_java_package.sh
@@ -32,7 +32,7 @@ docker run --rm \
     git config --global --add safe.directory /presto &&
     curl -fsSL https://deb.nodesource.com/setup_22.x | bash - &&
     apt-get install -y nodejs &&
-    npm install -g yarn &&
+    npm install -g yarn@1.22.22 &&
     ./mvnw clean install --no-transfer-progress -DskipTests -pl \!presto-docs -pl \!presto-openapi -Dair.check.skip-all=true &&
     echo 'Copying artifacts with version $PRESTO_VERSION...' &&
     cp presto-server/target/presto-server-*.tar.gz docker/presto-server-$PRESTO_VERSION.tar.gz &&


### PR DESCRIPTION
Presto builds (all variants) have been broken since this commit to upstream Presto...

https://github.com/prestodb/presto/commit/44200d7872b25f155b82852014f2cb5fc4504072

I reported it to IBM, but they did not respond. Probably because it turns out it's due to a staleness in our build process, which is a little embarrassing.

@quasiben came up with this fix, which despite a big red warning about how Node 18 is deprecated, seems to fix it, although it's not clear to me yet why. Perhaps an even newer version of Node would also work? Presumably the regular Presto build process avoids this somehow. More investigation needed. @cmatzenbach and @johallar please comment.