### PR TITLE
Temporary tweaks to Velox CI unit tests

### DIFF
--- a/velox/scripts/test_velox.sh
+++ b/velox/scripts/test_velox.sh
@@ -106,10 +106,10 @@ TEST_PREAMBLE='if [ -f "/opt/miniforge/etc/profile.d/conda.sh" ]; then
   export CLASSPATH=$(/usr/local/hadoop/bin/hdfs classpath --glob)'
 
 if [[ "$DEVICE_TYPE" == "cpu" ]]; then
-  SKIP_TESTS="velox_exec_test|velox_hdfs_file_test|velox_hdfs_insert_test"
-  # ulimit increased pending possible fix for velox_table_evolution_fuzzer_test to not open so many files
+  # disable velox_table_evolution_fuzzer_test pending resolution of too-many-open-files problem
   # seves 1/9/26
-  TEST_CMD="ulimit -n 4096 && ctest -j ${NUM_THREADS} --label-exclude cuda_driver --output-on-failure --no-tests=error -E \"${SKIP_TESTS}\""
+  SKIP_TESTS="velox_exec_test|velox_hdfs_file_test|velox_hdfs_insert_test|velox_table_evolution_fuzzer_test"
+  TEST_CMD="ctest -j ${NUM_THREADS} --label-exclude cuda_driver --output-on-failure --no-tests=error -E \"${SKIP_TESTS}\""
 else
   if [[ "$NUM_THREADS" -gt 2 ]]; then
     echo "Warning: For GPU mode, setting NUM_THREADS to 2 to avoid possible OOM errors."


### PR DESCRIPTION
* Raise ulimit -n (open files) to 4096 for CPU mode, avoiding failure in velox_table_evolution_fuzzer_test

Proper fix unclear.
Perhaps the code can be modified to not open so many files.
Or we just leave the ulimit raised, as is apparent done in a few other CI situations.

* Disable velox_cudf_s3_read_test in GPU mode, as this currently fails with a CUDA error on shutdown

Proper fix is https://github.com/rapidsai/rmm/pull/2202
Re-enable test once Velox is using an RMM with that in.