### PR TITLE
Harden pip install with retries/timeouts

### DIFF
--- a/presto/scripts/run_integ_test.sh
+++ b/presto/scripts/run_integ_test.sh
@@ -162,7 +162,18 @@ trap delete_python_virtual_env EXIT
 init_python_virtual_env
 
 TEST_DIR=$(readlink -f ../testing)
-pip install -q -r ${TEST_DIR}/requirements.txt
+# PyPI can occasionally be slow/flaky on GitHub-hosted runners; harden pip with retries/timeouts.
+# You can override these if needed:
+#   PIP_TIMEOUT=180 PIP_RETRIES=12 ./run_integ_test.sh ...
+PIP_TIMEOUT="${PIP_TIMEOUT:-120}"
+PIP_RETRIES="${PIP_RETRIES:-8}"
+python -m pip install \
+  --disable-pip-version-check \
+  --no-input \
+  --progress-bar off \
+  --retries "${PIP_RETRIES}" \
+  --timeout "${PIP_TIMEOUT}" \
+  -q -r "${TEST_DIR}/requirements.txt"
 
 source ./common_functions.sh
 


### PR DESCRIPTION
## Problem

The Presto integration tests occasionally [fail (CI job failure)](https://github.com/rapidsai/velox-testing/actions/runs/21159441437/job/60851038147) during the pip install step with:

     ReadTimeoutError: HTTPSConnectionPool(host='files.pythonhosted.org', port=443): Read timed out.

This is a transient network issue on GitHub Actions runners when downloading packages from PyPI. The default pip timeout (~15s) and lack of retries cause the entire CI job to fail, even though a retry would likely succeed.

## Solution

Harden the pip install command in `presto/scripts/run_integ_test.sh` with:
```sh
--retries 8 — automatically retry failed downloads up to 8 times
--timeout 120 — increase socket timeout to 120 seconds (default is ~15s)
--no-input --progress-bar off — prevent interactive prompts and reduce log noise
```
These values are configurable via environment variables (`PIP_RETRIES`, `PIP_TIMEOUT`) if further tuning is needed.

_Why this works_

PyPI/files.pythonhosted.org occasionally experiences latency spikes or brief outages. With retries and a longer timeout, pip can recover from transient failures without manual intervention or job restarts.