### PR TITLE
Support for external metastore URI

### DIFF
--- a/presto/scripts/generate_presto_config.sh
+++ b/presto/scripts/generate_presto_config.sh
@@ -90,7 +90,7 @@ EOF
     echo_error "ERROR: Errors reported by pbench genconfig. Configs were not generated successfully."
   fi
 
-  if [ -v HIVE_METASTORE_URI ]; then
+  if [ -n "$HIVE_METASTORE_URI" ]; then
     sed -i 's/hive.metastore=file/#hive.metastore=file/' "${CONFIG_DIR}/etc_coordinator/catalog/hive.properties" "${CONFIG_DIR}/etc_worker/catalog/hive.properties"
     sed -i "s|hive.metastore.catalog.dir=.*|hive.metastore.uri=${HIVE_METASTORE_URI}|" "${CONFIG_DIR}/etc_coordinator/catalog/hive.properties" "${CONFIG_DIR}/etc_worker/catalog/hive.properties"
   fi


### PR DESCRIPTION
So presto and the tooling can use a shared HMS instance.