### PR TITLE
Add lukewarm times and sum to benchmark report

### DIFF
--- a/presto/testing/performance_benchmarks/benchmark_keys.py
+++ b/presto/testing/performance_benchmarks/benchmark_keys.py
@@ -31,3 +31,4 @@ class BenchmarkKeys(str, Enum):
     TAG_KEY = "tag"
     CONTEXT_KEY = "context"
     ITERATIONS_COUNT_KEY = "iterations_count"
+    SCHEMA_NAME_KEY = "schema_name"

--- a/presto/testing/performance_benchmarks/conftest.py
+++ b/presto/testing/performance_benchmarks/conftest.py
@@ -37,6 +37,8 @@ def pytest_addoption(parser):
 def pytest_terminal_summary(terminalreporter, exitstatus, config):
     text_report = []
     iterations = config.getoption("--iterations")
+    schema_name = config.getoption("--schema-name")
+    tag = config.getoption("--tag")
     for benchmark_type, result in terminalreporter._session.benchmark_results.items():
         assert BenchmarkKeys.AGGREGATE_TIMES_KEY in result
 
@@ -46,6 +48,9 @@ def pytest_terminal_summary(terminalreporter, exitstatus, config):
 
         write_line(terminalreporter, text_report, "")
         write_line(terminalreporter, text_report, f"Iterations Count: {iterations}")
+        write_line(terminalreporter, text_report, f"Schema Name: {schema_name}")
+        if tag:
+            write_line(terminalreporter, text_report, f"Tag: {tag}")
         write_line(terminalreporter, text_report, "")
 
         if iterations > 1:
@@ -105,12 +110,14 @@ def write_section(terminalreporter, text_report, content, **kwargs):
 
 def pytest_sessionfinish(session, exitstatus):
     iterations = session.config.getoption("--iterations")
+    schema_name = session.config.getoption("--schema-name")
     json_result = {
         BenchmarkKeys.CONTEXT_KEY: {
             BenchmarkKeys.ITERATIONS_COUNT_KEY: iterations,
+            BenchmarkKeys.SCHEMA_NAME_KEY: schema_name,
         },
     }
-
+    
     tag = session.config.getoption("--tag")
     if tag:
         json_result[BenchmarkKeys.CONTEXT_KEY][BenchmarkKeys.TAG_KEY] = tag


### PR DESCRIPTION
* Update benchmark report to distinguish between hot and lukewarm times.

* Add sum row to benchmark text report.

* Add iterations count to benchmark report.

* Show only lukewarm times for single iteration runs.