### PR TITLE
Remove extra config from java hive

### DIFF
--- a/presto/scripts/generate_presto_config.sh
+++ b/presto/scripts/generate_presto_config.sh
@@ -130,33 +130,32 @@ EOF
     sed -i "s|hive.metastore.catalog.dir=.*|hive.metastore.uri=${HIVE_METASTORE_URI}|" "${CONFIG_DIR}/etc_coordinator/catalog/hive.properties" "${CONFIG_DIR}/etc_worker/catalog/hive.properties"
   fi
 
+  COORD_CONFIG="${CONFIG_DIR}/etc_coordinator/config_native.properties"
   # now perform other variant-specific modifications to the generated configs
   if [[ "${VARIANT_TYPE}" == "gpu" ]]; then
     # for GPU variant, uncomment these optimizer settings
     # optimizer.joins-not-null-inference-strategy=USE_FUNCTION_METADATA
     # optimizer.default-filter-factor-enabled=true
-    COORD_CONFIG="${CONFIG_DIR}/etc_coordinator/config_native.properties"
     sed -i 's/\#optimizer/optimizer/g' ${COORD_CONFIG}
-    
+
     if [[ ${NUM_WORKERS} -eq 1 ]]; then
-    # Adds a cluster tag for gpu variant
-    WORKER_CONFIG="${CONFIG_DIR}/etc_coordinator/config_native.properties"
-    echo "cluster-tag=native-gpu" >> ${WORKER_CONFIG}
+      # Adds a cluster tag for gpu variant
+      echo "cluster-tag=native-gpu" >> ${COORD_CONFIG}
     fi
   fi
 
   # now perform other variant-specific modifications to the generated configs
   if [[ "${VARIANT_TYPE}" == "cpu" ]]; then
     # Adds a cluster tag for cpu variant
-    WORKER_CONFIG="${CONFIG_DIR}/etc_coordinator/config_native.properties"
-    echo "cluster-tag=native-cpu" >> ${WORKER_CONFIG}
+    echo "cluster-tag=native-cpu" >> ${COORD_CONFIG}
   fi
-  
+
   # for Java variant, disable some Parquet properties which are now rejected
   if [[ "${VARIANT_TYPE}" == "java" ]]; then
     HIVE_CONFIG="${CONFIG_DIR}/etc_worker/catalog/hive.properties"
     sed -i 's/parquet\.reader\.chunk-read-limit/#parquet\.reader\.chunk-read-limit/' ${HIVE_CONFIG}
     sed -i 's/parquet\.reader\.pass-read-limit/#parquet\.reader\.pass-read-limit/' ${HIVE_CONFIG}
+    sed -i 's/^cudf/#cudf/' ${HIVE_CONFIG}
   fi
 
   # success message


### PR DESCRIPTION
A cudf-only config option was added to the general java build and causes java workers to break.  Pushed a change that comments out this option as we do for other similar options for java workers.