### PR TITLE
Downgrade tpchgen-cli to 2.0.1 to resolve DECIMAL Parquet file incompatibility

### DIFF
--- a/benchmark_data_tools/requirements.txt
+++ b/benchmark_data_tools/requirements.txt
@@ -7,6 +7,6 @@ presto-python-client==0.8.4
 requests==2.32.4
 six==1.17.0
 urllib3==2.5.0
-tpchgen-cli==2.0.2
+tpchgen-cli==2.0.1
 pyarrow==21.0.0
 pytest==9.0.2


### PR DESCRIPTION
PR #167 upgraded the `tpchgen-cli` module used by the Parquet generation scripts from "very old" to 2.0.2.

Unfortunately, if 2.0.2 is used to generate Parquets with DECIMAL, CUDF 26.02 cannot read them.

See https://github.com/rapidsai/cudf/issues/21085

The reader is fixed in https://github.com/rapidsai/cudf/pull/21144

This PR downgrades that module to 2.0.1 which resolves the issue until that CUDF fix filters through.

