### PR TITLE
Add username tag to Docker container name

### DIFF
--- a/presto/docker/docker-compose.common.yml
+++ b/presto/docker/docker-compose.common.yml
@@ -14,7 +14,7 @@ services:
   presto-base-coordinator:
     extends:
       service: presto-base-java
-    container_name: presto-coordinator
+    container_name: presto-coordinator-${IMAGE_TAG:-latest}
     image: presto-coordinator:${IMAGE_TAG:-latest}
     ports:
       - 8080:8080

--- a/presto/docker/docker-compose.native-cpu.yml
+++ b/presto/docker/docker-compose.native-cpu.yml
@@ -13,7 +13,7 @@ services:
     extends:
       file: docker-compose.common.yml
       service: presto-base-native-worker
-    container_name: presto-native-worker-cpu
+    container_name: presto-native-worker-cpu-${IMAGE_TAG:-latest}
     image: presto-native-worker-cpu:${IMAGE_TAG:-latest}
     build:
       args:

--- a/presto/docker/docker-compose/template/docker-compose.native-gpu.yml.jinja
+++ b/presto/docker/docker-compose/template/docker-compose.native-gpu.yml.jinja
@@ -59,7 +59,7 @@ services:
   {% for gpu_id in workers %}
   presto-native-worker-gpu-{{ gpu_id }}:
     <<: *gpu_worker_base
-    container_name: presto-native-worker-gpu-{{ gpu_id }}
+    container_name: presto-native-worker-gpu-{{ gpu_id }}-${IMAGE_TAG:-latest}
     environment:
       NVIDIA_VISIBLE_DEVICES: all
       PROFILE: ${PROFILE}
@@ -83,7 +83,7 @@ services:
   # Combined GPU worker - runs {{ workers|length if workers else 1 }} presto servers in parallel, each pinned to a specific GPU
   presto-native-worker-gpu:
     <<: *gpu_worker_base
-    container_name: presto-native-worker-gpu
+    container_name: presto-native-worker-gpu-${IMAGE_TAG:-latest}
 {%- if workers %}
     command: ["bash", "/opt/presto_profiling_wrapper.sh"{% for gpu_id in workers %}, "{{ gpu_id }}"{% endfor %}]
     environment:


### PR DESCRIPTION
Avoid conflicts due to multiple Presto coordinator and worker containers, and resolves the following error on a shared lab machine
```
Error response from daemon: Conflict. The container name "/presto-coordinator" is already in use by container "4ac48748c75b473172af9e359f9421200d70ec25d8cf466c1d4fd5f352acc982". You have to remove (or rename) that container to be able to reuse that name.
```
