### PR TITLE
Added preliminary CI checks

### DIFF
--- a/.github/actions/test-benchmark-data-tools/action.yml
+++ b/.github/actions/test-benchmark-data-tools/action.yml
@@ -1,0 +1,23 @@
+name: Test Benchmark Data Tools
+description: Run pytest for benchmark_data_tools
+runs:
+  using: "composite"
+  steps:
+    - name: Checkout velox-testing
+      uses: actions/checkout@v4
+
+    - name: Setup Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.12"
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r benchmark_data_tools/requirements.txt
+      shell: bash
+
+    - name: Run pytest
+      run: |
+        pytest benchmark_data_tools/tests
+      shell: bash

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,31 @@
+name: PR Checks
+
+on:
+  pull_request:
+    branches: [ main ]
+    types: [opened, synchronize, reopened]
+
+
+jobs:
+  detect-changes:
+    runs-on: ubuntu-latest
+    outputs:
+      benchmark_data_tools: ${{ steps.filter.outputs.benchmark_data_tools }}
+    steps:
+      - name: Checkout velox-testing
+        uses: actions/checkout@v4
+      - name: Detect changed paths
+        id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            benchmark_data_tools:
+              - "benchmark_data_tools/**"
+
+  test_benchmark_data_tools:
+    needs: detect-changes
+    if: ${{ needs.detect-changes.outputs.benchmark_data_tools == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Test benchmark_data_tools
+        uses: ./.github/actions/test-benchmark-data-tools


### PR DESCRIPTION
This PR introduces a lightweight `preliminary checks` layer for PRs. It runs targeted jobs only when relevant paths change (e.g., benchmark_data_tools → pytest). The goal is to keep PR validation fast and focused, while still enforcing required checks when specific areas are touched.