### PR TITLE
Add more digits to Q11's SF_FRACTION

### DIFF
--- a/presto/testing/common/fixtures.py
+++ b/presto/testing/common/fixtures.py
@@ -24,7 +24,7 @@ def tpch_queries(request, presto_cursor):
     # The "fraction" portion of Q11 is a value that depends on scale factor
     # (it should be 0.0001 / scale_factor), whereas our query is currently hard-coded as 0.0001.
     value_ratio = 0.0001 / float(test_utils.get_scale_factor(request, presto_cursor))
-    queries["Q11"] = queries["Q11"].format(SF_FRACTION=f"{value_ratio:f}")
+    queries["Q11"] = queries["Q11"].format(SF_FRACTION=f"{value_ratio:.12f}")
 
     # Referencing the CTE defined "supplier_no" alias in the parent query causes issues on presto.
     queries["Q15"] = queries["Q15"].replace(" AS supplier_no", "").replace("supplier_no", "l_suppkey")


### PR DESCRIPTION
Fixes Q11.
In this query, there is a SF dependent value in the sql.
For a large scale factor, the becomes smaller.
The python fixture (`def tpch_queries(request, presto_cursor)`) used to calculate this and create the sql text truncates the very small value 0.0000001 to 0.000000
This allows for a lot of rows to pass the condition in Q11.
A large output slows down the coordinator, resulting in a long e2e runtime.