### PR TITLE
Add --cuda-version option to build scripts

### DIFF
--- a/presto/scripts/build_centos_deps_image.sh
+++ b/presto/scripts/build_centos_deps_image.sh
@@ -6,6 +6,7 @@ set -e
 
 IMAGE_NAME="presto/prestissimo-dependency:centos9-${USER:-latest}"
 NO_CACHE_ARG=''
+CUDA_VERSION=''
 
 print_help() {
   cat << EOF
@@ -22,6 +23,7 @@ OPTIONS:
     -h, --help           Show this help message
     -i, --image-name     Desired Docker Image name (default: presto/prestissimo-dependency:centos9-\${USER:-latest})
     -n, --no-cache       Do not use Docker build cache (default: use cache)
+    --cuda-version       CUDA version to install (default: 12.9)
 
 EOF
 }
@@ -45,6 +47,15 @@ parse_args() {
       -n|--no-cache)
         NO_CACHE_ARG="--no-cache"
         shift
+        ;;
+      --cuda-version)
+        if [[ -n $2 ]]; then
+          CUDA_VERSION=$2
+          shift 2
+        else
+          echo "Error: --cuda-version requires a value"
+          exit 1
+        fi
         ;;
       *)
         echo "Error: Unknown argument $1"
@@ -96,7 +107,11 @@ cp -r ../../velox/CMake velox
 
 # now build
 echo "Building..."
-docker compose --progress plain build ${NO_CACHE_ARG} centos-native-dependency
+CUDA_VERSION_ARG=""
+if [[ -n "${CUDA_VERSION}" ]]; then
+  CUDA_VERSION_ARG="--build-arg CUDA_VERSION=${CUDA_VERSION}"
+fi
+docker compose --progress plain build ${NO_CACHE_ARG} ${CUDA_VERSION_ARG} centos-native-dependency
 
 # tag with the user-specific name to avoid conflicts between multiple users on the same host
 COMPOSE_IMAGE_NAME='presto/prestissimo-dependency:centos9'

--- a/presto/scripts/build_centos_deps_image.sh
+++ b/presto/scripts/build_centos_deps_image.sh
@@ -23,7 +23,7 @@ OPTIONS:
     -h, --help           Show this help message
     -i, --image-name     Desired Docker Image name (default: presto/prestissimo-dependency:centos9-\${USER:-latest})
     -n, --no-cache       Do not use Docker build cache (default: use cache)
-    --cuda-version       CUDA version to install (default: 12.9)
+    --cuda-version       CUDA version to install (major.minor, like 12.9)
 
 EOF
 }

--- a/velox/scripts/build_centos_deps_image.sh
+++ b/velox/scripts/build_centos_deps_image.sh
@@ -2,6 +2,50 @@
 
 set -e
 
+CUDA_VERSION=''
+
+print_help() {
+  cat << EOF
+
+Usage: build_centos_deps_image.sh [OPTIONS]
+
+This script does a local build of a Velox dependencies/run-time container to a Docker image.
+It expects a sibling Velox clone.
+
+OPTIONS:
+    -h, --help           Show this help message
+    --cuda-version       CUDA version to install (default: 12.9)
+
+EOF
+}
+
+parse_args() {
+  while [[ $# -gt 0 ]]; do
+    case $1 in
+      -h|--help)
+        print_help
+        exit 0
+        ;;
+      --cuda-version)
+        if [[ -n $2 ]]; then
+          CUDA_VERSION=$2
+          shift 2
+        else
+          echo "Error: --cuda-version requires a value"
+          exit 1
+        fi
+        ;;
+      *)
+        echo "Error: Unknown argument $1"
+        print_help
+        exit 1
+        ;;
+    esac
+  done
+}
+
+parse_args "$@"
+
 # Compute the directory where this script resides
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
@@ -11,7 +55,11 @@ REPO_ROOT="$(git -C "${SCRIPT_DIR}" rev-parse --show-toplevel)"
 echo "Building Velox dependencies/run-time container image..."
 
 pushd "${REPO_ROOT}/../velox"
-docker compose -f docker-compose.yml --progress plain build adapters-cpp
+CUDA_VERSION_ARG=""
+if [[ -n "${CUDA_VERSION}" ]]; then
+  CUDA_VERSION_ARG="--build-arg CUDA_VERSION=${CUDA_VERSION}"
+fi
+docker compose -f docker-compose.yml --progress plain build ${CUDA_VERSION_ARG} adapters-cpp
 popd
 
 echo "Velox dependencies/run-time container image built!"

--- a/velox/scripts/build_centos_deps_image.sh
+++ b/velox/scripts/build_centos_deps_image.sh
@@ -14,7 +14,7 @@ It expects a sibling Velox clone.
 
 OPTIONS:
     -h, --help           Show this help message
-    --cuda-version       CUDA version to install (default: 12.9)
+    --cuda-version       CUDA version to install (major.minor, like 12.9)
 
 EOF
 }

--- a/velox/scripts/build_centos_deps_image.sh
+++ b/velox/scripts/build_centos_deps_image.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
 
 set -e
 


### PR DESCRIPTION
## Summary
- Add `--cuda-version` option to `presto/scripts/build_centos_deps_image.sh`
- Add `--cuda-version` option to `velox/scripts/build_centos_deps_image.sh`

Both scripts pass the CUDA version as a build arg to the respective docker compose builds, allowing customization of the installed CUDA version (defaults to 12.9).

## Dependencies
This PR depends on:
- https://github.com/prestodb/presto/pull/27074
- https://github.com/facebookincubator/velox/pull/16234