### PR TITLE
Add thread multiplier configurations to worker/config_native.properties

### DIFF
--- a/presto/docker/config/template/etc_worker/config_native.properties
+++ b/presto/docker/config/template/etc_worker/config_native.properties
@@ -28,6 +28,33 @@ system-mem-pushback-enabled=true
 system-mem-limit-gb={{ sub .ContainerMemoryGb .GeneratorParameters.MemoryPushBackStartBelowLimitGb }}
 system-mem-shrink-gb=20
 
+# Each multiplier value affects number of threads used for each module.
+# hw_concurrency x multiplier.
+# 1.0 is default for each multiplier config.
+# Number of threads for HTTP IO executor
+http-server.num-io-threads-hw-multiplier=0.01
+# Number of threads for HTTP CPU executor
+http-server.num-cpu-threads-hw-multiplier=0.01
+# Number of threads for CPU executor for connectors mainly for async operators
+# If 0.0 then connector CPU executor would not be created.
+# 0.0 is default.
+#connector.num-cpu-threads-hw-multiplier=0.0
+# Number of threads for IO executor for connectors mainly to do preload/prefetch:
+# If 0.0 then connector preload/prefetch is disabled.
+# 0.0 is default.
+connector.num-io-threads-hw-multiplier=0.01
+# Number of threeads for Driver CPU executor
+# 4.0 is default. 4*nproc threads.
+#driver.num-cpu-threads-hw-multiplier
+# Number of threads for Spiller CPU executor
+# If 0.0 then spilling is disabled.
+# 1.0 is default.
+#spiller.num-cpu-threads-hw-multiplier
+# Number of threads for Exchange HTTP client CPU executor
+exchange.http-client.num-cpu-threads-hw-multiplier=0.01
+# Number of threads for Exchange HTTP client IO executor
+exchange.http-client.num-io-threads-hw-multiplier=0.01
+
 # Optimize for single-node execution when the entire query can run locally.
 single-node-execution-enabled=true
 


### PR DESCRIPTION
Added configuration options for thread multipliers in HTTP and connector executors.

There are total 10 hw-multiplier in https://github.com/prestodb/presto/blob/e1006483a1d6f5470a8d4229b7805cf08301d92e/presto-native-execution/presto_cpp/main/common/Configs.h#L198
Listed  only 8 of them.
Enabled only 5 of them. 
