### PR TITLE
Improve setup_benchmark_data_and_tables.sh and setup_benchmark_tables.sh scripts

### DIFF
--- a/presto/scripts/setup_benchmark_helper_check_instance_and_parse_args.sh
+++ b/presto/scripts/setup_benchmark_helper_check_instance_and_parse_args.sh
@@ -30,6 +30,7 @@ OPTIONS:
     -b, --benchmark-type                Type of benchmark to create tables for. Only "tpch" and "tpcds" are currently supported.
     -s, --schema-name                   Name of the schema that will contain the created tables.
     -d, --data-dir-name                 Name of the directory inside the PRESTO_DATA_DIR path for the benchmark data.
+    --skip-analyze-tables               Skip analyzing tables after creating them. Default is to analyze tables.
     $SCRIPT_EXTRA_OPTIONS_DESCRIPTION
 
 EXAMPLES:
@@ -48,10 +49,7 @@ fi
 # Compute the directory where this script resides (if not already set by caller)
 SCRIPT_DIR="${SCRIPT_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 
-source "${SCRIPT_DIR}/common_functions.sh"
-
-wait_for_worker_node_registration
-
+SKIP_ANALYZE_TABLES=false
 parse_args() {
   while [[ $# -gt 0 ]]; do
     case $1 in
@@ -85,6 +83,10 @@ parse_args() {
           echo "Error: --data-dir-name requires a value"
           exit 1
         fi
+        ;;
+      --skip-analyze-tables)
+        SKIP_ANALYZE_TABLES=true
+        shift
         ;;
       *)
         SCRIPT_EXTRA_OPTIONS_UNKNOWN_ARG=true

--- a/presto/scripts/setup_benchmark_tables.sh
+++ b/presto/scripts/setup_benchmark_tables.sh
@@ -32,6 +32,12 @@ function cleanup() {
 
 trap cleanup EXIT
 
+"${SCRIPT_DIR}/start_native_cpu_presto.sh"
+
+source "${SCRIPT_DIR}/common_functions.sh"
+
+wait_for_worker_node_registration
+
 "${SCRIPT_DIR}/../../scripts/run_py_script.sh" -p $SCHEMA_GEN_SCRIPT_PATH \
                                --benchmark-type $BENCHMARK_TYPE \
                                --schemas-dir-path $TEMP_SCHEMA_DIR \
@@ -42,3 +48,9 @@ trap cleanup EXIT
                                --schema-name $SCHEMA_NAME \
                                --schemas-dir-path $TEMP_SCHEMA_DIR \
                                --data-dir-name $DATA_DIR_NAME
+
+if [[ "$SKIP_ANALYZE_TABLES" == "false" ]]; then
+  "${SCRIPT_DIR}/analyze_tables.sh" -s $SCHEMA_NAME
+fi
+
+"${SCRIPT_DIR}/stop_presto.sh"


### PR DESCRIPTION
- Add `num-threads` option.

- Add `approx-row-group-bytes` option.

- Execute `analyze_tables.sh` script by default (add `skip-analyze-tables` option).

- Automatically start up and shut down Presto CPU for `analyze_tables.sh` script execution.