### PR TITLE
Enhance Presto scripts

### DIFF
--- a/presto/scripts/run_benchmark.sh
+++ b/presto/scripts/run_benchmark.sh
@@ -152,14 +152,6 @@ parse_args() {
         PROFILE=true
         shift
         ;;
-      -e|--explain)
-        EXPLAIN=true
-        shift
-        ;;
-      -ea|--explain-analyze)
-        EXPLAIN_ANALYZE=true
-        shift
-        ;;
       --skip-drop-cache)
         SKIP_DROP_CACHE=true
         shift
@@ -234,14 +226,6 @@ fi
 
 if [[ "${PROFILE}" == "true" ]]; then
   PYTEST_ARGS+=("--profile --profile-script-path $(readlink -f ./profiler_functions.sh)")
-fi
-
-if [[ "${EXPLAIN}" == "true" ]]; then
-  PYTEST_ARGS+=("--explain")
-fi
-
-if [[ "${EXPLAIN_ANALYZE}" == "true" ]]; then
-  PYTEST_ARGS+=("--explain-analyze")
 fi
 
 if [[ "${METRICS}" == "true" ]]; then

--- a/presto/scripts/run_integ_test.sh
+++ b/presto/scripts/run_integ_test.sh
@@ -44,6 +44,8 @@ OPTIONS:
     --preview-rows-count             Number of rows to include in the preview i.e. when --show-presto-result-preview or
                                      --show-reference-result-preview is specified.
     --skip-reference-comparison      Skip Presto rows comparison against a reference set of rows.
+    -e, --explain                    Run queries with EXPLAIN prefix. Requires --skip-reference-comparison.
+    --explain-analyze                Run queries with EXPLAIN ANALYZE prefix. Requires --skip-reference-comparison.
     --reuse-venv                     If this argument is specified, reuse the existing Python virtual environment if one exists
                                      and skip dependency installation.
 
@@ -59,6 +61,8 @@ EXAMPLES:
     $0 -b tpch -q "1,2" -s my_sf1_schema --store-reference-results
     $0 -b tpch -q "1,2" -s my_sf1_schema --show-presto-result-preview --show-reference-result-preview --preview-rows-count 5
     $0 -b tpch -q "1,2" -s my_sf1_schema --store-presto-results --skip-reference-comparison
+    $0 -b tpch -q "1,2" -s my_sf1_schema --skip-reference-comparison --explain
+    $0 -b tpch -q "1,2" -s my_sf1_schema --skip-reference-comparison --explain-analyze
     $0 -h
 
 EOF
@@ -178,6 +182,14 @@ parse_args() {
         SKIP_REFERENCE_COMPARISON=true
         shift
         ;;
+      -e|--explain)
+        EXPLAIN=true
+        shift
+        ;;
+      --explain-analyze)
+        EXPLAIN_ANALYZE=true
+        shift
+        ;;
       --reuse-venv)
         REUSE_VENV=true
         shift
@@ -195,6 +207,12 @@ parse_args "$@"
 
 if [[ -z ${BENCHMARK_TYPE} || ! ${BENCHMARK_TYPE} =~ ^tpc(h|ds)$ ]]; then
   echo "Error: A valid benchmark type (tpch or tpcds) is required. Use the -b or --benchmark-type argument."
+  print_help
+  exit 1
+fi
+
+if [[ "${EXPLAIN}" == "true" || "${EXPLAIN_ANALYZE}" == "true" ]] && [[ "${SKIP_REFERENCE_COMPARISON}" != "true" ]]; then
+  echo "Error: --explain and --explain-analyze require --skip-reference-comparison to also be specified."
   print_help
   exit 1
 fi
@@ -257,6 +275,16 @@ fi
 
 if [[ -n ${SKIP_REFERENCE_COMPARISON} ]]; then
   PYTEST_ARGS+=("--skip-reference-comparison")
+fi
+
+if [[ "${EXPLAIN}" == "true" ]]; then
+  PYTEST_ARGS+=("--explain")
+  PYTEST_ARGS+=("--store-presto-results")
+fi
+
+if [[ "${EXPLAIN_ANALYZE}" == "true" ]]; then
+  PYTEST_ARGS+=("--explain-analyze")
+  PYTEST_ARGS+=("--store-presto-results")
 fi
 
 source "${SCRIPT_DIR}/../../scripts/py_env_functions.sh"

--- a/presto/testing/integration_tests/conftest.py
+++ b/presto/testing/integration_tests/conftest.py
@@ -22,3 +22,5 @@ def pytest_addoption(parser):
     parser.addoption("--show-reference-result-preview", action="store_true", default=False)
     parser.addoption("--preview-rows-count", default=3, type=int)
     parser.addoption("--skip-reference-comparison", action="store_true", default=False)
+    parser.addoption("--explain", action="store_true", default=False)
+    parser.addoption("--explain-analyze", action="store_true", default=False)

--- a/presto/testing/integration_tests/test_utils.py
+++ b/presto/testing/integration_tests/test_utils.py
@@ -1,6 +1,10 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 
+from pathlib import Path
+
+import pandas as pd
+
 from common.testing.integration_tests.test_utils import (
     create_duckdb_table,  # noqa: F401
     initialize_output_dir,  # noqa: F401
@@ -13,8 +17,20 @@ from common.testing.integration_tests.test_utils import (
 def execute_query_and_compare_results(request_config, presto_cursor, queries, query_id):
     query = queries[query_id]
 
-    presto_cursor.execute(query)
+    explain = request_config.getoption("--explain")
+    explain_analyze = request_config.getoption("--explain-analyze")
+    explain_statement = "EXPLAIN " if explain else "EXPLAIN ANALYZE " if explain_analyze else ""
+
+    presto_cursor.execute(explain_statement + query)
     presto_rows = presto_cursor.fetchall()
     presto_columns = [desc[0] for desc in presto_cursor.description]
+
+    if explain or explain_analyze:
+        if request_config.getoption("--store-presto-results"):
+            output_dir = request_config.getoption("--output-dir")
+            plan_path = Path(output_dir) / "presto_results" / f"{query_id.lower()}.plan"
+            df = pd.DataFrame(presto_rows, columns=presto_columns)
+            df.to_csv(plan_path, index=False)
+        return
 
     base_execute_query_and_compare_results(request_config, queries, query_id, "presto", presto_rows, presto_columns)

--- a/presto/testing/performance_benchmarks/common_fixtures.py
+++ b/presto/testing/performance_benchmarks/common_fixtures.py
@@ -45,14 +45,11 @@ def benchmark_query(request, presto_cursor, benchmark_queries, benchmark_result_
     iterations = request.config.getoption("--iterations")
     profile = request.config.getoption("--profile")
     profile_script_path = request.config.getoption("--profile-script-path")
-    explain = request.config.getoption("--explain")
-    explain_analyze = request.config.getoption("--explain-analyze")
     metrics = request.config.getoption("--metrics")
     benchmark_type = request.node.obj.BENCHMARK_TYPE
     bench_output_dir = request.config.getoption("--output-dir")
     hostname = request.config.getoption("--hostname")
     port = request.config.getoption("--port")
-    explain_statement = "EXPLAIN " if explain else "EXPLAIN ANALYZE " if explain_analyze else ""
 
     if profile:
         assert profile_script_path is not None
@@ -81,14 +78,7 @@ def benchmark_query(request, presto_cursor, benchmark_queries, benchmark_result_
             result = []
             for iteration_num in range(iterations):
                 cursor = presto_cursor.execute(
-                    "--"
-                    + str(benchmark_type)
-                    + "_"
-                    + str(query_id)
-                    + "--"
-                    + "\n"
-                    + explain_statement
-                    + benchmark_queries[query_id]
+                    "--" + str(benchmark_type) + "_" + str(query_id) + "--" + "\n" + benchmark_queries[query_id]
                 )
                 result.append(cursor.stats["elapsedTimeMillis"])
 

--- a/presto/testing/performance_benchmarks/conftest.py
+++ b/presto/testing/performance_benchmarks/conftest.py
@@ -40,8 +40,6 @@ def pytest_addoption(parser):
     parser.addoption("--tag")
     parser.addoption("--profile", action="store_true", default=False)
     parser.addoption("--profile-script-path")
-    parser.addoption("--explain", action="store_true", default=False)
-    parser.addoption("--explain-analyze", action="store_true", default=False)
     parser.addoption("--metrics", action="store_true", default=False)
     parser.addoption("--skip-drop-cache", action="store_true", default=False)
 


### PR DESCRIPTION
- Fix first time multi-gpu build target missing error
- while running integration tests, do not delete if reference dir path is within output dir
- Add "EXPLAIN", "EXPLAIN ANALYZE" to benchmark run script
- ~Enable sharing `hive_metastore` with data, so that everyone does not need to copy .hive_metastore, or run analyze tables again on same data (changed from hidden directory to non-hidden).~

