### PR TITLE
Misiug/fixarmpython

### DIFF
--- a/scripts/py_env_functions.sh
+++ b/scripts/py_env_functions.sh
@@ -70,7 +70,8 @@ function init_python_virtual_env() {
     init_conda
 
     echo "Creating virtual environment using conda"
-    # This needs to be python 3.10 because there is an issue with ARM conda's python 3.12.
+    # Downgrade the version of python in conda because there is an issue with conda's python 3.12 on ARM.
+    # Installing python3.12 here leads to: "ModuleNotFoundError: No module named '_posixsubprocess'"
     conda create -q -y --prefix "$venv_dir" python=3.11 > /dev/null
   fi
 


### PR DESCRIPTION
On ARM machines, conda's version of python3.12 is broken and hits this error when you try to activate the environment:
```
Activating conda environment
Traceback (most recent call last):
  File "/raid/misiug/velox-testing/presto/scripts/.venv/bin/pip", line 10, in <module>
    sys.exit(main())
             ^^^^^^
  File "/raid/misiug/velox-testing/presto/scripts/.venv/lib/python3.12/site-packages/pip/_internal/cli/main.py", line 47, in main
    from pip._internal.cli.autocompletion import autocomplete
  File "/raid/misiug/velox-testing/presto/scripts/.venv/lib/python3.12/site-packages/pip/_internal/cli/autocompletion.py", line 12, in <module>
    from pip._internal.cli.main_parser import create_main_parser
  File "/raid/misiug/velox-testing/presto/scripts/.venv/lib/python3.12/site-packages/pip/_internal/cli/main_parser.py", line 6, in <module>
    import subprocess
  File "/usr/lib/python3.12/subprocess.py", line 104, in <module>
    from _posixsubprocess import fork_exec as _fork_exec
ModuleNotFoundError: No module named '_posixsubprocess'
```

Our deps generally require python3.11 or higher, so default to 3.11 in this context.