### PR TITLE
Check presto/velox repos only if need to build image

### DIFF
--- a/presto/scripts/start_presto_helper.sh
+++ b/presto/scripts/start_presto_helper.sh
@@ -140,7 +140,8 @@ if [[ "$VARIANT_TYPE" == "gpu" ]]; then
   fi
   DOCKER_COMPOSE_FILE_PATH="$RENDERED_PATH"
 fi
-if (( ${#BUILD_TARGET_ARG[@]} )) && [[ validate_sibling_repos ]]; then
+if (( ${#BUILD_TARGET_ARG[@]} )); then
+  validate_sibling_repos
   if [[ ${BUILD_TARGET_ARG[@]} =~ ($CPU_WORKER_SERVICE|$GPU_WORKER_SERVICE) ]] && is_image_missing ${DEPS_IMAGE}; then
     echo "ERROR: Presto dependencies/run-time image '${DEPS_IMAGE}' not found!"
     echo "Either build a local image using build_centos9_deps_image.sh or fetch a pre-built"


### PR DESCRIPTION
This better accommodates workflows where images are built out-of-band.