### PR TITLE
simplify default profiling options

### DIFF
--- a/presto/docker/presto_profiling_wrapper.sh
+++ b/presto/docker/presto_profiling_wrapper.sh
@@ -8,11 +8,7 @@ if [[ "$PROFILE" == "ON" ]]; then
   mkdir /presto_profiles
 
   if [[ -z $PROFILE_ARGS ]]; then
-    PROFILE_ARGS="-t nvtx,cuda,osrt,ucx
-                  --cuda-memory-usage=true
-                  --cuda-um-cpu-page-faults=true
-                  --cuda-um-gpu-page-faults=true
-                  --cudabacktrace=true"
+    PROFILE_ARGS="-t nvtx,cuda"
   fi
   PROFILE_CMD="nsys launch $PROFILE_ARGS"
 fi


### PR DESCRIPTION
Addresses this issue: closes https://github.com/rapidsai/velox-testing/issues/235

We want to simplify the default presto profiling metrics since it's causing too much overhead in multi-gpu cases.