### PR TITLE
Check if tables have been analyzed by default when running run_benchmark.sh

### DIFF
--- a/presto/scripts/run_benchmark.sh
+++ b/presto/scripts/run_benchmark.sh
@@ -40,6 +40,7 @@ OPTIONS:
                             Tags must contain only alphanumeric and underscore characters.
     -p, --profile           Enable profiling of benchmark queries.
     --skip-drop-cache       Skip dropping system caches before each benchmark query (dropped by default).
+    --skip-analyze-check    Skip checking that ANALYZE TABLE has been run on all tables (checked by default).
     -m, --metrics           Collect detailed metrics from Presto REST API after each query.
                             Metrics are stored in query-specific directories.
     -v, --verbose           Print debug logs for worker/engine detection
@@ -163,6 +164,10 @@ parse_args() {
         SKIP_DROP_CACHE=true
         shift
         ;;
+      --skip-analyze-check)
+        SKIP_ANALYZE_CHECK=true
+        shift
+        ;;
       -m|--metrics)
         METRICS=true
         shift
@@ -245,6 +250,10 @@ fi
 
 if [[ "${SKIP_DROP_CACHE}" == "true" ]]; then
   PYTEST_ARGS+=("--skip-drop-cache")
+fi
+
+if [[ "${SKIP_ANALYZE_CHECK}" == "true" ]]; then
+  PYTEST_ARGS+=("--skip-analyze-check")
 fi
 
 source "${SCRIPT_DIR}/../../scripts/py_env_functions.sh"

--- a/presto/testing/performance_benchmarks/common_fixtures.py
+++ b/presto/testing/performance_benchmarks/common_fixtures.py
@@ -42,6 +42,9 @@ def run_context_collector(request):
 @pytest.fixture(scope="session", autouse=True)
 def verify_tables_analyzed(request):
     """Session-scoped setup that verifies ANALYZE TABLE has been run on all tables."""
+    if request.config.getoption("--skip-analyze-check"):
+        print("[Analyze] Skipping analyze check (--skip-analyze-check flag set).")
+        return
     hostname = request.config.getoption("--hostname")
     port = request.config.getoption("--port")
     user = request.config.getoption("--user")
@@ -50,6 +53,8 @@ def verify_tables_analyzed(request):
     cursor = conn.cursor()
     try:
         check_tables_analyzed(cursor, schema)
+    except RuntimeError as e:
+        pytest.exit(str(e), returncode=1)
     finally:
         cursor.close()
         conn.close()

--- a/presto/testing/performance_benchmarks/conftest.py
+++ b/presto/testing/performance_benchmarks/conftest.py
@@ -27,6 +27,7 @@ from .common_fixtures import (
     benchmark_query,  # noqa: F401
     presto_cursor,  # noqa: F401
     run_context_collector,  # noqa: F401
+    verify_tables_analyzed,  # noqa: F401
 )
 
 
@@ -44,6 +45,7 @@ def pytest_addoption(parser):
     parser.addoption("--profile-script-path")
     parser.addoption("--metrics", action="store_true", default=False)
     parser.addoption("--skip-drop-cache", action="store_true", default=False)
+    parser.addoption("--skip-analyze-check", action="store_true", default=False)
 
 
 def pytest_configure(config):


### PR DESCRIPTION
This addresses this issue: resolves https://github.com/rapidsai/velox-testing/issues/215

The code to verify if ANALYZE has been run on the tables already existed (I believe it was added as part of the slurm environment support).  So this PR just adds it into the run_benchmark.sh workflow.

Now if you run a benchmark the script will first verify that the tables being referenced have appropriate statistics in the hive_metadata schema that would be generated by running ANALYZE TABLE on each one.

Example outputs:
```
./run_benchmark.sh -s sf1_unanalyzed -b tpch
no tests ran
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! _pytest.outcomes.Exit: ANALYZE TABLE has not been run on the following tables in schema 'sf1_unanalyzed': customer, lineitem, nation, orders, part, partsupp, region, supplier. Run analyze_tables.sh on a CPU Presto instance before benchmarking. !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!

./run_benchmark.sh -s sf1_analyzed -b tpch
[Analyze] All 8 table(s) in schema 'sf1' have statistics.
22 passed

./run_benchmark.sh -s sf1_unanalyzed -b tpch --skip-analyze-check
[Analyze] Skipping analyze check (--skip-analyze-check flag set).
22 passed
```