### PR TITLE
Add hive.node-selection-strategy for affinity scheduling

### DIFF
--- a/presto/docker/config/template/etc_coordinator/catalog/hive.properties
+++ b/presto/docker/config/template/etc_coordinator/catalog/hive.properties
@@ -41,3 +41,6 @@ hive.max-parallel-parsing-concurrency=16
 hive.optimize-parsing-of-partition-values-enabled=true
 hive.optimize-parsing-of-partition-values-threshold=200
 hive.split-loader-concurrency=16
+
+# Affinity scheduling
+hive.node-selection-strategy=SOFT_AFFINITY


### PR DESCRIPTION
With multiple Presto nodes this should prevent the caches being thrashed with random splits.

See here: https://prestodb.io/docs/0.284/release/release-0.233.html#hive-changes