### PR TITLE
Fix CI image deletion

### DIFF
--- a/.github/workflows/presto-build.yml
+++ b/.github/workflows/presto-build.yml
@@ -378,16 +378,6 @@ jobs:
                 "${REGISTRY}/${IMAGE_NAME}:presto-deps-${PRESTO_SHORT_SHA}-velox-${VELOX_SHORT_SHA}-cuda${cuda}-${BUILD_DATE}-arm64"
             done
           fi
-      - name: Delete intermediate arch-specific tags
-        continue-on-error: true
-        uses: ./.github/actions/delete-arch-tags
-        with:
-          registry: ${{ env.REGISTRY }}
-          image-name: ${{ env.IMAGE_NAME }}
-          base-tags: |
-            presto-deps-${{ inputs.presto_short_sha }}-velox-${{ inputs.velox_short_sha }}-cuda12.9-${{ inputs.date }}
-            presto-deps-${{ inputs.presto_short_sha }}-velox-${{ inputs.velox_short_sha }}-cuda13.1-${{ inputs.date }}
-
   merge-presto-build:
     name: merge-manifests (presto-build)
     needs: [presto-build]
@@ -445,6 +435,8 @@ jobs:
             presto-${{ inputs.presto_short_sha }}-velox-${{ inputs.velox_short_sha }}-gpu-cuda12.9-${{ inputs.date }}
             presto-${{ inputs.presto_short_sha }}-velox-${{ inputs.velox_short_sha }}-gpu-cuda13.1-${{ inputs.date }}
             presto-${{ inputs.presto_short_sha }}-velox-${{ inputs.velox_short_sha }}-cpu-${{ inputs.date }}
+            presto-deps-${{ inputs.presto_short_sha }}-velox-${{ inputs.velox_short_sha }}-cuda12.9-${{ inputs.date }}
+            presto-deps-${{ inputs.presto_short_sha }}-velox-${{ inputs.velox_short_sha }}-cuda13.1-${{ inputs.date }}
 
   merge-presto-coordinator:
     name: merge-manifests (presto-coordinator)

--- a/.github/workflows/velox-build.yml
+++ b/.github/workflows/velox-build.yml
@@ -292,16 +292,6 @@ jobs:
                 "${REGISTRY}/${IMAGE_NAME}:velox-deps-${VELOX_SHORT_SHA}-cuda${cuda}-${BUILD_DATE}-arm64"
             done
           fi
-      - name: Delete intermediate arch-specific tags
-        continue-on-error: true
-        uses: ./.github/actions/delete-arch-tags
-        with:
-          registry: ${{ env.REGISTRY }}
-          image-name: ${{ env.IMAGE_NAME }}
-          base-tags: |
-            velox-deps-${{ inputs.velox_short_sha }}-cuda12.9-${{ inputs.date }}
-            velox-deps-${{ inputs.velox_short_sha }}-cuda13.1-${{ inputs.date }}
-
   merge-velox-build:
     name: merge-manifests (velox-build)
     needs: [velox-build]
@@ -353,3 +343,5 @@ jobs:
             velox-${{ inputs.velox_short_sha }}-gpu-cuda12.9-${{ inputs.date }}
             velox-${{ inputs.velox_short_sha }}-gpu-cuda13.1-${{ inputs.date }}
             velox-${{ inputs.velox_short_sha }}-cpu-${{ inputs.date }}
+            velox-deps-${{ inputs.velox_short_sha }}-cuda12.9-${{ inputs.date }}
+            velox-deps-${{ inputs.velox_short_sha }}-cuda13.1-${{ inputs.date }}

--- a/ci/delete-arch-tags.sh
+++ b/ci/delete-arch-tags.sh
@@ -4,24 +4,22 @@
 
 set -euo pipefail
 
-# Delete a container image tag from GHCR via the OCI distribution API.
+# Delete a container image tag from GHCR via the GitHub Packages REST API.
 #
-# This resolves the tag to its digest, then deletes the manifest by digest.
-# This is the same mechanism used by `crane delete`.
+# The OCI distribution API DELETE endpoint returns 405 on GHCR; the Packages
+# REST API is the supported way to remove tags/versions.
 #
 # Usage:
-#   ./scripts/ghcr-delete-tags.sh TAG
+#   ./ci/delete-arch-tags.sh TAG
 #
 # Example:
 #   IMAGE_NAME=rapidsai/velox-testing-images GITHUB_TOKEN=ghp_... \
-#     ./scripts/ghcr-delete-tags.sh velox-deps-abc123-cuda12.9-20260319-amd64
+#     ./ci/delete-arch-tags.sh velox-deps-abc123-cuda12.9-20260319-amd64
 #
 # Environment:
-#   IMAGE_NAME   - Full image name without registry prefix (required)
-#   GITHUB_TOKEN - GitHub token with delete:packages scope (required)
-#   REGISTRY     - Container registry hostname (default: ghcr.io)
-
-REGISTRY="${REGISTRY:-ghcr.io}"
+#   IMAGE_NAME   - Full image name without registry prefix (e.g. rapidsai/velox-testing-images)
+#   GITHUB_TOKEN - GitHub token with write:packages scope
+#   REGISTRY     - Unused; kept for compatibility with the action that sets it
 
 if [[ $# -ne 1 ]]; then
   echo "Usage: $0 TAG" >&2
@@ -38,46 +36,23 @@ if [[ -z "${GITHUB_TOKEN:-}" ]]; then
   exit 1
 fi
 
-# Exchange GITHUB_TOKEN for a GHCR bearer token with delete scope
-GHCR_TOKEN=$(curl -sf -u "USERNAME:${GITHUB_TOKEN}" \
-  "https://${REGISTRY}/token?service=${REGISTRY}&scope=repository:${IMAGE_NAME}:delete" \
-  | jq -r '.token')
+# Split IMAGE_NAME into org and package name (e.g. rapidsai / velox-testing-images)
+ORG="${IMAGE_NAME%%/*}"
+PACKAGE="${IMAGE_NAME#*/}"
 
-if [[ -z "${GHCR_TOKEN}" || "${GHCR_TOKEN}" == "null" ]]; then
-  echo "Error: Failed to obtain GHCR bearer token" >&2
-  exit 1
-fi
+echo "Looking up tag '${TAG}' in ${ORG}/${PACKAGE}..."
+VERSION_ID=$(GH_TOKEN="${GITHUB_TOKEN}" gh api --paginate \
+  "orgs/${ORG}/packages/container/${PACKAGE}/versions" \
+  | jq -r --arg tag "${TAG}" \
+      '.[] | select(.metadata.container.tags | contains([$tag])) | .id' \
+  | head -n 1)
 
-BASE_URL="https://${REGISTRY}/v2/${IMAGE_NAME}"
-
-# Step 1: Resolve tag to digest
-echo "Resolving tag '${TAG}' to digest..."
-digest=$(curl -s -I \
-  -H "Authorization: Bearer ${GHCR_TOKEN}" \
-  -H "Accept: application/vnd.oci.image.manifest.v1+json, application/vnd.docker.distribution.manifest.v2+json, application/vnd.docker.distribution.manifest.list.v2+json, application/vnd.oci.image.index.v1+json" \
-  "${BASE_URL}/manifests/${TAG}" \
-  | grep -i '^docker-content-digest:' \
-  | tr -d '\r' \
-  | awk '{print $2}')
-
-if [[ -z "${digest}" ]]; then
-  echo "  Tag '${TAG}' not found or could not resolve digest."
+if [[ -z "${VERSION_ID}" ]]; then
+  echo "  Tag '${TAG}' not found. Skipping."
   exit 0
 fi
-echo "  Resolved to: ${digest}"
 
-# Step 2: Delete manifest by digest
-echo "Deleting manifest ${digest}..."
-http_code=$(curl -s -o /dev/null -w '%{http_code}' \
-  -X DELETE \
-  -H "Authorization: Bearer ${GHCR_TOKEN}" \
-  "${BASE_URL}/manifests/${digest}")
-
-if [[ "${http_code}" == "202" ]]; then
-  echo "  -> Deleted tag '${TAG}' (${digest})"
-elif [[ "${http_code}" == "404" || "${http_code}" == "405" ]]; then
-  echo "  -> Not found or not allowed (HTTP ${http_code}). Tag may already be gone."
-else
-  echo "  -> Failed to delete. HTTP status: ${http_code}" >&2
-  exit 1
-fi
+echo "  Found version ID: ${VERSION_ID}. Deleting..."
+GH_TOKEN="${GITHUB_TOKEN}" gh api --method DELETE \
+  "orgs/${ORG}/packages/container/${PACKAGE}/versions/${VERSION_ID}"
+echo "  -> Deleted tag '${TAG}' (version ${VERSION_ID})"

--- a/presto/testing/performance_benchmarks/common_fixtures.py
+++ b/presto/testing/performance_benchmarks/common_fixtures.py
@@ -9,10 +9,10 @@ import prestodb
 import pytest
 
 from common.testing.performance_benchmarks.benchmark_keys import BenchmarkKeys
+from common.testing.performance_benchmarks.profiler_utils import start_profiler, stop_profiler
 
 from ..integration_tests.analyze_tables import check_tables_analyzed
 from .metrics_collector import collect_metrics
-from common.testing.performance_benchmarks.profiler_utils import start_profiler, stop_profiler
 from .run_context import gather_run_context
 
 

--- a/spark_gluten/scripts/launch_spark_connect_server.sh
+++ b/spark_gluten/scripts/launch_spark_connect_server.sh
@@ -49,7 +49,7 @@ if [[ -n "${CONFIG_FILE}" && -f "${CONFIG_FILE}" ]]; then
   done < "${CONFIG_FILE}"
 fi
 
-$PROFILE_CMD $SPARK_HOME/bin/spark-submit \
+$PROFILE_CMD "$SPARK_HOME"/bin/spark-submit \
     --class org.apache.spark.sql.connect.service.SparkConnectServer \
     --master "local[*]" \
     --jars "${GLUTEN_JAR}" \

--- a/spark_gluten/scripts/profiler_functions.sh
+++ b/spark_gluten/scripts/profiler_functions.sh
@@ -35,21 +35,21 @@ function start_profiler() {
 
   local docker_exec_command
   docker_exec_command=$(get_docker_exec_command)
-  $docker_exec_command nsys start --gpu-metrics-devices=all -o /spark_profiles/$(basename $profile_output_file_path).nsys-rep
+  $docker_exec_command nsys start --gpu-metrics-devices=all -o "/spark_profiles/$(basename "$profile_output_file_path").nsys-rep"
 }
 
 function stop_profiler() {
   local -r profile_output_file_path=$1.nsys-rep
-  local -r container_file_path="/spark_profiles/$(basename $profile_output_file_path)"
+  local -r container_file_path="/spark_profiles/$(basename "$profile_output_file_path")"
   local docker_exec_command
   docker_exec_command=$(get_docker_exec_command)
 
   check_profile_output_directory
   $docker_exec_command nsys stop
-  $docker_exec_command chown -R $(id -u):$(id -g) /spark_profiles
+  $docker_exec_command chown -R "$(id -u)":"$(id -g)" /spark_profiles
 
   local container_id
   container_id=$(get_container_id)
-  docker cp ${container_id}:${container_file_path} $profile_output_file_path
-  $docker_exec_command rm ${container_file_path}
+  docker cp "${container_id}":"${container_file_path}" "$profile_output_file_path"
+  $docker_exec_command rm "${container_file_path}"
 }

--- a/spark_gluten/scripts/start_spark_connect.sh
+++ b/spark_gluten/scripts/start_spark_connect.sh
@@ -16,9 +16,9 @@ This script starts a Spark Connect server in a Docker container.
 
 OPTIONS:
     -h, --help                      Show this help message.
-    --image-tag                     Tag of the docker image to use for the server launch. The full 
-                                    image reference is "apache/gluten:{image-tag}". Default value 
-                                    is "dynamic_gpu_\${USER:-latest}". Cannot be used with 
+    --image-tag                     Tag of the docker image to use for the server launch. The full
+                                    image reference is "apache/gluten:{image-tag}". Default value
+                                    is "dynamic_gpu_\${USER:-latest}". Cannot be used with
                                     --static-gluten-jar-path.
     --static-gluten-jar-path        Path to a statically-linked Gluten JAR file on the host.
                                     Cannot be used with --image-tag.


### PR DESCRIPTION
Our CI generates images for arm and x86 architectures and then merges them into a single manifest; it is then supposed to delete the pointers to the x86/arm specific images so that we don't pollute our repository with redundant images (because we now have multi-arch images in place).

However, the approach we were using to delete images was not working correctly, as it was failing with insufficient  permissions, and therefore not deleting the images.

This PR use the gh api to delete the images instead of curl, so that we are able to delete the images with the appropriate permissions.  It also moves the image deletion to after the build is complete, so that we don't end up deleting the deps image when they are still needed to build the worker images.