### PR TITLE
Add image labels

### DIFF
--- a/.github/workflows/presto-build.yml
+++ b/.github/workflows/presto-build.yml
@@ -335,13 +335,12 @@ jobs:
             ENABLE_SCCACHE=ON
             GPU=${{ matrix.gpu_flag }}
             NUM_THREADS=31
-          labels: |
-            velox-testing.presto.sha=${{ inputs.presto_sha }}
-            velox-testing.presto.branch=
-            velox-testing.presto.repository=${{ inputs.presto_repository }}
-            velox-testing.velox.sha=${{ inputs.velox_sha }}
-            velox-testing.velox.branch=
-            velox-testing.velox.repository=${{ inputs.velox_repository }}
+            PRESTO_SHA=${{ inputs.presto_sha }}
+            PRESTO_BRANCH=
+            PRESTO_REPOSITORY=${{ inputs.presto_repository }}
+            VELOX_SHA=${{ inputs.velox_sha }}
+            VELOX_BRANCH=
+            VELOX_REPOSITORY=${{ inputs.velox_repository }}
           secret-files: |
             github_token=${{ env.SCCACHE_AUTH_DIR }}/github_token
             aws_credentials=${{ env.SCCACHE_AUTH_DIR }}/aws_credentials

--- a/.github/workflows/presto-build.yml
+++ b/.github/workflows/presto-build.yml
@@ -135,6 +135,11 @@ jobs:
           build-args: |
             CUDA_VERSION=${{ matrix.cuda_version }}
             ARM_BUILD_TARGET=generic
+          labels: |
+            velox-testing.presto.sha=${{ inputs.presto_sha }}
+            velox-testing.presto.repository=${{ inputs.presto_repository }}
+            velox-testing.velox.sha=${{ inputs.velox_sha }}
+            velox-testing.velox.repository=${{ inputs.velox_repository }}
           cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:cache-presto-deps-cuda${{ matrix.cuda_version }}-${{ matrix.arch }}
           cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:cache-presto-deps-cuda${{ matrix.cuda_version }}-${{ matrix.arch }},mode=max
           outputs: type=registry,compression=zstd,force-compression=true,compression-level=15
@@ -195,6 +200,11 @@ jobs:
           file: presto/docker/Dockerfile
           build-args: |
             PRESTO_VERSION=${{ inputs.presto_short_sha }}
+          labels: |
+            velox-testing.presto.sha=${{ inputs.presto_sha }}
+            velox-testing.presto.repository=${{ inputs.presto_repository }}
+            velox-testing.velox.sha=${{ inputs.velox_sha }}
+            velox-testing.velox.repository=${{ inputs.velox_repository }}
           outputs: type=registry,compression=zstd,force-compression=true,compression-level=15
           push: true
           tags: |
@@ -321,6 +331,11 @@ jobs:
             ENABLE_SCCACHE=ON
             GPU=${{ matrix.gpu_flag }}
             NUM_THREADS=31
+          labels: |
+            velox-testing.presto.sha=${{ inputs.presto_sha }}
+            velox-testing.presto.repository=${{ inputs.presto_repository }}
+            velox-testing.velox.sha=${{ inputs.velox_sha }}
+            velox-testing.velox.repository=${{ inputs.velox_repository }}
           secret-files: |
             github_token=${{ env.SCCACHE_AUTH_DIR }}/github_token
             aws_credentials=${{ env.SCCACHE_AUTH_DIR }}/aws_credentials

--- a/.github/workflows/presto-build.yml
+++ b/.github/workflows/presto-build.yml
@@ -137,8 +137,10 @@ jobs:
             ARM_BUILD_TARGET=generic
           labels: |
             velox-testing.presto.sha=${{ inputs.presto_sha }}
+            velox-testing.presto.branch=
             velox-testing.presto.repository=${{ inputs.presto_repository }}
             velox-testing.velox.sha=${{ inputs.velox_sha }}
+            velox-testing.velox.branch=
             velox-testing.velox.repository=${{ inputs.velox_repository }}
           cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:cache-presto-deps-cuda${{ matrix.cuda_version }}-${{ matrix.arch }}
           cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:cache-presto-deps-cuda${{ matrix.cuda_version }}-${{ matrix.arch }},mode=max
@@ -202,9 +204,11 @@ jobs:
             PRESTO_VERSION=${{ inputs.presto_short_sha }}
           labels: |
             velox-testing.presto.sha=${{ inputs.presto_sha }}
+            velox-testing.presto.branch=
             velox-testing.presto.repository=${{ inputs.presto_repository }}
-            velox-testing.velox.sha=${{ inputs.velox_sha }}
-            velox-testing.velox.repository=${{ inputs.velox_repository }}
+            velox-testing.velox.sha=
+            velox-testing.velox.branch=
+            velox-testing.velox.repository=
           outputs: type=registry,compression=zstd,force-compression=true,compression-level=15
           push: true
           tags: |
@@ -333,8 +337,10 @@ jobs:
             NUM_THREADS=31
           labels: |
             velox-testing.presto.sha=${{ inputs.presto_sha }}
+            velox-testing.presto.branch=
             velox-testing.presto.repository=${{ inputs.presto_repository }}
             velox-testing.velox.sha=${{ inputs.velox_sha }}
+            velox-testing.velox.branch=
             velox-testing.velox.repository=${{ inputs.velox_repository }}
           secret-files: |
             github_token=${{ env.SCCACHE_AUTH_DIR }}/github_token

--- a/presto/docker/docker-compose.common.yml
+++ b/presto/docker/docker-compose.common.yml
@@ -35,6 +35,12 @@ services:
       dockerfile: velox-testing/presto/docker/native_build.dockerfile
       args:
         - BASE_IMAGE=${DEPS_IMAGE:-presto/prestissimo-dependency:centos9-${USER}}
+        - PRESTO_SHA=${PRESTO_SHA:-}
+        - PRESTO_BRANCH=${PRESTO_BRANCH:-}
+        - PRESTO_REPOSITORY=${PRESTO_REPO:-}
+        - VELOX_SHA=${VELOX_SHA:-}
+        - VELOX_BRANCH=${VELOX_BRANCH:-}
+        - VELOX_REPOSITORY=${VELOX_REPO:-}
     environment:
       - GLOG_logtostderr=1
       - SERVER_START_TIMESTAMP=${SERVER_START_TIMESTAMP:-}

--- a/presto/docker/native_build.dockerfile
+++ b/presto/docker/native_build.dockerfile
@@ -112,4 +112,17 @@ RUN mkdir /usr/lib64/presto-native-libs && \
 
 COPY velox-testing/presto/docker/launch_presto_servers.sh velox-testing/presto/docker/presto_profiling_wrapper.sh /opt
 
+ARG PRESTO_SHA=""
+ARG PRESTO_BRANCH=""
+ARG PRESTO_REPOSITORY=""
+ARG VELOX_SHA=""
+ARG VELOX_BRANCH=""
+ARG VELOX_REPOSITORY=""
+LABEL velox-testing.presto.sha=${PRESTO_SHA} \
+      velox-testing.presto.branch=${PRESTO_BRANCH} \
+      velox-testing.presto.repository=${PRESTO_REPOSITORY} \
+      velox-testing.velox.sha=${VELOX_SHA} \
+      velox-testing.velox.branch=${VELOX_BRANCH} \
+      velox-testing.velox.repository=${VELOX_REPOSITORY}
+
 CMD ["bash", "/opt/presto_profiling_wrapper.sh"]

--- a/presto/docker/native_build.dockerfile
+++ b/presto/docker/native_build.dockerfile
@@ -112,12 +112,12 @@ RUN mkdir /usr/lib64/presto-native-libs && \
 
 COPY velox-testing/presto/docker/launch_presto_servers.sh velox-testing/presto/docker/presto_profiling_wrapper.sh /opt
 
-ARG PRESTO_SHA=""
-ARG PRESTO_BRANCH=""
-ARG PRESTO_REPOSITORY=""
-ARG VELOX_SHA=""
-ARG VELOX_BRANCH=""
-ARG VELOX_REPOSITORY=""
+ARG PRESTO_SHA
+ARG PRESTO_BRANCH
+ARG PRESTO_REPOSITORY
+ARG VELOX_SHA
+ARG VELOX_BRANCH
+ARG VELOX_REPOSITORY
 LABEL velox-testing.presto.sha=${PRESTO_SHA} \
       velox-testing.presto.branch=${PRESTO_BRANCH} \
       velox-testing.presto.repository=${PRESTO_REPOSITORY} \

--- a/presto/docker/provenance_labels.dockerfile
+++ b/presto/docker/provenance_labels.dockerfile
@@ -1,0 +1,15 @@
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE}
+
+ARG PRESTO_SHA
+ARG PRESTO_BRANCH
+ARG PRESTO_REPOSITORY
+ARG VELOX_SHA
+ARG VELOX_BRANCH
+ARG VELOX_REPOSITORY
+LABEL velox-testing.presto.sha=${PRESTO_SHA} \
+      velox-testing.presto.branch=${PRESTO_BRANCH} \
+      velox-testing.presto.repository=${PRESTO_REPOSITORY} \
+      velox-testing.velox.sha=${VELOX_SHA} \
+      velox-testing.velox.branch=${VELOX_BRANCH} \
+      velox-testing.velox.repository=${VELOX_REPOSITORY}

--- a/presto/scripts/build_centos_deps_image.sh
+++ b/presto/scripts/build_centos_deps_image.sh
@@ -94,9 +94,24 @@ mkdir -p velox
 cp -r ../../velox/scripts velox
 cp -r ../../velox/CMake velox
 
+# Capture build provenance from sibling repos for embedding in Docker labels.
+PRESTO_SHA=$(git -C "${REPO_ROOT}/../presto" rev-parse HEAD 2>/dev/null || echo "")
+PRESTO_BRANCH=$(git -C "${REPO_ROOT}/../presto" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
+PRESTO_REPO=$(git -C "${REPO_ROOT}/../presto" remote get-url origin 2>/dev/null || echo "")
+VELOX_SHA=$(git -C "${REPO_ROOT}/../velox" rev-parse HEAD 2>/dev/null || echo "")
+VELOX_BRANCH=$(git -C "${REPO_ROOT}/../velox" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
+VELOX_REPO=$(git -C "${REPO_ROOT}/../velox" remote get-url origin 2>/dev/null || echo "")
+
 # now build
 echo "Building..."
-docker compose --progress plain build ${NO_CACHE_ARG} centos-native-dependency
+docker compose --progress plain build ${NO_CACHE_ARG} \
+  --label "velox-testing.presto.sha=${PRESTO_SHA}" \
+  --label "velox-testing.presto.branch=${PRESTO_BRANCH}" \
+  --label "velox-testing.presto.repository=${PRESTO_REPO}" \
+  --label "velox-testing.velox.sha=${VELOX_SHA}" \
+  --label "velox-testing.velox.branch=${VELOX_BRANCH}" \
+  --label "velox-testing.velox.repository=${VELOX_REPO}" \
+  centos-native-dependency
 
 # tag with the user-specific name to avoid conflicts between multiple users on the same host
 COMPOSE_IMAGE_NAME='presto/prestissimo-dependency:centos9'

--- a/presto/scripts/build_centos_deps_image.sh
+++ b/presto/scripts/build_centos_deps_image.sh
@@ -104,17 +104,22 @@ VELOX_REPO=$(git -C "${REPO_ROOT}/../velox" remote get-url origin 2>/dev/null ||
 
 # now build
 echo "Building..."
-docker compose --progress plain build ${NO_CACHE_ARG} \
+docker compose --progress plain build ${NO_CACHE_ARG} centos-native-dependency
+
+# tag with the user-specific name to avoid conflicts between multiple users on the same host
+COMPOSE_IMAGE_NAME='presto/prestissimo-dependency:centos9'
+
+# Apply provenance labels; docker compose build --label is not universally supported.
+echo "Applying provenance labels..."
+echo "FROM ${COMPOSE_IMAGE_NAME}" | docker build --no-cache \
   --label "velox-testing.presto.sha=${PRESTO_SHA}" \
   --label "velox-testing.presto.branch=${PRESTO_BRANCH}" \
   --label "velox-testing.presto.repository=${PRESTO_REPO}" \
   --label "velox-testing.velox.sha=${VELOX_SHA}" \
   --label "velox-testing.velox.branch=${VELOX_BRANCH}" \
   --label "velox-testing.velox.repository=${VELOX_REPO}" \
-  centos-native-dependency
+  -t "${COMPOSE_IMAGE_NAME}" -
 
-# tag with the user-specific name to avoid conflicts between multiple users on the same host
-COMPOSE_IMAGE_NAME='presto/prestissimo-dependency:centos9'
 if [[ "${IMAGE_NAME}" != "${COMPOSE_IMAGE_NAME}" ]]; then
   echo "Tagging image as ${IMAGE_NAME}..."
   docker tag ${COMPOSE_IMAGE_NAME} ${IMAGE_NAME}

--- a/presto/scripts/build_centos_deps_image.sh
+++ b/presto/scripts/build_centos_deps_image.sh
@@ -106,18 +106,21 @@ docker compose --progress plain build ${NO_CACHE_ARG} centos-native-dependency
 COMPOSE_IMAGE_NAME='presto/prestissimo-dependency:centos9'
 
 # centos-dependency.dockerfile lives in the upstream presto repo and cannot be modified,
-# so provenance labels are applied via a scratch re-wrap layer instead of ARG+LABEL.
+# so provenance labels are applied via a wrapper Dockerfile instead of ARG+LABEL.
 # Capture the pre-label image ID so the now-untagged original can be cleaned up afterward.
 PRELABEL_IMAGE_ID=$(docker inspect --format='{{.Id}}' "${COMPOSE_IMAGE_NAME}")
 echo "Applying provenance labels..."
-echo "FROM ${COMPOSE_IMAGE_NAME}" | docker build --no-cache \
-  --label "velox-testing.presto.sha=${PRESTO_SHA}" \
-  --label "velox-testing.presto.branch=${PRESTO_BRANCH}" \
-  --label "velox-testing.presto.repository=${PRESTO_REPO}" \
-  --label "velox-testing.velox.sha=${VELOX_SHA}" \
-  --label "velox-testing.velox.branch=${VELOX_BRANCH}" \
-  --label "velox-testing.velox.repository=${VELOX_REPO}" \
-  -t "${COMPOSE_IMAGE_NAME}" -
+docker build --no-cache \
+  -f "${REPO_ROOT}/presto/docker/provenance_labels.dockerfile" \
+  --build-arg BASE_IMAGE="${COMPOSE_IMAGE_NAME}" \
+  --build-arg PRESTO_SHA="${PRESTO_SHA}" \
+  --build-arg PRESTO_BRANCH="${PRESTO_BRANCH}" \
+  --build-arg PRESTO_REPOSITORY="${PRESTO_REPO}" \
+  --build-arg VELOX_SHA="${VELOX_SHA}" \
+  --build-arg VELOX_BRANCH="${VELOX_BRANCH}" \
+  --build-arg VELOX_REPOSITORY="${VELOX_REPO}" \
+  -t "${COMPOSE_IMAGE_NAME}" \
+  "${REPO_ROOT}/presto/docker"
 docker rmi "${PRELABEL_IMAGE_ID}" 2>/dev/null || true
 
 if [[ "${IMAGE_NAME}" != "${COMPOSE_IMAGE_NAME}" ]]; then

--- a/presto/scripts/build_centos_deps_image.sh
+++ b/presto/scripts/build_centos_deps_image.sh
@@ -63,6 +63,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # Get the root of the git repository
 REPO_ROOT="$(git -C "${SCRIPT_DIR}" rev-parse --show-toplevel)"
 
+source "${SCRIPT_DIR}/common_functions.sh"
+
 # verify sibling Presto and Velox clones
 if [[ ! -d "${REPO_ROOT}/../presto/presto-native-execution" || ! -d "${REPO_ROOT}/../velox" ]]; then
   echo "Error: Sibling Presto and/or Velox clone not found"
@@ -94,13 +96,7 @@ mkdir -p velox
 cp -r ../../velox/scripts velox
 cp -r ../../velox/CMake velox
 
-# Capture build provenance from sibling repos for embedding in Docker labels.
-PRESTO_SHA=$(git -C "${REPO_ROOT}/../presto" rev-parse HEAD 2>/dev/null || echo "")
-PRESTO_BRANCH=$(git -C "${REPO_ROOT}/../presto" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
-PRESTO_REPO=$(git -C "${REPO_ROOT}/../presto" remote get-url origin 2>/dev/null || echo "")
-VELOX_SHA=$(git -C "${REPO_ROOT}/../velox" rev-parse HEAD 2>/dev/null || echo "")
-VELOX_BRANCH=$(git -C "${REPO_ROOT}/../velox" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
-VELOX_REPO=$(git -C "${REPO_ROOT}/../velox" remote get-url origin 2>/dev/null || echo "")
+capture_build_provenance "${REPO_ROOT}"
 
 # now build
 echo "Building..."
@@ -109,7 +105,10 @@ docker compose --progress plain build ${NO_CACHE_ARG} centos-native-dependency
 # tag with the user-specific name to avoid conflicts between multiple users on the same host
 COMPOSE_IMAGE_NAME='presto/prestissimo-dependency:centos9'
 
-# Apply provenance labels; docker compose build --label is not universally supported.
+# centos-dependency.dockerfile lives in the upstream presto repo and cannot be modified,
+# so provenance labels are applied via a scratch re-wrap layer instead of ARG+LABEL.
+# Capture the pre-label image ID so the now-untagged original can be cleaned up afterward.
+PRELABEL_IMAGE_ID=$(docker inspect --format='{{.Id}}' "${COMPOSE_IMAGE_NAME}")
 echo "Applying provenance labels..."
 echo "FROM ${COMPOSE_IMAGE_NAME}" | docker build --no-cache \
   --label "velox-testing.presto.sha=${PRESTO_SHA}" \
@@ -119,6 +118,7 @@ echo "FROM ${COMPOSE_IMAGE_NAME}" | docker build --no-cache \
   --label "velox-testing.velox.branch=${VELOX_BRANCH}" \
   --label "velox-testing.velox.repository=${VELOX_REPO}" \
   -t "${COMPOSE_IMAGE_NAME}" -
+docker rmi "${PRELABEL_IMAGE_ID}" 2>/dev/null || true
 
 if [[ "${IMAGE_NAME}" != "${COMPOSE_IMAGE_NAME}" ]]; then
   echo "Tagging image as ${IMAGE_NAME}..."

--- a/presto/scripts/common_functions.sh
+++ b/presto/scripts/common_functions.sh
@@ -3,6 +3,18 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 
+# Sets PRESTO_SHA, PRESTO_BRANCH, PRESTO_REPO, VELOX_SHA, VELOX_BRANCH, VELOX_REPO
+# by reading the sibling presto and velox repos relative to the given velox-testing root.
+function capture_build_provenance() {
+  local repo_root="$1"
+  PRESTO_SHA=$(git -C "${repo_root}/../presto" rev-parse HEAD 2>/dev/null || echo "")
+  PRESTO_BRANCH=$(git -C "${repo_root}/../presto" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
+  PRESTO_REPO=$(git -C "${repo_root}/../presto" remote get-url origin 2>/dev/null || echo "")
+  VELOX_SHA=$(git -C "${repo_root}/../velox" rev-parse HEAD 2>/dev/null || echo "")
+  VELOX_BRANCH=$(git -C "${repo_root}/../velox" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
+  VELOX_REPO=$(git -C "${repo_root}/../velox" remote get-url origin 2>/dev/null || echo "")
+}
+
 function wait_for_worker_node_registration() {
   local host="$1"
   local port="$2"

--- a/presto/scripts/start_presto_helper.sh
+++ b/presto/scripts/start_presto_helper.sh
@@ -36,6 +36,7 @@ function validate_sibling_repos() {
 }
 
 source "${SCRIPT_DIR}/start_presto_helper_parse_args.sh"
+source "${SCRIPT_DIR}/common_functions.sh"
 
 validate_sccache_auth() {
   if [[ "$ENABLE_SCCACHE" == true ]]; then
@@ -226,33 +227,18 @@ if (( ${#BUILD_TARGET_ARG[@]} )); then
     SCCACHE_BUILD_ARGS+=(--build-arg SCCACHE_NO_DIST_COMPILE=1)
   fi
 
-  # Capture build provenance from sibling repos for embedding in Docker labels.
-  PRESTO_REPO_DIR=$(readlink -f "${SCRIPT_DIR}/../../../presto")
-  PRESTO_SHA=$(git -C "${PRESTO_REPO_DIR}" rev-parse HEAD 2>/dev/null || echo "")
-  PRESTO_BRANCH=$(git -C "${PRESTO_REPO_DIR}" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
-  PRESTO_REPO=$(git -C "${PRESTO_REPO_DIR}" remote get-url origin 2>/dev/null || echo "")
-  if [[ "$VARIANT_TYPE" != "java" ]]; then
-    VELOX_REPO_DIR=$(readlink -f "${SCRIPT_DIR}/../../../velox")
-    VELOX_SHA=$(git -C "${VELOX_REPO_DIR}" rev-parse HEAD 2>/dev/null || echo "")
-    VELOX_BRANCH=$(git -C "${VELOX_REPO_DIR}" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
-    VELOX_REPO=$(git -C "${VELOX_REPO_DIR}" remote get-url origin 2>/dev/null || echo "")
-  else
-    VELOX_SHA=""
-    VELOX_BRANCH=""
-    VELOX_REPO=""
+  # Capture build provenance from sibling repos; exported so docker-compose picks them up.
+  capture_build_provenance "${REPO_ROOT}"
+  if [[ "$VARIANT_TYPE" == "java" ]]; then
+    VELOX_SHA="" VELOX_BRANCH="" VELOX_REPO=""
   fi
+  export PRESTO_SHA PRESTO_BRANCH PRESTO_REPO VELOX_SHA VELOX_BRANCH VELOX_REPO
 
   echo "Building services: ${BUILD_TARGET_ARG[@]}"
   docker compose --progress plain -f $DOCKER_COMPOSE_FILE_PATH build \
   $SKIP_CACHE_ARG --build-arg PRESTO_VERSION=$PRESTO_VERSION \
   --build-arg NUM_THREADS=$NUM_THREADS --build-arg BUILD_TYPE=$BUILD_TYPE \
   --build-arg CUDA_ARCHITECTURES=$CUDA_ARCHITECTURES \
-  --build-arg PRESTO_SHA="${PRESTO_SHA}" \
-  --build-arg PRESTO_BRANCH="${PRESTO_BRANCH}" \
-  --build-arg PRESTO_REPOSITORY="${PRESTO_REPO}" \
-  --build-arg VELOX_SHA="${VELOX_SHA}" \
-  --build-arg VELOX_BRANCH="${VELOX_BRANCH}" \
-  --build-arg VELOX_REPOSITORY="${VELOX_REPO}" \
   "${SCCACHE_BUILD_ARGS[@]}" \
   ${BUILD_TARGET_ARG[@]}
 

--- a/presto/scripts/start_presto_helper.sh
+++ b/presto/scripts/start_presto_helper.sh
@@ -226,12 +226,24 @@ if (( ${#BUILD_TARGET_ARG[@]} )); then
     SCCACHE_BUILD_ARGS+=(--build-arg SCCACHE_NO_DIST_COMPILE=1)
   fi
 
+  # Capture build provenance from sibling repos for embedding in Docker labels.
+  PRESTO_REPO_DIR=$(readlink -f "${SCRIPT_DIR}/../../../presto")
+  VELOX_REPO_DIR=$(readlink -f "${SCRIPT_DIR}/../../../velox")
+  PRESTO_SHA=$(git -C "${PRESTO_REPO_DIR}" rev-parse HEAD 2>/dev/null || echo "unknown")
+  VELOX_SHA=$(git -C "${VELOX_REPO_DIR}" rev-parse HEAD 2>/dev/null || echo "unknown")
+  PRESTO_BRANCH=$(git -C "${PRESTO_REPO_DIR}" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")
+  VELOX_BRANCH=$(git -C "${VELOX_REPO_DIR}" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")
+
   echo "Building services: ${BUILD_TARGET_ARG[@]}"
   docker compose --progress plain -f $DOCKER_COMPOSE_FILE_PATH build \
   $SKIP_CACHE_ARG --build-arg PRESTO_VERSION=$PRESTO_VERSION \
   --build-arg NUM_THREADS=$NUM_THREADS --build-arg BUILD_TYPE=$BUILD_TYPE \
   --build-arg CUDA_ARCHITECTURES=$CUDA_ARCHITECTURES \
   "${SCCACHE_BUILD_ARGS[@]}" \
+  --label "velox-testing.presto.sha=${PRESTO_SHA}" \
+  --label "velox-testing.presto.branch=${PRESTO_BRANCH}" \
+  --label "velox-testing.velox.sha=${VELOX_SHA}" \
+  --label "velox-testing.velox.branch=${VELOX_BRANCH}" \
   ${BUILD_TARGET_ARG[@]}
 fi
 

--- a/presto/scripts/start_presto_helper.sh
+++ b/presto/scripts/start_presto_helper.sh
@@ -247,24 +247,26 @@ if (( ${#BUILD_TARGET_ARG[@]} )); then
   $SKIP_CACHE_ARG --build-arg PRESTO_VERSION=$PRESTO_VERSION \
   --build-arg NUM_THREADS=$NUM_THREADS --build-arg BUILD_TYPE=$BUILD_TYPE \
   --build-arg CUDA_ARCHITECTURES=$CUDA_ARCHITECTURES \
+  --build-arg PRESTO_SHA="${PRESTO_SHA}" \
+  --build-arg PRESTO_BRANCH="${PRESTO_BRANCH}" \
+  --build-arg PRESTO_REPOSITORY="${PRESTO_REPO}" \
+  --build-arg VELOX_SHA="${VELOX_SHA}" \
+  --build-arg VELOX_BRANCH="${VELOX_BRANCH}" \
+  --build-arg VELOX_REPOSITORY="${VELOX_REPO}" \
   "${SCCACHE_BUILD_ARGS[@]}" \
   ${BUILD_TARGET_ARG[@]}
 
-  # Apply provenance labels; docker compose build --label is not universally supported.
+  # Coordinator and java-worker use external Dockerfiles (presto repo) without ARG+LABEL
+  # declarations, so labels must be applied via a re-wrap after build.
   PROVENANCE_LABEL_ARGS=(
     --label "velox-testing.presto.sha=${PRESTO_SHA}"
     --label "velox-testing.presto.branch=${PRESTO_BRANCH}"
     --label "velox-testing.presto.repository=${PRESTO_REPO}"
-    --label "velox-testing.velox.sha=${VELOX_SHA}"
-    --label "velox-testing.velox.branch=${VELOX_BRANCH}"
-    --label "velox-testing.velox.repository=${VELOX_REPO}"
   )
   for service in "${BUILD_TARGET_ARG[@]}"; do
     case "$service" in
       "$COORDINATOR_SERVICE") img="$COORDINATOR_IMAGE" ;;
       "$JAVA_WORKER_SERVICE") img="$JAVA_WORKER_IMAGE" ;;
-      "$CPU_WORKER_SERVICE") img="$CPU_WORKER_IMAGE" ;;
-      "$GPU_WORKER_SERVICE") img="$GPU_WORKER_IMAGE" ;;
       *) continue ;;
     esac
     echo "Applying provenance labels to ${img}..."

--- a/presto/scripts/start_presto_helper.sh
+++ b/presto/scripts/start_presto_helper.sh
@@ -243,11 +243,14 @@ if (( ${#BUILD_TARGET_ARG[@]} )); then
   ${BUILD_TARGET_ARG[@]}
 
   # Coordinator and java-worker use external Dockerfiles (presto repo) without ARG+LABEL
-  # declarations, so labels must be applied via a re-wrap after build.
-  PROVENANCE_LABEL_ARGS=(
-    --label "velox-testing.presto.sha=${PRESTO_SHA}"
-    --label "velox-testing.presto.branch=${PRESTO_BRANCH}"
-    --label "velox-testing.presto.repository=${PRESTO_REPO}"
+  # declarations, so provenance labels are applied via a wrapper Dockerfile after build.
+  PROVENANCE_LABEL_BUILDARGS=(
+    --build-arg PRESTO_SHA="${PRESTO_SHA}"
+    --build-arg PRESTO_BRANCH="${PRESTO_BRANCH}"
+    --build-arg PRESTO_REPOSITORY="${PRESTO_REPO}"
+    --build-arg VELOX_SHA=""
+    --build-arg VELOX_BRANCH=""
+    --build-arg VELOX_REPOSITORY=""
   )
   for service in "${BUILD_TARGET_ARG[@]}"; do
     case "$service" in
@@ -255,8 +258,15 @@ if (( ${#BUILD_TARGET_ARG[@]} )); then
       "$JAVA_WORKER_SERVICE") img="$JAVA_WORKER_IMAGE" ;;
       *) continue ;;
     esac
+    PRELABEL_IMAGE_ID=$(docker inspect --format='{{.Id}}' "${img}")
     echo "Applying provenance labels to ${img}..."
-    echo "FROM ${img}" | docker build --no-cache "${PROVENANCE_LABEL_ARGS[@]}" -t "${img}" -
+    docker build --no-cache \
+      -f "${REPO_ROOT}/presto/docker/provenance_labels.dockerfile" \
+      --build-arg BASE_IMAGE="${img}" \
+      "${PROVENANCE_LABEL_BUILDARGS[@]}" \
+      -t "${img}" \
+      "${REPO_ROOT}/presto/docker"
+    docker rmi "${PRELABEL_IMAGE_ID}" 2>/dev/null || true
   done
 fi
 

--- a/presto/scripts/start_presto_helper.sh
+++ b/presto/scripts/start_presto_helper.sh
@@ -248,13 +248,28 @@ if (( ${#BUILD_TARGET_ARG[@]} )); then
   --build-arg NUM_THREADS=$NUM_THREADS --build-arg BUILD_TYPE=$BUILD_TYPE \
   --build-arg CUDA_ARCHITECTURES=$CUDA_ARCHITECTURES \
   "${SCCACHE_BUILD_ARGS[@]}" \
-  --label "velox-testing.presto.sha=${PRESTO_SHA}" \
-  --label "velox-testing.presto.branch=${PRESTO_BRANCH}" \
-  --label "velox-testing.presto.repository=${PRESTO_REPO}" \
-  --label "velox-testing.velox.sha=${VELOX_SHA}" \
-  --label "velox-testing.velox.branch=${VELOX_BRANCH}" \
-  --label "velox-testing.velox.repository=${VELOX_REPO}" \
   ${BUILD_TARGET_ARG[@]}
+
+  # Apply provenance labels; docker compose build --label is not universally supported.
+  PROVENANCE_LABEL_ARGS=(
+    --label "velox-testing.presto.sha=${PRESTO_SHA}"
+    --label "velox-testing.presto.branch=${PRESTO_BRANCH}"
+    --label "velox-testing.presto.repository=${PRESTO_REPO}"
+    --label "velox-testing.velox.sha=${VELOX_SHA}"
+    --label "velox-testing.velox.branch=${VELOX_BRANCH}"
+    --label "velox-testing.velox.repository=${VELOX_REPO}"
+  )
+  for service in "${BUILD_TARGET_ARG[@]}"; do
+    case "$service" in
+      "$COORDINATOR_SERVICE") img="$COORDINATOR_IMAGE" ;;
+      "$JAVA_WORKER_SERVICE") img="$JAVA_WORKER_IMAGE" ;;
+      "$CPU_WORKER_SERVICE") img="$CPU_WORKER_IMAGE" ;;
+      "$GPU_WORKER_SERVICE") img="$GPU_WORKER_IMAGE" ;;
+      *) continue ;;
+    esac
+    echo "Applying provenance labels to ${img}..."
+    echo "FROM ${img}" | docker build --no-cache "${PROVENANCE_LABEL_ARGS[@]}" -t "${img}" -
+  done
 fi
 
 # Start all services defined in the rendered docker-compose file.

--- a/presto/scripts/start_presto_helper.sh
+++ b/presto/scripts/start_presto_helper.sh
@@ -228,11 +228,19 @@ if (( ${#BUILD_TARGET_ARG[@]} )); then
 
   # Capture build provenance from sibling repos for embedding in Docker labels.
   PRESTO_REPO_DIR=$(readlink -f "${SCRIPT_DIR}/../../../presto")
-  VELOX_REPO_DIR=$(readlink -f "${SCRIPT_DIR}/../../../velox")
-  PRESTO_SHA=$(git -C "${PRESTO_REPO_DIR}" rev-parse HEAD 2>/dev/null || echo "unknown")
-  VELOX_SHA=$(git -C "${VELOX_REPO_DIR}" rev-parse HEAD 2>/dev/null || echo "unknown")
-  PRESTO_BRANCH=$(git -C "${PRESTO_REPO_DIR}" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")
-  VELOX_BRANCH=$(git -C "${VELOX_REPO_DIR}" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")
+  PRESTO_SHA=$(git -C "${PRESTO_REPO_DIR}" rev-parse HEAD 2>/dev/null || echo "")
+  PRESTO_BRANCH=$(git -C "${PRESTO_REPO_DIR}" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
+  PRESTO_REPO=$(git -C "${PRESTO_REPO_DIR}" remote get-url origin 2>/dev/null || echo "")
+  if [[ "$VARIANT_TYPE" != "java" ]]; then
+    VELOX_REPO_DIR=$(readlink -f "${SCRIPT_DIR}/../../../velox")
+    VELOX_SHA=$(git -C "${VELOX_REPO_DIR}" rev-parse HEAD 2>/dev/null || echo "")
+    VELOX_BRANCH=$(git -C "${VELOX_REPO_DIR}" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
+    VELOX_REPO=$(git -C "${VELOX_REPO_DIR}" remote get-url origin 2>/dev/null || echo "")
+  else
+    VELOX_SHA=""
+    VELOX_BRANCH=""
+    VELOX_REPO=""
+  fi
 
   echo "Building services: ${BUILD_TARGET_ARG[@]}"
   docker compose --progress plain -f $DOCKER_COMPOSE_FILE_PATH build \
@@ -242,8 +250,10 @@ if (( ${#BUILD_TARGET_ARG[@]} )); then
   "${SCCACHE_BUILD_ARGS[@]}" \
   --label "velox-testing.presto.sha=${PRESTO_SHA}" \
   --label "velox-testing.presto.branch=${PRESTO_BRANCH}" \
+  --label "velox-testing.presto.repository=${PRESTO_REPO}" \
   --label "velox-testing.velox.sha=${VELOX_SHA}" \
   --label "velox-testing.velox.branch=${VELOX_BRANCH}" \
+  --label "velox-testing.velox.repository=${VELOX_REPO}" \
   ${BUILD_TARGET_ARG[@]}
 fi
 


### PR DESCRIPTION
This change updates our CI and build scripts to add labels into our docker  images to track which presto/velox branches the images were built with.  This is particularly useful since the scripts expect image names and tags to be uniform, so it can be easy to lose track of how an image was originally built.

This will be especially useful for benchmarking, as the post_results.py script can reference this to make sure we track exactly what was used to build an image that was used for a benchmark (follow-up PR).

The way these labels are filled is slightly different between the CI and a local build, only because the CI references SHAs only, whereas a local build will also reference the branch the CI belongs to for ease of use.

Example docker inspect on worker image (from CI):

```
"Labels": {
                ...
                "velox-testing.presto.branch": "",
                "velox-testing.presto.repository": "prestodb/presto",
                "velox-testing.presto.sha": "dae4091c7105d1370544bfcb11baf8f8a79256bc",
                "velox-testing.velox.branch": "",
                "velox-testing.velox.repository": "facebookincubator/velox",
                "velox-testing.velox.sha": "948e7be0619f8d123ae9d8fbd8a4f7b928492aec"
            }
```
Coord image (CI):
```
"Labels": {
                 ...
                "velox-testing.presto.branch": "",
                "velox-testing.presto.repository": "prestodb/presto",
                "velox-testing.presto.sha": "dae4091c7105d1370544bfcb11baf8f8a79256bc",
                "velox-testing.velox.branch": "",
                "velox-testing.velox.repository": "",
                "velox-testing.velox.sha": ""
            }
```
Deps image (Local):
```
"Labels": {
                ...
                "velox-testing.presto.branch": "master",
                "velox-testing.presto.repository": "https://github.com/prestodb/presto.git",
                "velox-testing.presto.sha": "91e9132db5abcbfb0d7ab2232602784c5f02d5b4",
                "velox-testing.velox.branch": "main",
                "velox-testing.velox.repository": "https://github.com/facebookincubator/velox.git",
                "velox-testing.velox.sha": "7ed90a53dee9e640cba92a644dae85fe52b07fb9"
}
```
Worker image (Local):
```
            "Labels": {
                ...
                "velox-testing.presto.branch": "master",
                "velox-testing.presto.repository": "https://github.com/prestodb/presto.git",
                "velox-testing.presto.sha": "91e9132db5abcbfb0d7ab2232602784c5f02d5b4",
                "velox-testing.velox.branch": "main",
                "velox-testing.velox.repository": "https://github.com/facebookincubator/velox.git",
                "velox-testing.velox.sha": "7ed90a53dee9e640cba92a644dae85fe52b07fb9"
}
```