### PR TITLE
Handle both flat and nested scale_factor in metadata.json

### DIFF
--- a/common/testing/test_utils.py
+++ b/common/testing/test_utils.py
@@ -17,7 +17,9 @@ def get_queries(benchmark_type, queries_file=None):
 def get_scale_factor_from_file(file):
     with open(get_abs_file_path(__file__, file), "r") as file:
         metadata = json.load(file)
-        return metadata["scale_factor"]
+        if "scale_factor" in metadata:
+            return metadata["scale_factor"]
+        return metadata["options"]["scale_factor"]
 
 
 def get_abs_file_path(file_path, relative_path):

--- a/presto/testing/common/test_utils.py
+++ b/presto/testing/common/test_utils.py
@@ -58,9 +58,15 @@ def get_scale_factor(request, presto_cursor):
     if not os.path.exists(meta_file):
         raise pytest.UsageError(
             f"Could not find metadata file in data repository '{repository_path}'.\n"
-            "Metadata file must be called 'metadata.json' and have the following format:\n"
+            "Metadata file must be called 'metadata.json' and have one of the following formats:\n"
             "{\n"
             '  "scale_factor": <scale_factor>\n'
+            "}\n"
+            "or\n"
+            "{\n"
+            '  "options": {\n'
+            '    "scale_factor": <scale_factor>\n'
+            "  }\n"
             "}\n"
             "where <scale_factor> is a floating point number."
         )

--- a/spark_gluten/testing/common/test_utils.py
+++ b/spark_gluten/testing/common/test_utils.py
@@ -16,9 +16,15 @@ def get_scale_factor(request, benchmark_type):
     if not os.path.exists(meta_file):
         raise pytest.UsageError(
             f"Could not find metadata file in dataset directory '{dataset_dir}'.\n"
-            "Metadata file must be called 'metadata.json' and have the following format:\n"
+            "Metadata file must be called 'metadata.json' and have one of the following formats:\n"
             "{\n"
             '  "scale_factor": <scale_factor>\n'
+            "}\n"
+            "or\n"
+            "{\n"
+            '  "options": {\n'
+            '    "scale_factor": <scale_factor>\n'
+            "  }\n"
             "}\n"
             "where <scale_factor> is a floating point number."
         )


### PR DESCRIPTION
Datasets with a newer metadata format nest scale_factor under an "options" key. Update get_scale_factor_from_file() to try the top-level key first and fall back to options.scale_factor, and update error messages in Presto and Spark Gluten test utils to document both formats.