### PR TITLE
Fix stop_presto.sh failing when PRESTO_IMAGE_TAG is not set

### DIFF
--- a/presto/scripts/stop_presto.sh
+++ b/presto/scripts/stop_presto.sh
@@ -1,9 +1,15 @@
 #!/bin/bash
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
 
 set -e
 
 # Compute the directory where this script resides
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+if [ -z "${PRESTO_IMAGE_TAG}" ]; then
+  export PRESTO_IMAGE_TAG="${USER:-latest}"
+fi
 
 GPU_FILE="${SCRIPT_DIR}/../docker/docker-compose/generated/docker-compose.native-gpu.rendered.yml"
 JAVA_FILE="${SCRIPT_DIR}/../docker/docker-compose.java.yml"


### PR DESCRIPTION
After adding `:?` enforcement to docker-compose files, stop_presto.sh would fail immediately if PRESTO_IMAGE_TAG wasn't already in the environment.  stop_presto.sh was still executing correctly, but would end with an error.

Apply the same `USER:-latest` default used in start_presto_helper.sh and run_benchmark.sh.