### PR TITLE
Add Parquet format/type overrides to match reference TPC-H dataset

### DIFF
--- a/benchmark_data_tools/generate_data_files.py
+++ b/benchmark_data_tools/generate_data_files.py
@@ -29,6 +29,9 @@ def generate_partition(
     approx_row_group_bytes,
     convert_decimals_to_floats,
     codec_defs,
+    parquet_version,
+    nationkey_type,
+    regionkey_type,
 ):
     if verbose:
         print(f"Generating '{table}' partition: {partition}")
@@ -49,6 +52,12 @@ def generate_partition(
         "parquet",
         "--parquet-row-group-bytes",
         str(approx_row_group_bytes),
+        "--parquet-version",
+        parquet_version,
+        "--nationkey-type",
+        nationkey_type,
+        "--regionkey-type",
+        regionkey_type,
     ]
 
     if convert_decimals_to_floats:
@@ -126,6 +135,9 @@ def generate_data_files_with_tpchgen(args, codec_defs):
                         args.approx_row_group_bytes,
                         args.convert_decimals_to_floats,
                         codec_defs,
+                        args.parquet_version,
+                        args.nationkey_type,
+                        args.regionkey_type,
                     )
                 )
             max_partitions = num_partitions if num_partitions > max_partitions else max_partitions
@@ -414,6 +426,31 @@ if __name__ == "__main__":
         required=False,
         default=None,
         help="Path to a JSON file specifying per-table/per-column encoding, compression, and dictionary settings.",
+    )
+    parser.add_argument(
+        "--parquet-version",
+        type=str,
+        required=False,
+        default="v2",
+        choices=["v1", "v2"],
+        help="Parquet format version. v2 enables Data Page V2 encodings (RLE_DICTIONARY, DELTA_BINARY_PACKED) "
+        "that cuDF's Parquet reader relies on for efficient integer decoding. Default: v2.",
+    )
+    parser.add_argument(
+        "--nationkey-type",
+        type=str,
+        required=False,
+        default="i32",
+        choices=["i32", "i64"],
+        help="Arrow type for c_nationkey, n_nationkey, s_nationkey. Default: i32.",
+    )
+    parser.add_argument(
+        "--regionkey-type",
+        type=str,
+        required=False,
+        default="i32",
+        choices=["i32", "i64"],
+        help="Arrow type for n_regionkey, r_regionkey. Default: i32.",
     )
     args = parser.parse_args()
     generate_data_files(args)

--- a/benchmark_data_tools/tests/common_fixtures.py
+++ b/benchmark_data_tools/tests/common_fixtures.py
@@ -31,6 +31,9 @@ class DataGenArgs:
     keep_original_dataset: bool
     approx_row_group_bytes: int
     codec_definitions: str = None
+    parquet_version: str = "v2"
+    nationkey_type: str = "i32"
+    regionkey_type: str = "i32"
 
 
 @pytest.fixture

--- a/presto/scripts/setup_benchmark_data_and_tables.sh
+++ b/presto/scripts/setup_benchmark_data_and_tables.sh
@@ -14,7 +14,10 @@ SCRIPT_EXAMPLE_ARGS="-b tpch -s my_tpch_sf100 -d sf100 -f 100 -c"
 SCRIPT_EXTRA_OPTIONS_DESCRIPTION="-f, --scale-factor                  The scale factor of the generated dataset.
     -c, --convert-decimals-to-floats    Convert all decimal columns to float column type.
     -j, --num-threads                   Number of threads to use for data generation. Default is $((`nproc` / 4)).
-    --approx-row-group-bytes            Approximate row group size in bytes."
+    --approx-row-group-bytes            Approximate row group size in bytes.
+    --parquet-version                   Parquet format version: v1 or v2. Default: v2.
+    --nationkey-type                    Arrow type for nationkey columns: i32 or i64. Default: i32.
+    --regionkey-type                    Arrow type for regionkey columns: i32 or i64. Default: i32."
 
 NUM_THREADS=$(($(nproc) / 4))
 function extra_options_parser() {
@@ -61,6 +64,42 @@ function extra_options_parser() {
       fi
       shift 2
       ;;
+    --parquet-version)
+      if [[ -n $2 ]]; then
+        PARQUET_VERSION_ARG="--parquet-version $2"
+        SCRIPT_EXTRA_OPTIONS_SHIFTS=2
+        SCRIPT_EXTRA_OPTIONS_UNKNOWN_ARG=false
+        return 0
+      else
+        echo "Error: --parquet-version requires a value"
+        return 1
+      fi
+      shift 2
+      ;;
+    --nationkey-type)
+      if [[ -n $2 ]]; then
+        NATIONKEY_TYPE_ARG="--nationkey-type $2"
+        SCRIPT_EXTRA_OPTIONS_SHIFTS=2
+        SCRIPT_EXTRA_OPTIONS_UNKNOWN_ARG=false
+        return 0
+      else
+        echo "Error: --nationkey-type requires a value"
+        return 1
+      fi
+      shift 2
+      ;;
+    --regionkey-type)
+      if [[ -n $2 ]]; then
+        REGIONKEY_TYPE_ARG="--regionkey-type $2"
+        SCRIPT_EXTRA_OPTIONS_SHIFTS=2
+        SCRIPT_EXTRA_OPTIONS_UNKNOWN_ARG=false
+        return 0
+      else
+        echo "Error: --regionkey-type requires a value"
+        return 1
+      fi
+      shift 2
+      ;;
     *)
       return 0
       ;;
@@ -77,7 +116,8 @@ DATA_GEN_SCRIPT_PATH=$(readlink -f "${SCRIPT_DIR}/../../benchmark_data_tools/gen
 
 "${SCRIPT_DIR}/../../scripts/run_py_script.sh" -p $DATA_GEN_SCRIPT_PATH --benchmark-type $BENCHMARK_TYPE \
 --data-dir-path ${PRESTO_DATA_DIR}/${DATA_DIR_NAME} --scale-factor $SCALE_FACTOR \
---num-threads $NUM_THREADS $CONVERT_DECIMALS_TO_FLOATS_ARG $APPROX_ROW_GROUP_BYTES_ARG
+--num-threads $NUM_THREADS $CONVERT_DECIMALS_TO_FLOATS_ARG $APPROX_ROW_GROUP_BYTES_ARG \
+$PARQUET_VERSION_ARG $NATIONKEY_TYPE_ARG $REGIONKEY_TYPE_ARG
 
 SKIP_ANALYZE_TABLES_ARG=""
 if [[ "$SKIP_ANALYZE_TABLES" == "true" ]]; then


### PR DESCRIPTION
Builds on #314's per-column encoding/compression overrides by adding
three dataset-wide knobs that determine the Parquet wire format and
the integer width of nationkey/regionkey columns. Required to
reproduce layouts used as reference datasets elsewhere, where a
mismatch between the generated schema and the CREATE TABLE DDL (int32
vs int64) causes silent casts, and where Parquet v2 Data Page format
is what downstream readers assume for the encodings #314 configures.

* Add --parquet-version {v1,v2} to generate_data_files.py, default v2.
  tpchgen-cli's default is v1 (broader compatibility). v2 emits Data
  Page V2 headers, which cuDF's Parquet reader relies on for efficient
  decode of DELTA_BINARY_PACKED integer columns (the encoding 314's)
  default codec defs apply to every integer column).
* Add --nationkey-type {i32,i64} (default i32) and --regionkey-type
  {i32,i64} (default i32). tpchgen-cli defaults both to i64; these
  columns are low cardinality (25 nations, 5 regions) so i32 halves
  their bytes and matches the INTEGER width used in reference TPC-H
  DDL.
* Plumb the three flags through
  presto/scripts/setup_benchmark_data_and_tables.sh so the top-level
  benchmark setup script accepts the same options and forwards them to
  generate_data_files.py.
* Extend the DataGenArgs fixture in
  benchmark_data_tools/tests/common_fixtures.py with matching defaults
  so the existing codec/decimal/row-group tests exercise the new
  values automatically.