### PR TITLE
fix(ci): forward attestation+artifact-metadata perms through nightly reusable workflows

### DIFF
--- a/.github/workflows/presto-nightly.yml
+++ b/.github/workflows/presto-nightly.yml
@@ -17,6 +17,8 @@ jobs:
       contents: read
       id-token: write
       packages: write
+      attestations: write
+      artifact-metadata: write
     uses: ./.github/workflows/presto.yml
     with:
       variant_label: upstream
@@ -34,6 +36,8 @@ jobs:
       contents: read
       id-token: write
       packages: write
+      attestations: write
+      artifact-metadata: write
     uses: ./.github/workflows/presto.yml
     with:
       variant_label: pinned
@@ -51,6 +55,8 @@ jobs:
       contents: read
       id-token: write
       packages: write
+      attestations: write
+      artifact-metadata: write
     uses: ./.github/workflows/presto.yml
     with:
       variant_label: staging

--- a/.github/workflows/presto.yml
+++ b/.github/workflows/presto.yml
@@ -88,6 +88,8 @@ jobs:
       contents: read
       id-token: write
       packages: write
+      attestations: write
+      artifact-metadata: write
     uses: ./.github/workflows/presto-build.yml
     with:
       velox_repository: ${{ inputs.velox_repository }}

--- a/.github/workflows/velox-nightly.yml
+++ b/.github/workflows/velox-nightly.yml
@@ -17,6 +17,8 @@ jobs:
       contents: read
       id-token: write
       packages: write
+      attestations: write
+      artifact-metadata: write
     uses: ./.github/workflows/velox.yml
     with:
       variant_label: upstream
@@ -32,6 +34,8 @@ jobs:
       contents: read
       id-token: write
       packages: write
+      attestations: write
+      artifact-metadata: write
     uses: ./.github/workflows/velox.yml
     with:
       variant_label: staging

--- a/.github/workflows/velox.yml
+++ b/.github/workflows/velox.yml
@@ -72,6 +72,8 @@ jobs:
       contents: read
       id-token: write
       packages: write
+      attestations: write
+      artifact-metadata: write
     uses: ./.github/workflows/velox-build.yml
     with:
       velox_repository: ${{ inputs.velox_repository }}


### PR DESCRIPTION
This PR fixes the “Startup failure” issue that has been occurring in the nightly jobs recently.