### PR TITLE
Add s2 bundled to devcontainer

### DIFF
--- a/scripts/devcontainer/configure-velox
+++ b/scripts/devcontainer/configure-velox
@@ -91,6 +91,7 @@ EXTRA_CMAKE_FLAGS+=" -Dabsl_SOURCE=BUNDLED"
 EXTRA_CMAKE_FLAGS+=" -DgRPC_SOURCE=BUNDLED"
 EXTRA_CMAKE_FLAGS+=" -DArrow_SOURCE=BUNDLED"
 EXTRA_CMAKE_FLAGS+=" -Dgeos_SOURCE=BUNDLED"
+EXTRA_CMAKE_FLAGS+=" -Ds2geometry_SOURCE=BUNDLED"
 
 # Auto-detect pre-built RAPIDS libraries (cudf, rmm, kvikio)
 CUDF_BUILD_DIR=$(get_rapids_cmake_dir "cudf")


### PR DESCRIPTION
Velox added a new dependency called s2geometry in https://github.com/facebookincubator/velox/commit/fcb63d379fb99661a9dbd9d0e5cbff52c92d9f15 and devcontainer build-velox was broken without it