### PR TITLE
Fix CI image tag collisions with per-call intermediate tags

### DIFF
--- a/.github/actions/resolve-inputs/action.yml
+++ b/.github/actions/resolve-inputs/action.yml
@@ -33,9 +33,9 @@ outputs:
   date:
     description: 'Resolved build date'
     value: ${{ steps.resolve.outputs.date }}
-  image_tag_suffix:
-    description: 'Suffix after the resolved build date, if present'
-    value: ${{ steps.resolve.outputs.image_tag_suffix }}
+  run_id_suffix:
+    description: 'Run ID suffix after the resolved build date, if present'
+    value: ${{ steps.resolve.outputs.run_id_suffix }}
 
 runs:
   using: composite
@@ -62,7 +62,7 @@ runs:
             if [[ ! "${suffix}" =~ ^-[0-9]+$ ]]; then
               suffix=""
             fi
-            echo "image_tag_suffix=${suffix}" >> "$GITHUB_OUTPUT"
+            echo "run_id_suffix=${suffix}" >> "$GITHUB_OUTPUT"
             echo "Parsed presto image: presto=${BASH_REMATCH[1]}, velox=${BASH_REMATCH[2]}, date=${BASH_REMATCH[3]}"
 
           # Velox format: velox-{SHA}-...-{DATE}[-suffix]
@@ -74,7 +74,7 @@ runs:
             if [[ ! "${suffix}" =~ ^-[0-9]+$ ]]; then
               suffix=""
             fi
-            echo "image_tag_suffix=${suffix}" >> "$GITHUB_OUTPUT"
+            echo "run_id_suffix=${suffix}" >> "$GITHUB_OUTPUT"
             echo "Parsed velox image: velox=${BASH_REMATCH[1]}, date=${BASH_REMATCH[2]}"
 
           else
@@ -89,5 +89,5 @@ runs:
           echo "velox_short_sha=${VELOX_SHORT_SHA}" >> "$GITHUB_OUTPUT"
           echo "presto_short_sha=${PRESTO_SHORT_SHA}" >> "$GITHUB_OUTPUT"
           echo "date=${DATE}" >> "$GITHUB_OUTPUT"
-          echo "image_tag_suffix=" >> "$GITHUB_OUTPUT"
+          echo "run_id_suffix=" >> "$GITHUB_OUTPUT"
         fi

--- a/.github/actions/resolve-inputs/action.yml
+++ b/.github/actions/resolve-inputs/action.yml
@@ -33,6 +33,9 @@ outputs:
   date:
     description: 'Resolved build date'
     value: ${{ steps.resolve.outputs.date }}
+  image_tag_suffix:
+    description: 'Suffix after the resolved build date, if present'
+    value: ${{ steps.resolve.outputs.image_tag_suffix }}
 
 runs:
   using: composite
@@ -50,18 +53,28 @@ runs:
           TAG="${IMAGE_TAG##*:}"
           echo "Parsing tag: ${TAG}"
 
-          # Presto format: presto-{SHA}-velox-{SHA}-...-{DATE}[-arch]
+          # Presto format: presto-{SHA}-velox-{SHA}-...-{DATE}[-suffix]
           if [[ "$TAG" =~ ^presto-([a-f0-9]+)-velox-([a-f0-9]+)-.*-([0-9]{8})(-[a-z0-9]+)?$ ]]; then
             echo "presto_short_sha=${BASH_REMATCH[1]}" >> "$GITHUB_OUTPUT"
             echo "velox_short_sha=${BASH_REMATCH[2]}" >> "$GITHUB_OUTPUT"
             echo "date=${BASH_REMATCH[3]}" >> "$GITHUB_OUTPUT"
+            suffix="${BASH_REMATCH[4]}"
+            if [[ ! "${suffix}" =~ ^-[0-9]+$ ]]; then
+              suffix=""
+            fi
+            echo "image_tag_suffix=${suffix}" >> "$GITHUB_OUTPUT"
             echo "Parsed presto image: presto=${BASH_REMATCH[1]}, velox=${BASH_REMATCH[2]}, date=${BASH_REMATCH[3]}"
 
-          # Velox format: velox-{SHA}-...-{DATE}[-arch]
+          # Velox format: velox-{SHA}-...-{DATE}[-suffix]
           elif [[ "$TAG" =~ ^velox-([a-f0-9]+)-.*-([0-9]{8})(-[a-z0-9]+)?$ ]]; then
             echo "velox_short_sha=${BASH_REMATCH[1]}" >> "$GITHUB_OUTPUT"
             echo "presto_short_sha=" >> "$GITHUB_OUTPUT"
             echo "date=${BASH_REMATCH[2]}" >> "$GITHUB_OUTPUT"
+            suffix="${BASH_REMATCH[3]}"
+            if [[ ! "${suffix}" =~ ^-[0-9]+$ ]]; then
+              suffix=""
+            fi
+            echo "image_tag_suffix=${suffix}" >> "$GITHUB_OUTPUT"
             echo "Parsed velox image: velox=${BASH_REMATCH[1]}, date=${BASH_REMATCH[2]}"
 
           else
@@ -76,4 +89,5 @@ runs:
           echo "velox_short_sha=${VELOX_SHORT_SHA}" >> "$GITHUB_OUTPUT"
           echo "presto_short_sha=${PRESTO_SHORT_SHA}" >> "$GITHUB_OUTPUT"
           echo "date=${DATE}" >> "$GITHUB_OUTPUT"
+          echo "image_tag_suffix=" >> "$GITHUB_OUTPUT"
         fi

--- a/.github/actions/resolve-inputs/action.yml
+++ b/.github/actions/resolve-inputs/action.yml
@@ -34,7 +34,7 @@ outputs:
     description: 'Resolved build date'
     value: ${{ steps.resolve.outputs.date }}
   run_id_suffix:
-    description: 'Run ID suffix after the resolved build date, if present'
+    description: 'Run ID suffix, if present'
     value: ${{ steps.resolve.outputs.run_id_suffix }}
 
 runs:
@@ -53,7 +53,7 @@ runs:
           TAG="${IMAGE_TAG##*:}"
           echo "Parsing tag: ${TAG}"
 
-          # Presto format: presto-{SHA}-velox-{SHA}-...-{DATE}[-suffix]
+          # Presto format: presto-{SHA}-velox-{SHA}-...-{DATE}{RUN_ID_SUFFIX}
           if [[ "$TAG" =~ ^presto-([a-f0-9]+)-velox-([a-f0-9]+)-.*-([0-9]{8})(-[a-z0-9]+)?$ ]]; then
             echo "presto_short_sha=${BASH_REMATCH[1]}" >> "$GITHUB_OUTPUT"
             echo "velox_short_sha=${BASH_REMATCH[2]}" >> "$GITHUB_OUTPUT"
@@ -65,7 +65,7 @@ runs:
             echo "run_id_suffix=${suffix}" >> "$GITHUB_OUTPUT"
             echo "Parsed presto image: presto=${BASH_REMATCH[1]}, velox=${BASH_REMATCH[2]}, date=${BASH_REMATCH[3]}"
 
-          # Velox format: velox-{SHA}-...-{DATE}[-suffix]
+          # Velox format: velox-{SHA}-...-{DATE}{RUN_ID_SUFFIX}
           elif [[ "$TAG" =~ ^velox-([a-f0-9]+)-.*-([0-9]{8})(-[a-z0-9]+)?$ ]]; then
             echo "velox_short_sha=${BASH_REMATCH[1]}" >> "$GITHUB_OUTPUT"
             echo "presto_short_sha=" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -11,8 +11,8 @@ This directory contains GitHub Actions workflows for automated testing, benchmar
 | `velox-create-staging.yml` | Creates Velox staging branch by merging cuDF PRs | Auto-fetches PRs with `cudf` label by default |
 | `presto-create-staging.yml` | Creates Presto staging branch by merging specified PRs | Requires manual PR numbers (no auto-fetch) |
 | **CI Images** |||
-| `velox-nightly.yml` | Nightly Velox builds + tests + benchmarks (upstream, staging) | Schedule (5am UTC) + manual dispatch |
-| `presto-nightly.yml` | Nightly Presto builds + tests (upstream, pinned, staging) | Schedule (5am UTC) + manual dispatch |
+| `velox-nightly.yml` | Nightly Velox builds + tests + benchmarks (upstream) | Schedule (5am UTC) + manual dispatch |
+| `presto-nightly.yml` | Nightly Presto builds + tests (upstream, pinned) | Schedule (5am UTC) + manual dispatch |
 | `velox.yml` | Velox CI image build + test + benchmark pipeline | Called by nightly; also supports `workflow_dispatch` |
 | `presto.yml` | Presto CI image build + test pipeline | Called by nightly; also supports `workflow_dispatch` |
 | `actions/resolve-commits/` | Composite action to resolve Velox/Presto commit SHAs | Used by CI image workflows |
@@ -108,10 +108,6 @@ Multi-arch (amd64/arm64) Docker images for Velox and Presto are built and publis
   |---------|-------|--------|
   | `upstream` | `facebookincubator/velox:main` | `prestodb/presto:master` |
   | `pinned` | Presto's pinned Velox submodule | `prestodb/presto:master` |
-  | `staging` | `$STABLE_VELOX_REPO:$STABLE_VELOX_COMMIT` | `$STABLE_PRESTO_REPO:$STABLE_PRESTO_COMMIT` |
-
-  `staging` remains available through manual `workflow_dispatch` runs, but is not scheduled nightly while it resolves to the same commits as other variants.
-
 ### CI Image Pipeline
 
 The Velox pipeline (`velox.yml`):
@@ -154,7 +150,7 @@ Images are tagged with commit SHAs, CUDA version, and build date:
 - **Presto build (CPU):** `presto-${PRESTO_SHA}-velox-${VELOX_SHA}-cpu-${DATE}`
 - **Presto coordinator:** `presto-coordinator-${PRESTO_SHA}-${DATE}`
 
-Manual build runs append the GitHub run ID to final image tags, for example `velox-${VELOX_SHA}-gpu-cuda${CUDA_VERSION}-${DATE}-${GITHUB_RUN_ID}`. Manual builds do not update stable `latest` tags. Intermediate arch-specific tags include the run ID and run attempt before the architecture suffix so overlapping builds cannot delete each other's merge inputs.
+Manual build runs append the GitHub run ID to final image tags, for example `velox-${VELOX_SHA}-gpu-cuda${CUDA_VERSION}-${DATE}-${GITHUB_RUN_ID}`. Manual builds do not update stable `latest` tags. Intermediate arch-specific tags include the run ID before the architecture suffix so overlapping builds cannot delete each other's merge inputs.
 
 Images are purged after 30 days by the `ci-image-cleanup.yml` workflow.
 

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -150,7 +150,7 @@ Images are tagged with commit SHAs, CUDA version, and build date:
 - **Presto build (CPU):** `presto-${PRESTO_SHA}-velox-${VELOX_SHA}-cpu-${DATE}`
 - **Presto coordinator:** `presto-coordinator-${PRESTO_SHA}-${DATE}`
 
-Manual build runs append the GitHub run ID to final image tags, for example `velox-${VELOX_SHA}-gpu-cuda${CUDA_VERSION}-${DATE}-${GITHUB_RUN_ID}`. Manual builds do not update stable `latest` tags. Intermediate arch-specific tags include the run ID before the architecture suffix so overlapping builds cannot delete each other's merge inputs.
+Manual build runs append the GitHub run ID to final image tags, for example `velox-${VELOX_SHA}-gpu-cuda${CUDA_VERSION}-${DATE}-${GITHUB_RUN_ID}`. Manual builds do not update stable `latest` tags. Intermediate arch-specific tags include the run ID, run attempt, and sanitized/truncated variant label before the architecture suffix so overlapping builds cannot delete each other's merge inputs.
 
 Images are purged after 30 days by the `ci-image-cleanup.yml` workflow.
 

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -100,8 +100,8 @@ The additional merge happens **after** the base reset but **before** PR merging.
 
 Multi-arch (amd64/arm64) Docker images for Velox and Presto are built and published to [GitHub Container Registry](https://github.com/orgs/rapidsai/packages?repo_name=velox-testing) under the `velox-testing-images` package.
 
-- **`velox-nightly.yml`** — Nightly schedule (5am UTC). Calls `velox.yml` for upstream and staging variants.
-- **`presto-nightly.yml`** — Nightly schedule (5am UTC). Calls `presto.yml` for upstream, pinned, and staging variants.
+- **`velox-nightly.yml`** — Nightly schedule (5am UTC). Calls `velox.yml` for the upstream variant.
+- **`presto-nightly.yml`** — Nightly schedule (5am UTC). Calls `presto.yml` for upstream and pinned variants.
 - **`velox.yml`** / **`presto.yml`** — Reusable pipelines that resolve commits, build images, run tests, and (for Velox) run benchmarks. Also support `workflow_dispatch` for manual runs.
 
   | Variant | Velox | Presto |
@@ -109,6 +109,8 @@ Multi-arch (amd64/arm64) Docker images for Velox and Presto are built and publis
   | `upstream` | `facebookincubator/velox:main` | `prestodb/presto:master` |
   | `pinned` | Presto's pinned Velox submodule | `prestodb/presto:master` |
   | `staging` | `$STABLE_VELOX_REPO:$STABLE_VELOX_COMMIT` | `$STABLE_PRESTO_REPO:$STABLE_PRESTO_COMMIT` |
+
+  `staging` remains available through manual `workflow_dispatch` runs, but is not scheduled nightly while it resolves to the same commits as other variants.
 
 ### CI Image Pipeline
 
@@ -151,6 +153,8 @@ Images are tagged with commit SHAs, CUDA version, and build date:
 - **Presto build (GPU):** `presto-${PRESTO_SHA}-velox-${VELOX_SHA}-gpu-cuda${CUDA_VERSION}-${DATE}`
 - **Presto build (CPU):** `presto-${PRESTO_SHA}-velox-${VELOX_SHA}-cpu-${DATE}`
 - **Presto coordinator:** `presto-coordinator-${PRESTO_SHA}-${DATE}`
+
+Manual build runs append the GitHub run ID to final image tags, for example `velox-${VELOX_SHA}-gpu-cuda${CUDA_VERSION}-${DATE}-${GITHUB_RUN_ID}`. Manual builds do not update stable `latest` tags. Intermediate arch-specific tags include the run ID and run attempt before the architecture suffix so overlapping builds cannot delete each other's merge inputs.
 
 Images are purged after 30 days by the `ci-image-cleanup.yml` workflow.
 

--- a/.github/workflows/presto-build.yml
+++ b/.github/workflows/presto-build.yml
@@ -37,20 +37,16 @@ on:
         required: false
         default: 'manual'
       build_variant:
-        description: 'One of: [upstream, pinned, staging, manual]'
+        description: 'One of: [upstream, pinned, manual]'
         type: string
         required: false
         default: 'manual'
       github_run_id:
-        description: 'GitHub Actions run ID used to isolate temporary tags'
+        description: 'GitHub Actions run ID used to make temporary tags unique'
         type: string
         required: true
-      github_run_attempt:
-        description: 'GitHub Actions run attempt used to isolate temporary tags'
-        type: string
-        required: true
-      final_image_tag_suffix:
-        description: 'Optional suffix appended to final multi-arch image tags'
+      final_run_id_suffix:
+        description: 'Optional run ID suffix appended to final multi-arch image tags'
         type: string
         required: false
         default: ''
@@ -156,7 +152,7 @@ jobs:
           outputs: type=registry,compression=zstd,force-compression=true,compression-level=15
           push: true
           tags: |
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:presto-deps-${{ inputs.presto_short_sha }}-velox-${{ inputs.velox_short_sha }}-cuda${{ matrix.cuda_version }}-${{ inputs.date }}-${{ inputs.github_run_id }}-${{ inputs.github_run_attempt }}-${{ matrix.arch }}
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:presto-deps-${{ inputs.presto_short_sha }}-velox-${{ inputs.velox_short_sha }}-cuda${{ matrix.cuda_version }}-${{ inputs.date }}-${{ inputs.github_run_id }}-${{ matrix.arch }}
 
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@96278af6caaf10aea03fd8d33a09a777ca52d62f  # v3.2.0
@@ -200,10 +196,9 @@ jobs:
           PRESTO_SHORT_SHA: ${{ inputs.presto_short_sha }}
           BUILD_DATE: ${{ inputs.date }}
           GITHUB_RUN_ID: ${{ inputs.github_run_id }}
-          GITHUB_RUN_ATTEMPT: ${{ inputs.github_run_attempt }}
           ARCH: ${{ matrix.arch }}
         run: |
-          echo "tag=presto-coordinator-${PRESTO_SHORT_SHA}-${BUILD_DATE}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${ARCH}" >> "$GITHUB_OUTPUT"
+          echo "tag=presto-coordinator-${PRESTO_SHORT_SHA}-${BUILD_DATE}-${GITHUB_RUN_ID}-${ARCH}" >> "$GITHUB_OUTPUT"
 
       - name: Build and push Presto coordinator image
         id: push
@@ -304,11 +299,10 @@ jobs:
           VELOX_SHORT_SHA: ${{ inputs.velox_short_sha }}
           BUILD_DATE: ${{ inputs.date }}
           GITHUB_RUN_ID: ${{ inputs.github_run_id }}
-          GITHUB_RUN_ATTEMPT: ${{ inputs.github_run_attempt }}
           ARCH: ${{ matrix.arch }}
           CUDA: ${{ matrix.cuda_version || '12.9' }}
         run: |
-          echo "image=${REGISTRY}/${IMAGE_NAME}:presto-deps-${PRESTO_SHORT_SHA}-velox-${VELOX_SHORT_SHA}-cuda${CUDA}-${BUILD_DATE}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${ARCH}" >> "$GITHUB_OUTPUT"
+          echo "image=${REGISTRY}/${IMAGE_NAME}:presto-deps-${PRESTO_SHORT_SHA}-velox-${VELOX_SHORT_SHA}-cuda${CUDA}-${BUILD_DATE}-${GITHUB_RUN_ID}-${ARCH}" >> "$GITHUB_OUTPUT"
 
       - name: Determine image tag
         id: tag
@@ -317,15 +311,14 @@ jobs:
           VELOX_SHORT_SHA: ${{ inputs.velox_short_sha }}
           BUILD_DATE: ${{ inputs.date }}
           GITHUB_RUN_ID: ${{ inputs.github_run_id }}
-          GITHUB_RUN_ATTEMPT: ${{ inputs.github_run_attempt }}
           ARCH: ${{ matrix.arch }}
           BUILD_TYPE: ${{ matrix.build_type }}
           CUDA_VERSION: ${{ matrix.cuda_version }}
         run: |
           if [[ "${BUILD_TYPE}" == "cpu" ]]; then
-            echo "tag=presto-${PRESTO_SHORT_SHA}-velox-${VELOX_SHORT_SHA}-cpu-${BUILD_DATE}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${ARCH}" >> "$GITHUB_OUTPUT"
+            echo "tag=presto-${PRESTO_SHORT_SHA}-velox-${VELOX_SHORT_SHA}-cpu-${BUILD_DATE}-${GITHUB_RUN_ID}-${ARCH}" >> "$GITHUB_OUTPUT"
           else
-            echo "tag=presto-${PRESTO_SHORT_SHA}-velox-${VELOX_SHORT_SHA}-gpu-cuda${CUDA_VERSION}-${BUILD_DATE}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${ARCH}" >> "$GITHUB_OUTPUT"
+            echo "tag=presto-${PRESTO_SHORT_SHA}-velox-${VELOX_SHORT_SHA}-gpu-cuda${CUDA_VERSION}-${BUILD_DATE}-${GITHUB_RUN_ID}-${ARCH}" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Build and push Presto native worker image
@@ -384,26 +377,25 @@ jobs:
           BUILD_TYPE: ${{ inputs.build_type }}
           BUILD_VARIANT: ${{ inputs.build_variant }}
           GITHUB_RUN_ID: ${{ inputs.github_run_id }}
-          GITHUB_RUN_ATTEMPT: ${{ inputs.github_run_attempt }}
-          FINAL_IMAGE_TAG_SUFFIX: ${{ inputs.final_image_tag_suffix }}
+          FINAL_RUN_ID_SUFFIX: ${{ inputs.final_run_id_suffix }}
         run: |
           create_manifest() {
             local tag="$1"
-            local final_tag="${tag}${FINAL_IMAGE_TAG_SUFFIX}"
+            local final_tag="${tag}${FINAL_RUN_ID_SUFFIX}"
             echo "Creating multi-arch manifest: ${tag}"
             docker buildx imagetools create -t "${REGISTRY}/${IMAGE_NAME}:${final_tag}" \
-              "${REGISTRY}/${IMAGE_NAME}:${tag}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-amd64" \
-              "${REGISTRY}/${IMAGE_NAME}:${tag}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-arm64"
+              "${REGISTRY}/${IMAGE_NAME}:${tag}-${GITHUB_RUN_ID}-amd64" \
+              "${REGISTRY}/${IMAGE_NAME}:${tag}-${GITHUB_RUN_ID}-arm64"
           }
           for cuda in 12.9 13.1; do
             create_manifest "presto-deps-${PRESTO_SHORT_SHA}-velox-${VELOX_SHORT_SHA}-cuda${cuda}-${BUILD_DATE}"
           done
-          if [[ "${BUILD_TYPE}" == "nightly" && "${BUILD_VARIANT}" == "pinned" && -z "${FINAL_IMAGE_TAG_SUFFIX}" ]]; then
+          if [[ "${BUILD_TYPE}" == "nightly" && "${BUILD_VARIANT}" == "pinned" && -z "${FINAL_RUN_ID_SUFFIX}" ]]; then
             for cuda in 12.9 13.1; do
               docker buildx imagetools create \
                 -t "${REGISTRY}/${IMAGE_NAME}:presto-deps-latest-cuda${cuda}" \
-                "${REGISTRY}/${IMAGE_NAME}:presto-deps-${PRESTO_SHORT_SHA}-velox-${VELOX_SHORT_SHA}-cuda${cuda}-${BUILD_DATE}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-amd64" \
-                "${REGISTRY}/${IMAGE_NAME}:presto-deps-${PRESTO_SHORT_SHA}-velox-${VELOX_SHORT_SHA}-cuda${cuda}-${BUILD_DATE}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-arm64"
+                "${REGISTRY}/${IMAGE_NAME}:presto-deps-${PRESTO_SHORT_SHA}-velox-${VELOX_SHORT_SHA}-cuda${cuda}-${BUILD_DATE}-${GITHUB_RUN_ID}-amd64" \
+                "${REGISTRY}/${IMAGE_NAME}:presto-deps-${PRESTO_SHORT_SHA}-velox-${VELOX_SHORT_SHA}-cuda${cuda}-${BUILD_DATE}-${GITHUB_RUN_ID}-arm64"
             done
           fi
   merge-presto-build:
@@ -432,32 +424,31 @@ jobs:
           BUILD_TYPE: ${{ inputs.build_type }}
           BUILD_VARIANT: ${{ inputs.build_variant }}
           GITHUB_RUN_ID: ${{ inputs.github_run_id }}
-          GITHUB_RUN_ATTEMPT: ${{ inputs.github_run_attempt }}
-          FINAL_IMAGE_TAG_SUFFIX: ${{ inputs.final_image_tag_suffix }}
+          FINAL_RUN_ID_SUFFIX: ${{ inputs.final_run_id_suffix }}
         run: |
           create_manifest() {
             local tag="$1"
-            local final_tag="${tag}${FINAL_IMAGE_TAG_SUFFIX}"
+            local final_tag="${tag}${FINAL_RUN_ID_SUFFIX}"
             echo "Creating multi-arch manifest: ${tag}"
             docker buildx imagetools create -t "${REGISTRY}/${IMAGE_NAME}:${final_tag}" \
-              "${REGISTRY}/${IMAGE_NAME}:${tag}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-amd64" \
-              "${REGISTRY}/${IMAGE_NAME}:${tag}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-arm64"
+              "${REGISTRY}/${IMAGE_NAME}:${tag}-${GITHUB_RUN_ID}-amd64" \
+              "${REGISTRY}/${IMAGE_NAME}:${tag}-${GITHUB_RUN_ID}-arm64"
           }
           for cuda in 12.9 13.1; do
             create_manifest "presto-${PRESTO_SHORT_SHA}-velox-${VELOX_SHORT_SHA}-gpu-cuda${cuda}-${BUILD_DATE}"
           done
           create_manifest "presto-${PRESTO_SHORT_SHA}-velox-${VELOX_SHORT_SHA}-cpu-${BUILD_DATE}"
-          if [[ "${BUILD_TYPE}" == "nightly" && "${BUILD_VARIANT}" == "pinned" && -z "${FINAL_IMAGE_TAG_SUFFIX}" ]]; then
+          if [[ "${BUILD_TYPE}" == "nightly" && "${BUILD_VARIANT}" == "pinned" && -z "${FINAL_RUN_ID_SUFFIX}" ]]; then
             for cuda in 12.9 13.1; do
               docker buildx imagetools create \
                 -t "${REGISTRY}/${IMAGE_NAME}:presto-latest-gpu-cuda${cuda}" \
-                "${REGISTRY}/${IMAGE_NAME}:presto-${PRESTO_SHORT_SHA}-velox-${VELOX_SHORT_SHA}-gpu-cuda${cuda}-${BUILD_DATE}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-amd64" \
-                "${REGISTRY}/${IMAGE_NAME}:presto-${PRESTO_SHORT_SHA}-velox-${VELOX_SHORT_SHA}-gpu-cuda${cuda}-${BUILD_DATE}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-arm64"
+                "${REGISTRY}/${IMAGE_NAME}:presto-${PRESTO_SHORT_SHA}-velox-${VELOX_SHORT_SHA}-gpu-cuda${cuda}-${BUILD_DATE}-${GITHUB_RUN_ID}-amd64" \
+                "${REGISTRY}/${IMAGE_NAME}:presto-${PRESTO_SHORT_SHA}-velox-${VELOX_SHORT_SHA}-gpu-cuda${cuda}-${BUILD_DATE}-${GITHUB_RUN_ID}-arm64"
             done
             docker buildx imagetools create \
               -t "${REGISTRY}/${IMAGE_NAME}:presto-latest-cpu" \
-              "${REGISTRY}/${IMAGE_NAME}:presto-${PRESTO_SHORT_SHA}-velox-${VELOX_SHORT_SHA}-cpu-${BUILD_DATE}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-amd64" \
-              "${REGISTRY}/${IMAGE_NAME}:presto-${PRESTO_SHORT_SHA}-velox-${VELOX_SHORT_SHA}-cpu-${BUILD_DATE}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-arm64"
+              "${REGISTRY}/${IMAGE_NAME}:presto-${PRESTO_SHORT_SHA}-velox-${VELOX_SHORT_SHA}-cpu-${BUILD_DATE}-${GITHUB_RUN_ID}-amd64" \
+              "${REGISTRY}/${IMAGE_NAME}:presto-${PRESTO_SHORT_SHA}-velox-${VELOX_SHORT_SHA}-cpu-${BUILD_DATE}-${GITHUB_RUN_ID}-arm64"
           fi
       - name: Delete intermediate arch-specific tags
         continue-on-error: true
@@ -466,11 +457,11 @@ jobs:
           registry: ${{ env.REGISTRY }}
           image-name: ${{ env.IMAGE_NAME }}
           base-tags: |
-            presto-${{ inputs.presto_short_sha }}-velox-${{ inputs.velox_short_sha }}-gpu-cuda12.9-${{ inputs.date }}-${{ inputs.github_run_id }}-${{ inputs.github_run_attempt }}
-            presto-${{ inputs.presto_short_sha }}-velox-${{ inputs.velox_short_sha }}-gpu-cuda13.1-${{ inputs.date }}-${{ inputs.github_run_id }}-${{ inputs.github_run_attempt }}
-            presto-${{ inputs.presto_short_sha }}-velox-${{ inputs.velox_short_sha }}-cpu-${{ inputs.date }}-${{ inputs.github_run_id }}-${{ inputs.github_run_attempt }}
-            presto-deps-${{ inputs.presto_short_sha }}-velox-${{ inputs.velox_short_sha }}-cuda12.9-${{ inputs.date }}-${{ inputs.github_run_id }}-${{ inputs.github_run_attempt }}
-            presto-deps-${{ inputs.presto_short_sha }}-velox-${{ inputs.velox_short_sha }}-cuda13.1-${{ inputs.date }}-${{ inputs.github_run_id }}-${{ inputs.github_run_attempt }}
+            presto-${{ inputs.presto_short_sha }}-velox-${{ inputs.velox_short_sha }}-gpu-cuda12.9-${{ inputs.date }}-${{ inputs.github_run_id }}
+            presto-${{ inputs.presto_short_sha }}-velox-${{ inputs.velox_short_sha }}-gpu-cuda13.1-${{ inputs.date }}-${{ inputs.github_run_id }}
+            presto-${{ inputs.presto_short_sha }}-velox-${{ inputs.velox_short_sha }}-cpu-${{ inputs.date }}-${{ inputs.github_run_id }}
+            presto-deps-${{ inputs.presto_short_sha }}-velox-${{ inputs.velox_short_sha }}-cuda12.9-${{ inputs.date }}-${{ inputs.github_run_id }}
+            presto-deps-${{ inputs.presto_short_sha }}-velox-${{ inputs.velox_short_sha }}-cuda13.1-${{ inputs.date }}-${{ inputs.github_run_id }}
 
   merge-presto-coordinator:
     name: merge-manifests (presto-coordinator)
@@ -497,20 +488,19 @@ jobs:
           BUILD_TYPE: ${{ inputs.build_type }}
           BUILD_VARIANT: ${{ inputs.build_variant }}
           GITHUB_RUN_ID: ${{ inputs.github_run_id }}
-          GITHUB_RUN_ATTEMPT: ${{ inputs.github_run_attempt }}
-          FINAL_IMAGE_TAG_SUFFIX: ${{ inputs.final_image_tag_suffix }}
+          FINAL_RUN_ID_SUFFIX: ${{ inputs.final_run_id_suffix }}
         run: |
           TAG="presto-coordinator-${PRESTO_SHORT_SHA}-${BUILD_DATE}"
-          FINAL_TAG="${TAG}${FINAL_IMAGE_TAG_SUFFIX}"
+          FINAL_TAG="${TAG}${FINAL_RUN_ID_SUFFIX}"
           echo "Creating multi-arch manifest: ${TAG}"
           docker buildx imagetools create -t "${REGISTRY}/${IMAGE_NAME}:${FINAL_TAG}" \
-            "${REGISTRY}/${IMAGE_NAME}:${TAG}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-amd64" \
-            "${REGISTRY}/${IMAGE_NAME}:${TAG}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-arm64"
-          if [[ "${BUILD_TYPE}" == "nightly" && "${BUILD_VARIANT}" == "pinned" && -z "${FINAL_IMAGE_TAG_SUFFIX}" ]]; then
+            "${REGISTRY}/${IMAGE_NAME}:${TAG}-${GITHUB_RUN_ID}-amd64" \
+            "${REGISTRY}/${IMAGE_NAME}:${TAG}-${GITHUB_RUN_ID}-arm64"
+          if [[ "${BUILD_TYPE}" == "nightly" && "${BUILD_VARIANT}" == "pinned" && -z "${FINAL_RUN_ID_SUFFIX}" ]]; then
             docker buildx imagetools create \
               -t "${REGISTRY}/${IMAGE_NAME}:presto-coordinator-latest" \
-              "${REGISTRY}/${IMAGE_NAME}:${TAG}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-amd64" \
-              "${REGISTRY}/${IMAGE_NAME}:${TAG}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-arm64"
+              "${REGISTRY}/${IMAGE_NAME}:${TAG}-${GITHUB_RUN_ID}-amd64" \
+              "${REGISTRY}/${IMAGE_NAME}:${TAG}-${GITHUB_RUN_ID}-arm64"
           fi
       - name: Delete intermediate arch-specific tags
         continue-on-error: true
@@ -518,4 +508,4 @@ jobs:
         with:
           registry: ${{ env.REGISTRY }}
           image-name: ${{ env.IMAGE_NAME }}
-          base-tags: presto-coordinator-${{ inputs.presto_short_sha }}-${{ inputs.date }}-${{ inputs.github_run_id }}-${{ inputs.github_run_attempt }}
+          base-tags: presto-coordinator-${{ inputs.presto_short_sha }}-${{ inputs.date }}-${{ inputs.github_run_id }}

--- a/.github/workflows/presto-build.yml
+++ b/.github/workflows/presto-build.yml
@@ -41,6 +41,19 @@ on:
         type: string
         required: false
         default: 'manual'
+      github_run_id:
+        description: 'GitHub Actions run ID used to isolate temporary tags'
+        type: string
+        required: true
+      github_run_attempt:
+        description: 'GitHub Actions run attempt used to isolate temporary tags'
+        type: string
+        required: true
+      final_image_tag_suffix:
+        description: 'Optional suffix appended to final multi-arch image tags'
+        type: string
+        required: false
+        default: ''
 
 env:
   REGISTRY: ghcr.io
@@ -143,7 +156,7 @@ jobs:
           outputs: type=registry,compression=zstd,force-compression=true,compression-level=15
           push: true
           tags: |
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:presto-deps-${{ inputs.presto_short_sha }}-velox-${{ inputs.velox_short_sha }}-cuda${{ matrix.cuda_version }}-${{ inputs.date }}-${{ matrix.arch }}
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:presto-deps-${{ inputs.presto_short_sha }}-velox-${{ inputs.velox_short_sha }}-cuda${{ matrix.cuda_version }}-${{ inputs.date }}-${{ inputs.github_run_id }}-${{ inputs.github_run_attempt }}-${{ matrix.arch }}
 
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@96278af6caaf10aea03fd8d33a09a777ca52d62f  # v3.2.0
@@ -186,9 +199,11 @@ jobs:
         env:
           PRESTO_SHORT_SHA: ${{ inputs.presto_short_sha }}
           BUILD_DATE: ${{ inputs.date }}
+          GITHUB_RUN_ID: ${{ inputs.github_run_id }}
+          GITHUB_RUN_ATTEMPT: ${{ inputs.github_run_attempt }}
           ARCH: ${{ matrix.arch }}
         run: |
-          echo "tag=presto-coordinator-${PRESTO_SHORT_SHA}-${BUILD_DATE}-${ARCH}" >> "$GITHUB_OUTPUT"
+          echo "tag=presto-coordinator-${PRESTO_SHORT_SHA}-${BUILD_DATE}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${ARCH}" >> "$GITHUB_OUTPUT"
 
       - name: Build and push Presto coordinator image
         id: push
@@ -288,10 +303,12 @@ jobs:
           PRESTO_SHORT_SHA: ${{ inputs.presto_short_sha }}
           VELOX_SHORT_SHA: ${{ inputs.velox_short_sha }}
           BUILD_DATE: ${{ inputs.date }}
+          GITHUB_RUN_ID: ${{ inputs.github_run_id }}
+          GITHUB_RUN_ATTEMPT: ${{ inputs.github_run_attempt }}
           ARCH: ${{ matrix.arch }}
           CUDA: ${{ matrix.cuda_version || '12.9' }}
         run: |
-          echo "image=${REGISTRY}/${IMAGE_NAME}:presto-deps-${PRESTO_SHORT_SHA}-velox-${VELOX_SHORT_SHA}-cuda${CUDA}-${BUILD_DATE}-${ARCH}" >> "$GITHUB_OUTPUT"
+          echo "image=${REGISTRY}/${IMAGE_NAME}:presto-deps-${PRESTO_SHORT_SHA}-velox-${VELOX_SHORT_SHA}-cuda${CUDA}-${BUILD_DATE}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${ARCH}" >> "$GITHUB_OUTPUT"
 
       - name: Determine image tag
         id: tag
@@ -299,14 +316,16 @@ jobs:
           PRESTO_SHORT_SHA: ${{ inputs.presto_short_sha }}
           VELOX_SHORT_SHA: ${{ inputs.velox_short_sha }}
           BUILD_DATE: ${{ inputs.date }}
+          GITHUB_RUN_ID: ${{ inputs.github_run_id }}
+          GITHUB_RUN_ATTEMPT: ${{ inputs.github_run_attempt }}
           ARCH: ${{ matrix.arch }}
           BUILD_TYPE: ${{ matrix.build_type }}
           CUDA_VERSION: ${{ matrix.cuda_version }}
         run: |
           if [[ "${BUILD_TYPE}" == "cpu" ]]; then
-            echo "tag=presto-${PRESTO_SHORT_SHA}-velox-${VELOX_SHORT_SHA}-cpu-${BUILD_DATE}-${ARCH}" >> "$GITHUB_OUTPUT"
+            echo "tag=presto-${PRESTO_SHORT_SHA}-velox-${VELOX_SHORT_SHA}-cpu-${BUILD_DATE}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${ARCH}" >> "$GITHUB_OUTPUT"
           else
-            echo "tag=presto-${PRESTO_SHORT_SHA}-velox-${VELOX_SHORT_SHA}-gpu-cuda${CUDA_VERSION}-${BUILD_DATE}-${ARCH}" >> "$GITHUB_OUTPUT"
+            echo "tag=presto-${PRESTO_SHORT_SHA}-velox-${VELOX_SHORT_SHA}-gpu-cuda${CUDA_VERSION}-${BUILD_DATE}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${ARCH}" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Build and push Presto native worker image
@@ -364,23 +383,27 @@ jobs:
           BUILD_DATE: ${{ inputs.date }}
           BUILD_TYPE: ${{ inputs.build_type }}
           BUILD_VARIANT: ${{ inputs.build_variant }}
+          GITHUB_RUN_ID: ${{ inputs.github_run_id }}
+          GITHUB_RUN_ATTEMPT: ${{ inputs.github_run_attempt }}
+          FINAL_IMAGE_TAG_SUFFIX: ${{ inputs.final_image_tag_suffix }}
         run: |
           create_manifest() {
             local tag="$1"
+            local final_tag="${tag}${FINAL_IMAGE_TAG_SUFFIX}"
             echo "Creating multi-arch manifest: ${tag}"
-            docker buildx imagetools create -t "${REGISTRY}/${IMAGE_NAME}:${tag}" \
-              "${REGISTRY}/${IMAGE_NAME}:${tag}-amd64" \
-              "${REGISTRY}/${IMAGE_NAME}:${tag}-arm64"
+            docker buildx imagetools create -t "${REGISTRY}/${IMAGE_NAME}:${final_tag}" \
+              "${REGISTRY}/${IMAGE_NAME}:${tag}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-amd64" \
+              "${REGISTRY}/${IMAGE_NAME}:${tag}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-arm64"
           }
           for cuda in 12.9 13.1; do
             create_manifest "presto-deps-${PRESTO_SHORT_SHA}-velox-${VELOX_SHORT_SHA}-cuda${cuda}-${BUILD_DATE}"
           done
-          if [[ "${BUILD_TYPE}" == "nightly" && "${BUILD_VARIANT}" == "pinned" ]]; then
+          if [[ "${BUILD_TYPE}" == "nightly" && "${BUILD_VARIANT}" == "pinned" && -z "${FINAL_IMAGE_TAG_SUFFIX}" ]]; then
             for cuda in 12.9 13.1; do
               docker buildx imagetools create \
                 -t "${REGISTRY}/${IMAGE_NAME}:presto-deps-latest-cuda${cuda}" \
-                "${REGISTRY}/${IMAGE_NAME}:presto-deps-${PRESTO_SHORT_SHA}-velox-${VELOX_SHORT_SHA}-cuda${cuda}-${BUILD_DATE}-amd64" \
-                "${REGISTRY}/${IMAGE_NAME}:presto-deps-${PRESTO_SHORT_SHA}-velox-${VELOX_SHORT_SHA}-cuda${cuda}-${BUILD_DATE}-arm64"
+                "${REGISTRY}/${IMAGE_NAME}:presto-deps-${PRESTO_SHORT_SHA}-velox-${VELOX_SHORT_SHA}-cuda${cuda}-${BUILD_DATE}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-amd64" \
+                "${REGISTRY}/${IMAGE_NAME}:presto-deps-${PRESTO_SHORT_SHA}-velox-${VELOX_SHORT_SHA}-cuda${cuda}-${BUILD_DATE}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-arm64"
             done
           fi
   merge-presto-build:
@@ -408,29 +431,33 @@ jobs:
           BUILD_DATE: ${{ inputs.date }}
           BUILD_TYPE: ${{ inputs.build_type }}
           BUILD_VARIANT: ${{ inputs.build_variant }}
+          GITHUB_RUN_ID: ${{ inputs.github_run_id }}
+          GITHUB_RUN_ATTEMPT: ${{ inputs.github_run_attempt }}
+          FINAL_IMAGE_TAG_SUFFIX: ${{ inputs.final_image_tag_suffix }}
         run: |
           create_manifest() {
             local tag="$1"
+            local final_tag="${tag}${FINAL_IMAGE_TAG_SUFFIX}"
             echo "Creating multi-arch manifest: ${tag}"
-            docker buildx imagetools create -t "${REGISTRY}/${IMAGE_NAME}:${tag}" \
-              "${REGISTRY}/${IMAGE_NAME}:${tag}-amd64" \
-              "${REGISTRY}/${IMAGE_NAME}:${tag}-arm64"
+            docker buildx imagetools create -t "${REGISTRY}/${IMAGE_NAME}:${final_tag}" \
+              "${REGISTRY}/${IMAGE_NAME}:${tag}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-amd64" \
+              "${REGISTRY}/${IMAGE_NAME}:${tag}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-arm64"
           }
           for cuda in 12.9 13.1; do
             create_manifest "presto-${PRESTO_SHORT_SHA}-velox-${VELOX_SHORT_SHA}-gpu-cuda${cuda}-${BUILD_DATE}"
           done
           create_manifest "presto-${PRESTO_SHORT_SHA}-velox-${VELOX_SHORT_SHA}-cpu-${BUILD_DATE}"
-          if [[ "${BUILD_TYPE}" == "nightly" && "${BUILD_VARIANT}" == "pinned" ]]; then
+          if [[ "${BUILD_TYPE}" == "nightly" && "${BUILD_VARIANT}" == "pinned" && -z "${FINAL_IMAGE_TAG_SUFFIX}" ]]; then
             for cuda in 12.9 13.1; do
               docker buildx imagetools create \
                 -t "${REGISTRY}/${IMAGE_NAME}:presto-latest-gpu-cuda${cuda}" \
-                "${REGISTRY}/${IMAGE_NAME}:presto-${PRESTO_SHORT_SHA}-velox-${VELOX_SHORT_SHA}-gpu-cuda${cuda}-${BUILD_DATE}-amd64" \
-                "${REGISTRY}/${IMAGE_NAME}:presto-${PRESTO_SHORT_SHA}-velox-${VELOX_SHORT_SHA}-gpu-cuda${cuda}-${BUILD_DATE}-arm64"
+                "${REGISTRY}/${IMAGE_NAME}:presto-${PRESTO_SHORT_SHA}-velox-${VELOX_SHORT_SHA}-gpu-cuda${cuda}-${BUILD_DATE}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-amd64" \
+                "${REGISTRY}/${IMAGE_NAME}:presto-${PRESTO_SHORT_SHA}-velox-${VELOX_SHORT_SHA}-gpu-cuda${cuda}-${BUILD_DATE}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-arm64"
             done
             docker buildx imagetools create \
               -t "${REGISTRY}/${IMAGE_NAME}:presto-latest-cpu" \
-              "${REGISTRY}/${IMAGE_NAME}:presto-${PRESTO_SHORT_SHA}-velox-${VELOX_SHORT_SHA}-cpu-${BUILD_DATE}-amd64" \
-              "${REGISTRY}/${IMAGE_NAME}:presto-${PRESTO_SHORT_SHA}-velox-${VELOX_SHORT_SHA}-cpu-${BUILD_DATE}-arm64"
+              "${REGISTRY}/${IMAGE_NAME}:presto-${PRESTO_SHORT_SHA}-velox-${VELOX_SHORT_SHA}-cpu-${BUILD_DATE}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-amd64" \
+              "${REGISTRY}/${IMAGE_NAME}:presto-${PRESTO_SHORT_SHA}-velox-${VELOX_SHORT_SHA}-cpu-${BUILD_DATE}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-arm64"
           fi
       - name: Delete intermediate arch-specific tags
         continue-on-error: true
@@ -439,11 +466,11 @@ jobs:
           registry: ${{ env.REGISTRY }}
           image-name: ${{ env.IMAGE_NAME }}
           base-tags: |
-            presto-${{ inputs.presto_short_sha }}-velox-${{ inputs.velox_short_sha }}-gpu-cuda12.9-${{ inputs.date }}
-            presto-${{ inputs.presto_short_sha }}-velox-${{ inputs.velox_short_sha }}-gpu-cuda13.1-${{ inputs.date }}
-            presto-${{ inputs.presto_short_sha }}-velox-${{ inputs.velox_short_sha }}-cpu-${{ inputs.date }}
-            presto-deps-${{ inputs.presto_short_sha }}-velox-${{ inputs.velox_short_sha }}-cuda12.9-${{ inputs.date }}
-            presto-deps-${{ inputs.presto_short_sha }}-velox-${{ inputs.velox_short_sha }}-cuda13.1-${{ inputs.date }}
+            presto-${{ inputs.presto_short_sha }}-velox-${{ inputs.velox_short_sha }}-gpu-cuda12.9-${{ inputs.date }}-${{ inputs.github_run_id }}-${{ inputs.github_run_attempt }}
+            presto-${{ inputs.presto_short_sha }}-velox-${{ inputs.velox_short_sha }}-gpu-cuda13.1-${{ inputs.date }}-${{ inputs.github_run_id }}-${{ inputs.github_run_attempt }}
+            presto-${{ inputs.presto_short_sha }}-velox-${{ inputs.velox_short_sha }}-cpu-${{ inputs.date }}-${{ inputs.github_run_id }}-${{ inputs.github_run_attempt }}
+            presto-deps-${{ inputs.presto_short_sha }}-velox-${{ inputs.velox_short_sha }}-cuda12.9-${{ inputs.date }}-${{ inputs.github_run_id }}-${{ inputs.github_run_attempt }}
+            presto-deps-${{ inputs.presto_short_sha }}-velox-${{ inputs.velox_short_sha }}-cuda13.1-${{ inputs.date }}-${{ inputs.github_run_id }}-${{ inputs.github_run_attempt }}
 
   merge-presto-coordinator:
     name: merge-manifests (presto-coordinator)
@@ -469,17 +496,21 @@ jobs:
           BUILD_DATE: ${{ inputs.date }}
           BUILD_TYPE: ${{ inputs.build_type }}
           BUILD_VARIANT: ${{ inputs.build_variant }}
+          GITHUB_RUN_ID: ${{ inputs.github_run_id }}
+          GITHUB_RUN_ATTEMPT: ${{ inputs.github_run_attempt }}
+          FINAL_IMAGE_TAG_SUFFIX: ${{ inputs.final_image_tag_suffix }}
         run: |
           TAG="presto-coordinator-${PRESTO_SHORT_SHA}-${BUILD_DATE}"
+          FINAL_TAG="${TAG}${FINAL_IMAGE_TAG_SUFFIX}"
           echo "Creating multi-arch manifest: ${TAG}"
-          docker buildx imagetools create -t "${REGISTRY}/${IMAGE_NAME}:${TAG}" \
-            "${REGISTRY}/${IMAGE_NAME}:${TAG}-amd64" \
-            "${REGISTRY}/${IMAGE_NAME}:${TAG}-arm64"
-          if [[ "${BUILD_TYPE}" == "nightly" && "${BUILD_VARIANT}" == "pinned" ]]; then
+          docker buildx imagetools create -t "${REGISTRY}/${IMAGE_NAME}:${FINAL_TAG}" \
+            "${REGISTRY}/${IMAGE_NAME}:${TAG}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-amd64" \
+            "${REGISTRY}/${IMAGE_NAME}:${TAG}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-arm64"
+          if [[ "${BUILD_TYPE}" == "nightly" && "${BUILD_VARIANT}" == "pinned" && -z "${FINAL_IMAGE_TAG_SUFFIX}" ]]; then
             docker buildx imagetools create \
               -t "${REGISTRY}/${IMAGE_NAME}:presto-coordinator-latest" \
-              "${REGISTRY}/${IMAGE_NAME}:${TAG}-amd64" \
-              "${REGISTRY}/${IMAGE_NAME}:${TAG}-arm64"
+              "${REGISTRY}/${IMAGE_NAME}:${TAG}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-amd64" \
+              "${REGISTRY}/${IMAGE_NAME}:${TAG}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-arm64"
           fi
       - name: Delete intermediate arch-specific tags
         continue-on-error: true
@@ -487,4 +518,4 @@ jobs:
         with:
           registry: ${{ env.REGISTRY }}
           image-name: ${{ env.IMAGE_NAME }}
-          base-tags: presto-coordinator-${{ inputs.presto_short_sha }}-${{ inputs.date }}
+          base-tags: presto-coordinator-${{ inputs.presto_short_sha }}-${{ inputs.date }}-${{ inputs.github_run_id }}-${{ inputs.github_run_attempt }}

--- a/.github/workflows/presto-build.yml
+++ b/.github/workflows/presto-build.yml
@@ -41,15 +41,15 @@ on:
         type: string
         required: false
         default: 'manual'
-      github_run_id:
-        description: 'Caller workflow run ID used to make temporary tags unique'
-        type: string
-        required: true
       run_id_suffix:
         description: 'Optional run ID suffix appended to image tags'
         type: string
         required: false
         default: ''
+      intermediate_tag_suffix:
+        description: 'Run-scoped suffix appended to intermediate arch-specific tags'
+        type: string
+        required: true
 
 env:
   REGISTRY: ghcr.io
@@ -152,7 +152,7 @@ jobs:
           outputs: type=registry,compression=zstd,force-compression=true,compression-level=15
           push: true
           tags: |
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:presto-deps-${{ inputs.presto_short_sha }}-velox-${{ inputs.velox_short_sha }}-cuda${{ matrix.cuda_version }}-${{ inputs.date }}-${{ inputs.github_run_id }}-${{ matrix.arch }}
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:presto-deps-${{ inputs.presto_short_sha }}-velox-${{ inputs.velox_short_sha }}-cuda${{ matrix.cuda_version }}-${{ inputs.date }}${{ inputs.intermediate_tag_suffix }}-${{ matrix.arch }}
 
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@96278af6caaf10aea03fd8d33a09a777ca52d62f  # v3.2.0
@@ -195,10 +195,10 @@ jobs:
         env:
           PRESTO_SHORT_SHA: ${{ inputs.presto_short_sha }}
           BUILD_DATE: ${{ inputs.date }}
-          GITHUB_RUN_ID: ${{ inputs.github_run_id }}
+          INTERMEDIATE_TAG_SUFFIX: ${{ inputs.intermediate_tag_suffix }}
           ARCH: ${{ matrix.arch }}
         run: |
-          echo "tag=presto-coordinator-${PRESTO_SHORT_SHA}-${BUILD_DATE}-${GITHUB_RUN_ID}-${ARCH}" >> "$GITHUB_OUTPUT"
+          echo "tag=presto-coordinator-${PRESTO_SHORT_SHA}-${BUILD_DATE}${INTERMEDIATE_TAG_SUFFIX}-${ARCH}" >> "$GITHUB_OUTPUT"
 
       - name: Build and push Presto coordinator image
         id: push
@@ -298,11 +298,11 @@ jobs:
           PRESTO_SHORT_SHA: ${{ inputs.presto_short_sha }}
           VELOX_SHORT_SHA: ${{ inputs.velox_short_sha }}
           BUILD_DATE: ${{ inputs.date }}
-          GITHUB_RUN_ID: ${{ inputs.github_run_id }}
+          INTERMEDIATE_TAG_SUFFIX: ${{ inputs.intermediate_tag_suffix }}
           ARCH: ${{ matrix.arch }}
           CUDA: ${{ matrix.cuda_version || '12.9' }}
         run: |
-          echo "image=${REGISTRY}/${IMAGE_NAME}:presto-deps-${PRESTO_SHORT_SHA}-velox-${VELOX_SHORT_SHA}-cuda${CUDA}-${BUILD_DATE}-${GITHUB_RUN_ID}-${ARCH}" >> "$GITHUB_OUTPUT"
+          echo "image=${REGISTRY}/${IMAGE_NAME}:presto-deps-${PRESTO_SHORT_SHA}-velox-${VELOX_SHORT_SHA}-cuda${CUDA}-${BUILD_DATE}${INTERMEDIATE_TAG_SUFFIX}-${ARCH}" >> "$GITHUB_OUTPUT"
 
       - name: Determine image tag
         id: tag
@@ -310,15 +310,15 @@ jobs:
           PRESTO_SHORT_SHA: ${{ inputs.presto_short_sha }}
           VELOX_SHORT_SHA: ${{ inputs.velox_short_sha }}
           BUILD_DATE: ${{ inputs.date }}
-          GITHUB_RUN_ID: ${{ inputs.github_run_id }}
+          INTERMEDIATE_TAG_SUFFIX: ${{ inputs.intermediate_tag_suffix }}
           ARCH: ${{ matrix.arch }}
           BUILD_TYPE: ${{ matrix.build_type }}
           CUDA_VERSION: ${{ matrix.cuda_version }}
         run: |
           if [[ "${BUILD_TYPE}" == "cpu" ]]; then
-            echo "tag=presto-${PRESTO_SHORT_SHA}-velox-${VELOX_SHORT_SHA}-cpu-${BUILD_DATE}-${GITHUB_RUN_ID}-${ARCH}" >> "$GITHUB_OUTPUT"
+            echo "tag=presto-${PRESTO_SHORT_SHA}-velox-${VELOX_SHORT_SHA}-cpu-${BUILD_DATE}${INTERMEDIATE_TAG_SUFFIX}-${ARCH}" >> "$GITHUB_OUTPUT"
           else
-            echo "tag=presto-${PRESTO_SHORT_SHA}-velox-${VELOX_SHORT_SHA}-gpu-cuda${CUDA_VERSION}-${BUILD_DATE}-${GITHUB_RUN_ID}-${ARCH}" >> "$GITHUB_OUTPUT"
+            echo "tag=presto-${PRESTO_SHORT_SHA}-velox-${VELOX_SHORT_SHA}-gpu-cuda${CUDA_VERSION}-${BUILD_DATE}${INTERMEDIATE_TAG_SUFFIX}-${ARCH}" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Build and push Presto native worker image
@@ -376,16 +376,16 @@ jobs:
           BUILD_DATE: ${{ inputs.date }}
           BUILD_TYPE: ${{ inputs.build_type }}
           BUILD_VARIANT: ${{ inputs.build_variant }}
-          GITHUB_RUN_ID: ${{ inputs.github_run_id }}
           RUN_ID_SUFFIX: ${{ inputs.run_id_suffix }}
+          INTERMEDIATE_TAG_SUFFIX: ${{ inputs.intermediate_tag_suffix }}
         run: |
           create_manifest() {
             local tag="$1"
             local final_tag="$2"
             echo "Creating multi-arch manifest: ${tag}"
             docker buildx imagetools create -t "${REGISTRY}/${IMAGE_NAME}:${final_tag}" \
-              "${REGISTRY}/${IMAGE_NAME}:${tag}-${GITHUB_RUN_ID}-amd64" \
-              "${REGISTRY}/${IMAGE_NAME}:${tag}-${GITHUB_RUN_ID}-arm64"
+              "${REGISTRY}/${IMAGE_NAME}:${tag}${INTERMEDIATE_TAG_SUFFIX}-amd64" \
+              "${REGISTRY}/${IMAGE_NAME}:${tag}${INTERMEDIATE_TAG_SUFFIX}-arm64"
           }
           for cuda in 12.9 13.1; do
             tag="presto-deps-${PRESTO_SHORT_SHA}-velox-${VELOX_SHORT_SHA}-cuda${cuda}-${BUILD_DATE}"
@@ -395,8 +395,8 @@ jobs:
             for cuda in 12.9 13.1; do
               docker buildx imagetools create \
                 -t "${REGISTRY}/${IMAGE_NAME}:presto-deps-latest-cuda${cuda}" \
-                "${REGISTRY}/${IMAGE_NAME}:presto-deps-${PRESTO_SHORT_SHA}-velox-${VELOX_SHORT_SHA}-cuda${cuda}-${BUILD_DATE}-${GITHUB_RUN_ID}-amd64" \
-                "${REGISTRY}/${IMAGE_NAME}:presto-deps-${PRESTO_SHORT_SHA}-velox-${VELOX_SHORT_SHA}-cuda${cuda}-${BUILD_DATE}-${GITHUB_RUN_ID}-arm64"
+                "${REGISTRY}/${IMAGE_NAME}:presto-deps-${PRESTO_SHORT_SHA}-velox-${VELOX_SHORT_SHA}-cuda${cuda}-${BUILD_DATE}${INTERMEDIATE_TAG_SUFFIX}-amd64" \
+                "${REGISTRY}/${IMAGE_NAME}:presto-deps-${PRESTO_SHORT_SHA}-velox-${VELOX_SHORT_SHA}-cuda${cuda}-${BUILD_DATE}${INTERMEDIATE_TAG_SUFFIX}-arm64"
             done
           fi
   merge-presto-build:
@@ -424,16 +424,16 @@ jobs:
           BUILD_DATE: ${{ inputs.date }}
           BUILD_TYPE: ${{ inputs.build_type }}
           BUILD_VARIANT: ${{ inputs.build_variant }}
-          GITHUB_RUN_ID: ${{ inputs.github_run_id }}
           RUN_ID_SUFFIX: ${{ inputs.run_id_suffix }}
+          INTERMEDIATE_TAG_SUFFIX: ${{ inputs.intermediate_tag_suffix }}
         run: |
           create_manifest() {
             local tag="$1"
             local final_tag="$2"
             echo "Creating multi-arch manifest: ${tag}"
             docker buildx imagetools create -t "${REGISTRY}/${IMAGE_NAME}:${final_tag}" \
-              "${REGISTRY}/${IMAGE_NAME}:${tag}-${GITHUB_RUN_ID}-amd64" \
-              "${REGISTRY}/${IMAGE_NAME}:${tag}-${GITHUB_RUN_ID}-arm64"
+              "${REGISTRY}/${IMAGE_NAME}:${tag}${INTERMEDIATE_TAG_SUFFIX}-amd64" \
+              "${REGISTRY}/${IMAGE_NAME}:${tag}${INTERMEDIATE_TAG_SUFFIX}-arm64"
           }
           for cuda in 12.9 13.1; do
             tag="presto-${PRESTO_SHORT_SHA}-velox-${VELOX_SHORT_SHA}-gpu-cuda${cuda}-${BUILD_DATE}"
@@ -445,13 +445,13 @@ jobs:
             for cuda in 12.9 13.1; do
               docker buildx imagetools create \
                 -t "${REGISTRY}/${IMAGE_NAME}:presto-latest-gpu-cuda${cuda}" \
-                "${REGISTRY}/${IMAGE_NAME}:presto-${PRESTO_SHORT_SHA}-velox-${VELOX_SHORT_SHA}-gpu-cuda${cuda}-${BUILD_DATE}-${GITHUB_RUN_ID}-amd64" \
-                "${REGISTRY}/${IMAGE_NAME}:presto-${PRESTO_SHORT_SHA}-velox-${VELOX_SHORT_SHA}-gpu-cuda${cuda}-${BUILD_DATE}-${GITHUB_RUN_ID}-arm64"
+                "${REGISTRY}/${IMAGE_NAME}:presto-${PRESTO_SHORT_SHA}-velox-${VELOX_SHORT_SHA}-gpu-cuda${cuda}-${BUILD_DATE}${INTERMEDIATE_TAG_SUFFIX}-amd64" \
+                "${REGISTRY}/${IMAGE_NAME}:presto-${PRESTO_SHORT_SHA}-velox-${VELOX_SHORT_SHA}-gpu-cuda${cuda}-${BUILD_DATE}${INTERMEDIATE_TAG_SUFFIX}-arm64"
             done
             docker buildx imagetools create \
               -t "${REGISTRY}/${IMAGE_NAME}:presto-latest-cpu" \
-              "${REGISTRY}/${IMAGE_NAME}:presto-${PRESTO_SHORT_SHA}-velox-${VELOX_SHORT_SHA}-cpu-${BUILD_DATE}-${GITHUB_RUN_ID}-amd64" \
-              "${REGISTRY}/${IMAGE_NAME}:presto-${PRESTO_SHORT_SHA}-velox-${VELOX_SHORT_SHA}-cpu-${BUILD_DATE}-${GITHUB_RUN_ID}-arm64"
+              "${REGISTRY}/${IMAGE_NAME}:presto-${PRESTO_SHORT_SHA}-velox-${VELOX_SHORT_SHA}-cpu-${BUILD_DATE}${INTERMEDIATE_TAG_SUFFIX}-amd64" \
+              "${REGISTRY}/${IMAGE_NAME}:presto-${PRESTO_SHORT_SHA}-velox-${VELOX_SHORT_SHA}-cpu-${BUILD_DATE}${INTERMEDIATE_TAG_SUFFIX}-arm64"
           fi
       - name: Delete intermediate arch-specific tags
         continue-on-error: true
@@ -460,11 +460,11 @@ jobs:
           registry: ${{ env.REGISTRY }}
           image-name: ${{ env.IMAGE_NAME }}
           base-tags: |
-            presto-${{ inputs.presto_short_sha }}-velox-${{ inputs.velox_short_sha }}-gpu-cuda12.9-${{ inputs.date }}-${{ inputs.github_run_id }}
-            presto-${{ inputs.presto_short_sha }}-velox-${{ inputs.velox_short_sha }}-gpu-cuda13.1-${{ inputs.date }}-${{ inputs.github_run_id }}
-            presto-${{ inputs.presto_short_sha }}-velox-${{ inputs.velox_short_sha }}-cpu-${{ inputs.date }}-${{ inputs.github_run_id }}
-            presto-deps-${{ inputs.presto_short_sha }}-velox-${{ inputs.velox_short_sha }}-cuda12.9-${{ inputs.date }}-${{ inputs.github_run_id }}
-            presto-deps-${{ inputs.presto_short_sha }}-velox-${{ inputs.velox_short_sha }}-cuda13.1-${{ inputs.date }}-${{ inputs.github_run_id }}
+            presto-${{ inputs.presto_short_sha }}-velox-${{ inputs.velox_short_sha }}-gpu-cuda12.9-${{ inputs.date }}${{ inputs.intermediate_tag_suffix }}
+            presto-${{ inputs.presto_short_sha }}-velox-${{ inputs.velox_short_sha }}-gpu-cuda13.1-${{ inputs.date }}${{ inputs.intermediate_tag_suffix }}
+            presto-${{ inputs.presto_short_sha }}-velox-${{ inputs.velox_short_sha }}-cpu-${{ inputs.date }}${{ inputs.intermediate_tag_suffix }}
+            presto-deps-${{ inputs.presto_short_sha }}-velox-${{ inputs.velox_short_sha }}-cuda12.9-${{ inputs.date }}${{ inputs.intermediate_tag_suffix }}
+            presto-deps-${{ inputs.presto_short_sha }}-velox-${{ inputs.velox_short_sha }}-cuda13.1-${{ inputs.date }}${{ inputs.intermediate_tag_suffix }}
 
   merge-presto-coordinator:
     name: merge-manifests (presto-coordinator)
@@ -490,20 +490,20 @@ jobs:
           BUILD_DATE: ${{ inputs.date }}
           BUILD_TYPE: ${{ inputs.build_type }}
           BUILD_VARIANT: ${{ inputs.build_variant }}
-          GITHUB_RUN_ID: ${{ inputs.github_run_id }}
           RUN_ID_SUFFIX: ${{ inputs.run_id_suffix }}
+          INTERMEDIATE_TAG_SUFFIX: ${{ inputs.intermediate_tag_suffix }}
         run: |
           TAG="presto-coordinator-${PRESTO_SHORT_SHA}-${BUILD_DATE}"
           FINAL_TAG="${TAG}${RUN_ID_SUFFIX}"
           echo "Creating multi-arch manifest: ${TAG}"
           docker buildx imagetools create -t "${REGISTRY}/${IMAGE_NAME}:${FINAL_TAG}" \
-            "${REGISTRY}/${IMAGE_NAME}:${TAG}-${GITHUB_RUN_ID}-amd64" \
-            "${REGISTRY}/${IMAGE_NAME}:${TAG}-${GITHUB_RUN_ID}-arm64"
+            "${REGISTRY}/${IMAGE_NAME}:${TAG}${INTERMEDIATE_TAG_SUFFIX}-amd64" \
+            "${REGISTRY}/${IMAGE_NAME}:${TAG}${INTERMEDIATE_TAG_SUFFIX}-arm64"
           if [[ "${BUILD_TYPE}" == "nightly" && "${BUILD_VARIANT}" == "pinned" && -z "${RUN_ID_SUFFIX}" ]]; then
             docker buildx imagetools create \
               -t "${REGISTRY}/${IMAGE_NAME}:presto-coordinator-latest" \
-              "${REGISTRY}/${IMAGE_NAME}:${TAG}-${GITHUB_RUN_ID}-amd64" \
-              "${REGISTRY}/${IMAGE_NAME}:${TAG}-${GITHUB_RUN_ID}-arm64"
+              "${REGISTRY}/${IMAGE_NAME}:${TAG}${INTERMEDIATE_TAG_SUFFIX}-amd64" \
+              "${REGISTRY}/${IMAGE_NAME}:${TAG}${INTERMEDIATE_TAG_SUFFIX}-arm64"
           fi
       - name: Delete intermediate arch-specific tags
         continue-on-error: true
@@ -511,4 +511,4 @@ jobs:
         with:
           registry: ${{ env.REGISTRY }}
           image-name: ${{ env.IMAGE_NAME }}
-          base-tags: presto-coordinator-${{ inputs.presto_short_sha }}-${{ inputs.date }}-${{ inputs.github_run_id }}
+          base-tags: presto-coordinator-${{ inputs.presto_short_sha }}-${{ inputs.date }}${{ inputs.intermediate_tag_suffix }}

--- a/.github/workflows/presto-build.yml
+++ b/.github/workflows/presto-build.yml
@@ -45,8 +45,8 @@ on:
         description: 'GitHub Actions run ID used to make temporary tags unique'
         type: string
         required: true
-      final_run_id_suffix:
-        description: 'Optional run ID suffix appended to final multi-arch image tags'
+      run_id_suffix:
+        description: 'Optional run ID suffix appended to image tags'
         type: string
         required: false
         default: ''
@@ -377,20 +377,21 @@ jobs:
           BUILD_TYPE: ${{ inputs.build_type }}
           BUILD_VARIANT: ${{ inputs.build_variant }}
           GITHUB_RUN_ID: ${{ inputs.github_run_id }}
-          FINAL_RUN_ID_SUFFIX: ${{ inputs.final_run_id_suffix }}
+          RUN_ID_SUFFIX: ${{ inputs.run_id_suffix }}
         run: |
           create_manifest() {
             local tag="$1"
-            local final_tag="${tag}${FINAL_RUN_ID_SUFFIX}"
+            local final_tag="$2"
             echo "Creating multi-arch manifest: ${tag}"
             docker buildx imagetools create -t "${REGISTRY}/${IMAGE_NAME}:${final_tag}" \
               "${REGISTRY}/${IMAGE_NAME}:${tag}-${GITHUB_RUN_ID}-amd64" \
               "${REGISTRY}/${IMAGE_NAME}:${tag}-${GITHUB_RUN_ID}-arm64"
           }
           for cuda in 12.9 13.1; do
-            create_manifest "presto-deps-${PRESTO_SHORT_SHA}-velox-${VELOX_SHORT_SHA}-cuda${cuda}-${BUILD_DATE}"
+            tag="presto-deps-${PRESTO_SHORT_SHA}-velox-${VELOX_SHORT_SHA}-cuda${cuda}-${BUILD_DATE}"
+            create_manifest "${tag}" "${tag}${RUN_ID_SUFFIX}"
           done
-          if [[ "${BUILD_TYPE}" == "nightly" && "${BUILD_VARIANT}" == "pinned" && -z "${FINAL_RUN_ID_SUFFIX}" ]]; then
+          if [[ "${BUILD_TYPE}" == "nightly" && "${BUILD_VARIANT}" == "pinned" && -z "${RUN_ID_SUFFIX}" ]]; then
             for cuda in 12.9 13.1; do
               docker buildx imagetools create \
                 -t "${REGISTRY}/${IMAGE_NAME}:presto-deps-latest-cuda${cuda}" \
@@ -424,21 +425,23 @@ jobs:
           BUILD_TYPE: ${{ inputs.build_type }}
           BUILD_VARIANT: ${{ inputs.build_variant }}
           GITHUB_RUN_ID: ${{ inputs.github_run_id }}
-          FINAL_RUN_ID_SUFFIX: ${{ inputs.final_run_id_suffix }}
+          RUN_ID_SUFFIX: ${{ inputs.run_id_suffix }}
         run: |
           create_manifest() {
             local tag="$1"
-            local final_tag="${tag}${FINAL_RUN_ID_SUFFIX}"
+            local final_tag="$2"
             echo "Creating multi-arch manifest: ${tag}"
             docker buildx imagetools create -t "${REGISTRY}/${IMAGE_NAME}:${final_tag}" \
               "${REGISTRY}/${IMAGE_NAME}:${tag}-${GITHUB_RUN_ID}-amd64" \
               "${REGISTRY}/${IMAGE_NAME}:${tag}-${GITHUB_RUN_ID}-arm64"
           }
           for cuda in 12.9 13.1; do
-            create_manifest "presto-${PRESTO_SHORT_SHA}-velox-${VELOX_SHORT_SHA}-gpu-cuda${cuda}-${BUILD_DATE}"
+            tag="presto-${PRESTO_SHORT_SHA}-velox-${VELOX_SHORT_SHA}-gpu-cuda${cuda}-${BUILD_DATE}"
+            create_manifest "${tag}" "${tag}${RUN_ID_SUFFIX}"
           done
-          create_manifest "presto-${PRESTO_SHORT_SHA}-velox-${VELOX_SHORT_SHA}-cpu-${BUILD_DATE}"
-          if [[ "${BUILD_TYPE}" == "nightly" && "${BUILD_VARIANT}" == "pinned" && -z "${FINAL_RUN_ID_SUFFIX}" ]]; then
+          tag="presto-${PRESTO_SHORT_SHA}-velox-${VELOX_SHORT_SHA}-cpu-${BUILD_DATE}"
+          create_manifest "${tag}" "${tag}${RUN_ID_SUFFIX}"
+          if [[ "${BUILD_TYPE}" == "nightly" && "${BUILD_VARIANT}" == "pinned" && -z "${RUN_ID_SUFFIX}" ]]; then
             for cuda in 12.9 13.1; do
               docker buildx imagetools create \
                 -t "${REGISTRY}/${IMAGE_NAME}:presto-latest-gpu-cuda${cuda}" \
@@ -488,15 +491,15 @@ jobs:
           BUILD_TYPE: ${{ inputs.build_type }}
           BUILD_VARIANT: ${{ inputs.build_variant }}
           GITHUB_RUN_ID: ${{ inputs.github_run_id }}
-          FINAL_RUN_ID_SUFFIX: ${{ inputs.final_run_id_suffix }}
+          RUN_ID_SUFFIX: ${{ inputs.run_id_suffix }}
         run: |
           TAG="presto-coordinator-${PRESTO_SHORT_SHA}-${BUILD_DATE}"
-          FINAL_TAG="${TAG}${FINAL_RUN_ID_SUFFIX}"
+          FINAL_TAG="${TAG}${RUN_ID_SUFFIX}"
           echo "Creating multi-arch manifest: ${TAG}"
           docker buildx imagetools create -t "${REGISTRY}/${IMAGE_NAME}:${FINAL_TAG}" \
             "${REGISTRY}/${IMAGE_NAME}:${TAG}-${GITHUB_RUN_ID}-amd64" \
             "${REGISTRY}/${IMAGE_NAME}:${TAG}-${GITHUB_RUN_ID}-arm64"
-          if [[ "${BUILD_TYPE}" == "nightly" && "${BUILD_VARIANT}" == "pinned" && -z "${FINAL_RUN_ID_SUFFIX}" ]]; then
+          if [[ "${BUILD_TYPE}" == "nightly" && "${BUILD_VARIANT}" == "pinned" && -z "${RUN_ID_SUFFIX}" ]]; then
             docker buildx imagetools create \
               -t "${REGISTRY}/${IMAGE_NAME}:presto-coordinator-latest" \
               "${REGISTRY}/${IMAGE_NAME}:${TAG}-${GITHUB_RUN_ID}-amd64" \

--- a/.github/workflows/presto-build.yml
+++ b/.github/workflows/presto-build.yml
@@ -42,7 +42,7 @@ on:
         required: false
         default: 'manual'
       github_run_id:
-        description: 'GitHub Actions run ID used to make temporary tags unique'
+        description: 'Caller workflow run ID used to make temporary tags unique'
         type: string
         required: true
       run_id_suffix:

--- a/.github/workflows/presto-nightly.yml
+++ b/.github/workflows/presto-nightly.yml
@@ -12,7 +12,22 @@ concurrency:
 permissions: {}
 
 jobs:
+  resolve-run-id-suffix:
+    runs-on: ubuntu-latest
+    outputs:
+      run_id_suffix: ${{ steps.resolve.outputs.run_id_suffix }}
+    steps:
+      - name: Resolve run ID suffix
+        id: resolve
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            echo "run_id_suffix=-${{ github.run_id }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "run_id_suffix=" >> "$GITHUB_OUTPUT"
+          fi
+
   upstream:
+    needs: [resolve-run-id-suffix]
     permissions:
       contents: read
       id-token: write
@@ -29,10 +44,11 @@ jobs:
       run_tests: true
       build_type: nightly
       build_variant: upstream
-      run_id_suffix: ${{ github.event_name == 'workflow_dispatch' && format('-{0}', github.run_id) || '' }}
+      run_id_suffix: ${{ needs.resolve-run-id-suffix.outputs.run_id_suffix }}
     secrets: inherit  # zizmor: ignore[secrets-inherit]
 
   pinned:
+    needs: [resolve-run-id-suffix]
     permissions:
       contents: read
       id-token: write
@@ -49,5 +65,5 @@ jobs:
       run_tests: true
       build_type: nightly
       build_variant: pinned
-      run_id_suffix: ${{ github.event_name == 'workflow_dispatch' && format('-{0}', github.run_id) || '' }}
+      run_id_suffix: ${{ needs.resolve-run-id-suffix.outputs.run_id_suffix }}
     secrets: inherit  # zizmor: ignore[secrets-inherit]

--- a/.github/workflows/presto-nightly.yml
+++ b/.github/workflows/presto-nightly.yml
@@ -29,6 +29,7 @@ jobs:
       run_tests: true
       build_type: nightly
       build_variant: upstream
+      final_image_tag_suffix: ${{ github.event_name == 'workflow_dispatch' && format('-{0}', github.run_id) || '' }}
     secrets: inherit  # zizmor: ignore[secrets-inherit]
 
   pinned:
@@ -48,23 +49,5 @@ jobs:
       run_tests: true
       build_type: nightly
       build_variant: pinned
-    secrets: inherit  # zizmor: ignore[secrets-inherit]
-
-  staging:
-    permissions:
-      contents: read
-      id-token: write
-      packages: write
-      attestations: write
-      artifact-metadata: write
-    uses: ./.github/workflows/presto.yml
-    with:
-      variant_label: staging
-      presto_repository: ${{ vars.STABLE_PRESTO_REPO }}
-      presto_commit: ${{ vars.STABLE_PRESTO_COMMIT }}
-      velox_repository: ${{ vars.STABLE_VELOX_REPO }}
-      velox_commit: ${{ vars.STABLE_VELOX_COMMIT }}
-      run_tests: true
-      build_type: nightly
-      build_variant: staging
+      final_image_tag_suffix: ${{ github.event_name == 'workflow_dispatch' && format('-{0}', github.run_id) || '' }}
     secrets: inherit  # zizmor: ignore[secrets-inherit]

--- a/.github/workflows/presto-nightly.yml
+++ b/.github/workflows/presto-nightly.yml
@@ -29,7 +29,7 @@ jobs:
       run_tests: true
       build_type: nightly
       build_variant: upstream
-      final_run_id_suffix: ${{ github.event_name == 'workflow_dispatch' && format('-{0}', github.run_id) || '' }}
+      run_id_suffix: ${{ github.event_name == 'workflow_dispatch' && format('-{0}', github.run_id) || '' }}
     secrets: inherit  # zizmor: ignore[secrets-inherit]
 
   pinned:
@@ -49,5 +49,5 @@ jobs:
       run_tests: true
       build_type: nightly
       build_variant: pinned
-      final_run_id_suffix: ${{ github.event_name == 'workflow_dispatch' && format('-{0}', github.run_id) || '' }}
+      run_id_suffix: ${{ github.event_name == 'workflow_dispatch' && format('-{0}', github.run_id) || '' }}
     secrets: inherit  # zizmor: ignore[secrets-inherit]

--- a/.github/workflows/presto-nightly.yml
+++ b/.github/workflows/presto-nightly.yml
@@ -29,7 +29,7 @@ jobs:
       run_tests: true
       build_type: nightly
       build_variant: upstream
-      final_image_tag_suffix: ${{ github.event_name == 'workflow_dispatch' && format('-{0}', github.run_id) || '' }}
+      final_run_id_suffix: ${{ github.event_name == 'workflow_dispatch' && format('-{0}', github.run_id) || '' }}
     secrets: inherit  # zizmor: ignore[secrets-inherit]
 
   pinned:
@@ -49,5 +49,5 @@ jobs:
       run_tests: true
       build_type: nightly
       build_variant: pinned
-      final_image_tag_suffix: ${{ github.event_name == 'workflow_dispatch' && format('-{0}', github.run_id) || '' }}
+      final_run_id_suffix: ${{ github.event_name == 'workflow_dispatch' && format('-{0}', github.run_id) || '' }}
     secrets: inherit  # zizmor: ignore[secrets-inherit]

--- a/.github/workflows/presto-test.yml
+++ b/.github/workflows/presto-test.yml
@@ -15,8 +15,8 @@ on:
         description: 'Build date (YYYYMMDD)'
         type: string
         required: true
-      image_tag_suffix:
-        description: 'Optional suffix appended to Presto image tags'
+      run_id_suffix:
+        description: 'Optional run ID suffix appended to Presto image tags'
         type: string
         required: false
         default: ''
@@ -43,8 +43,8 @@ on:
         type: string
         required: false
         default: ''
-      image_tag_suffix:
-        description: 'Optional suffix appended to Presto image tags'
+      run_id_suffix:
+        description: 'Optional run ID suffix appended to Presto image tags'
         type: string
         required: false
         default: ''
@@ -62,7 +62,7 @@ jobs:
       velox_short_sha: ${{ steps.resolve.outputs.velox_short_sha }}
       presto_short_sha: ${{ steps.resolve.outputs.presto_short_sha }}
       date: ${{ steps.resolve.outputs.date }}
-      image_tag_suffix: ${{ inputs.image_tag_suffix || steps.resolve.outputs.image_tag_suffix }}
+      run_id_suffix: ${{ inputs.run_id_suffix || steps.resolve.outputs.run_id_suffix }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
@@ -224,13 +224,13 @@ jobs:
           PRESTO_SHORT_SHA: ${{ needs.resolve-inputs.outputs.presto_short_sha }}
           BUILD_DATE: ${{ needs.resolve-inputs.outputs.date }}
           CUDA_VERSION: ${{ matrix.cuda_version }}
-          IMAGE_TAG_SUFFIX: ${{ needs.resolve-inputs.outputs.image_tag_suffix }}
+          RUN_ID_SUFFIX: ${{ needs.resolve-inputs.outputs.run_id_suffix }}
         run: |
-          COORD_IMAGE="${REGISTRY}/${IMAGE_NAME}:presto-coordinator-${PRESTO_SHORT_SHA}-${BUILD_DATE}${IMAGE_TAG_SUFFIX}"
+          COORD_IMAGE="${REGISTRY}/${IMAGE_NAME}:presto-coordinator-${PRESTO_SHORT_SHA}-${BUILD_DATE}${RUN_ID_SUFFIX}"
           docker pull "${COORD_IMAGE}"
           docker tag "${COORD_IMAGE}" "presto-coordinator:ci"
 
-          WORKER_IMAGE="${REGISTRY}/${IMAGE_NAME}:presto-${PRESTO_SHORT_SHA}-velox-${VELOX_SHORT_SHA}-gpu-cuda${CUDA_VERSION}-${BUILD_DATE}${IMAGE_TAG_SUFFIX}"
+          WORKER_IMAGE="${REGISTRY}/${IMAGE_NAME}:presto-${PRESTO_SHORT_SHA}-velox-${VELOX_SHORT_SHA}-gpu-cuda${CUDA_VERSION}-${BUILD_DATE}${RUN_ID_SUFFIX}"
           docker pull "${WORKER_IMAGE}"
           docker tag "${WORKER_IMAGE}" "presto-native-worker-gpu:ci"
 

--- a/.github/workflows/presto-test.yml
+++ b/.github/workflows/presto-test.yml
@@ -15,6 +15,11 @@ on:
         description: 'Build date (YYYYMMDD)'
         type: string
         required: true
+      image_tag_suffix:
+        description: 'Optional suffix appended to Presto image tags'
+        type: string
+        required: false
+        default: ''
 
   workflow_dispatch:
     inputs:
@@ -38,6 +43,11 @@ on:
         type: string
         required: false
         default: ''
+      image_tag_suffix:
+        description: 'Optional suffix appended to Presto image tags'
+        type: string
+        required: false
+        default: ''
 
 env:
   REGISTRY: ghcr.io
@@ -52,6 +62,7 @@ jobs:
       velox_short_sha: ${{ steps.resolve.outputs.velox_short_sha }}
       presto_short_sha: ${{ steps.resolve.outputs.presto_short_sha }}
       date: ${{ steps.resolve.outputs.date }}
+      image_tag_suffix: ${{ inputs.image_tag_suffix || steps.resolve.outputs.image_tag_suffix }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
@@ -213,12 +224,13 @@ jobs:
           PRESTO_SHORT_SHA: ${{ needs.resolve-inputs.outputs.presto_short_sha }}
           BUILD_DATE: ${{ needs.resolve-inputs.outputs.date }}
           CUDA_VERSION: ${{ matrix.cuda_version }}
+          IMAGE_TAG_SUFFIX: ${{ needs.resolve-inputs.outputs.image_tag_suffix }}
         run: |
-          COORD_IMAGE="${REGISTRY}/${IMAGE_NAME}:presto-coordinator-${PRESTO_SHORT_SHA}-${BUILD_DATE}"
+          COORD_IMAGE="${REGISTRY}/${IMAGE_NAME}:presto-coordinator-${PRESTO_SHORT_SHA}-${BUILD_DATE}${IMAGE_TAG_SUFFIX}"
           docker pull "${COORD_IMAGE}"
           docker tag "${COORD_IMAGE}" "presto-coordinator:ci"
 
-          WORKER_IMAGE="${REGISTRY}/${IMAGE_NAME}:presto-${PRESTO_SHORT_SHA}-velox-${VELOX_SHORT_SHA}-gpu-cuda${CUDA_VERSION}-${BUILD_DATE}"
+          WORKER_IMAGE="${REGISTRY}/${IMAGE_NAME}:presto-${PRESTO_SHORT_SHA}-velox-${VELOX_SHORT_SHA}-gpu-cuda${CUDA_VERSION}-${BUILD_DATE}${IMAGE_TAG_SUFFIX}"
           docker pull "${WORKER_IMAGE}"
           docker tag "${WORKER_IMAGE}" "presto-native-worker-gpu:ci"
 

--- a/.github/workflows/presto.yml
+++ b/.github/workflows/presto.yml
@@ -68,11 +68,16 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       run_id_suffix: ${{ steps.resolve.outputs.run_id_suffix }}
+      intermediate_tag_suffix: ${{ steps.resolve.outputs.intermediate_tag_suffix }}
     steps:
       - name: Resolve run ID suffix
         id: resolve
         env:
           INPUT_RUN_ID_SUFFIX: ${{ inputs.run_id_suffix || '' }}
+          VARIANT_LABEL: ${{ inputs.variant_label || '' }}
+          BUILD_VARIANT: ${{ inputs.build_variant || '' }}
+          GITHUB_RUN_ID_VALUE: ${{ github.run_id }}
+          GITHUB_RUN_ATTEMPT_VALUE: ${{ github.run_attempt }}
         run: |
           if [[ -n "${INPUT_RUN_ID_SUFFIX}" ]]; then
             echo "run_id_suffix=${INPUT_RUN_ID_SUFFIX}" >> "$GITHUB_OUTPUT"
@@ -81,6 +86,17 @@ jobs:
           else
             echo "run_id_suffix=" >> "$GITHUB_OUTPUT"
           fi
+
+          label="$(printf '%s' "${VARIANT_LABEL:-${BUILD_VARIANT:-manual}}" \
+            | tr '[:upper:]' '[:lower:]' \
+            | sed -E 's/[^a-z0-9_.-]+/-/g; s/^-+//; s/-+$//; s/-+/-/g' \
+            | cut -c1-40 \
+            | sed -E 's/^-+//; s/-+$//')"
+          if [[ -z "${label}" ]]; then
+            label="manual"
+          fi
+          namespace="${GITHUB_RUN_ID_VALUE}-${GITHUB_RUN_ATTEMPT_VALUE}-${label}"
+          echo "intermediate_tag_suffix=-${namespace}" >> "$GITHUB_OUTPUT"
 
   resolve-commits:
     runs-on: ubuntu-latest
@@ -124,8 +140,8 @@ jobs:
       date: ${{ needs.resolve-commits.outputs.date }}
       build_type: ${{ inputs.build_type }}
       build_variant: ${{ inputs.build_variant }}
-      github_run_id: ${{ github.run_id }}
       run_id_suffix: ${{ needs.resolve-run-id-suffix.outputs.run_id_suffix }}
+      intermediate_tag_suffix: ${{ needs.resolve-run-id-suffix.outputs.intermediate_tag_suffix }}
     secrets: inherit  # zizmor: ignore[secrets-inherit]
 
   presto-test:

--- a/.github/workflows/presto.yml
+++ b/.github/workflows/presto.yml
@@ -40,7 +40,7 @@ on:
         required: false
         default: 'manual'
       build_variant: &build_variant
-        description: 'One of: [upstream, pinned, staging, manual]'
+        description: 'One of: [upstream, pinned, manual]'
         type: string
         required: false
         default: 'manual'
@@ -55,8 +55,8 @@ on:
       run_tests: *run_tests
       build_type: *build_type
       build_variant: *build_variant
-      final_image_tag_suffix:
-        description: 'Optional suffix appended to final multi-arch image tags'
+      final_run_id_suffix:
+        description: 'Optional run ID suffix appended to final multi-arch image tags'
         type: string
         required: false
         default: ''
@@ -107,8 +107,7 @@ jobs:
       build_type: ${{ inputs.build_type }}
       build_variant: ${{ inputs.build_variant }}
       github_run_id: ${{ github.run_id }}
-      github_run_attempt: ${{ github.run_attempt }}
-      final_image_tag_suffix: ${{ inputs.final_image_tag_suffix || (github.event_name == 'workflow_dispatch' && format('-{0}', github.run_id) || '') }}
+      final_run_id_suffix: ${{ inputs.final_run_id_suffix || (github.event_name == 'workflow_dispatch' && format('-{0}', github.run_id) || '') }}
     secrets: inherit  # zizmor: ignore[secrets-inherit]
 
   presto-test:
@@ -122,4 +121,4 @@ jobs:
       velox_short_sha: ${{ needs.resolve-commits.outputs.velox_short_sha }}
       presto_short_sha: ${{ needs.resolve-commits.outputs.presto_short_sha }}
       date: ${{ needs.resolve-commits.outputs.date }}
-      image_tag_suffix: ${{ inputs.final_image_tag_suffix || (github.event_name == 'workflow_dispatch' && format('-{0}', github.run_id) || '') }}
+      run_id_suffix: ${{ inputs.final_run_id_suffix || (github.event_name == 'workflow_dispatch' && format('-{0}', github.run_id) || '') }}

--- a/.github/workflows/presto.yml
+++ b/.github/workflows/presto.yml
@@ -55,8 +55,8 @@ on:
       run_tests: *run_tests
       build_type: *build_type
       build_variant: *build_variant
-      final_run_id_suffix:
-        description: 'Optional run ID suffix appended to final multi-arch image tags'
+      run_id_suffix:
+        description: 'Optional run ID suffix appended to image tags'
         type: string
         required: false
         default: ''
@@ -107,7 +107,7 @@ jobs:
       build_type: ${{ inputs.build_type }}
       build_variant: ${{ inputs.build_variant }}
       github_run_id: ${{ github.run_id }}
-      final_run_id_suffix: ${{ inputs.final_run_id_suffix || (github.event_name == 'workflow_dispatch' && format('-{0}', github.run_id) || '') }}
+      run_id_suffix: ${{ inputs.run_id_suffix || (github.event_name == 'workflow_dispatch' && format('-{0}', github.run_id) || '') }}
     secrets: inherit  # zizmor: ignore[secrets-inherit]
 
   presto-test:
@@ -121,4 +121,4 @@ jobs:
       velox_short_sha: ${{ needs.resolve-commits.outputs.velox_short_sha }}
       presto_short_sha: ${{ needs.resolve-commits.outputs.presto_short_sha }}
       date: ${{ needs.resolve-commits.outputs.date }}
-      run_id_suffix: ${{ inputs.final_run_id_suffix || (github.event_name == 'workflow_dispatch' && format('-{0}', github.run_id) || '') }}
+      run_id_suffix: ${{ inputs.run_id_suffix || (github.event_name == 'workflow_dispatch' && format('-{0}', github.run_id) || '') }}

--- a/.github/workflows/presto.yml
+++ b/.github/workflows/presto.yml
@@ -64,6 +64,24 @@ on:
 permissions: {}
 
 jobs:
+  resolve-run-id-suffix:
+    runs-on: ubuntu-latest
+    outputs:
+      run_id_suffix: ${{ steps.resolve.outputs.run_id_suffix }}
+    steps:
+      - name: Resolve run ID suffix
+        id: resolve
+        env:
+          INPUT_RUN_ID_SUFFIX: ${{ inputs.run_id_suffix || '' }}
+        run: |
+          if [[ -n "${INPUT_RUN_ID_SUFFIX}" ]]; then
+            echo "run_id_suffix=${INPUT_RUN_ID_SUFFIX}" >> "$GITHUB_OUTPUT"
+          elif [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            echo "run_id_suffix=-${{ github.run_id }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "run_id_suffix=" >> "$GITHUB_OUTPUT"
+          fi
+
   resolve-commits:
     runs-on: ubuntu-latest
     permissions:
@@ -88,7 +106,7 @@ jobs:
           github_token: ${{ github.token }}
 
   presto-build:
-    needs: [resolve-commits]
+    needs: [resolve-commits, resolve-run-id-suffix]
     permissions:
       contents: read
       id-token: write
@@ -107,11 +125,11 @@ jobs:
       build_type: ${{ inputs.build_type }}
       build_variant: ${{ inputs.build_variant }}
       github_run_id: ${{ github.run_id }}
-      run_id_suffix: ${{ inputs.run_id_suffix || (github.event_name == 'workflow_dispatch' && format('-{0}', github.run_id) || '') }}
+      run_id_suffix: ${{ needs.resolve-run-id-suffix.outputs.run_id_suffix }}
     secrets: inherit  # zizmor: ignore[secrets-inherit]
 
   presto-test:
-    needs: [resolve-commits, presto-build]
+    needs: [resolve-commits, resolve-run-id-suffix, presto-build]
     if: ${{ inputs.run_tests }}
     permissions:
       contents: read
@@ -121,4 +139,4 @@ jobs:
       velox_short_sha: ${{ needs.resolve-commits.outputs.velox_short_sha }}
       presto_short_sha: ${{ needs.resolve-commits.outputs.presto_short_sha }}
       date: ${{ needs.resolve-commits.outputs.date }}
-      run_id_suffix: ${{ inputs.run_id_suffix || (github.event_name == 'workflow_dispatch' && format('-{0}', github.run_id) || '') }}
+      run_id_suffix: ${{ needs.resolve-run-id-suffix.outputs.run_id_suffix }}

--- a/.github/workflows/presto.yml
+++ b/.github/workflows/presto.yml
@@ -55,6 +55,11 @@ on:
       run_tests: *run_tests
       build_type: *build_type
       build_variant: *build_variant
+      final_image_tag_suffix:
+        description: 'Optional suffix appended to final multi-arch image tags'
+        type: string
+        required: false
+        default: ''
 
 permissions: {}
 
@@ -101,6 +106,9 @@ jobs:
       date: ${{ needs.resolve-commits.outputs.date }}
       build_type: ${{ inputs.build_type }}
       build_variant: ${{ inputs.build_variant }}
+      github_run_id: ${{ github.run_id }}
+      github_run_attempt: ${{ github.run_attempt }}
+      final_image_tag_suffix: ${{ inputs.final_image_tag_suffix || (github.event_name == 'workflow_dispatch' && format('-{0}', github.run_id) || '') }}
     secrets: inherit  # zizmor: ignore[secrets-inherit]
 
   presto-test:
@@ -114,3 +122,4 @@ jobs:
       velox_short_sha: ${{ needs.resolve-commits.outputs.velox_short_sha }}
       presto_short_sha: ${{ needs.resolve-commits.outputs.presto_short_sha }}
       date: ${{ needs.resolve-commits.outputs.date }}
+      image_tag_suffix: ${{ inputs.final_image_tag_suffix || (github.event_name == 'workflow_dispatch' && format('-{0}', github.run_id) || '') }}

--- a/.github/workflows/velox-benchmark.yml
+++ b/.github/workflows/velox-benchmark.yml
@@ -12,12 +12,12 @@ on:
         type: string
         required: true
       variant_label:
-        description: 'Variant label to disambiguate artifacts (e.g. upstream, staging)'
+        description: 'Variant label to disambiguate artifacts (e.g. upstream)'
         type: string
         required: false
         default: ''
-      image_tag_suffix:
-        description: 'Optional suffix appended to Velox image tags'
+      run_id_suffix:
+        description: 'Optional run ID suffix appended to Velox image tags'
         type: string
         required: false
         default: ''
@@ -40,12 +40,12 @@ on:
         required: false
         default: ''
       variant_label:
-        description: 'Variant label to disambiguate artifacts (e.g. upstream, staging)'
+        description: 'Variant label to disambiguate artifacts (e.g. upstream)'
         type: string
         required: false
         default: ''
-      image_tag_suffix:
-        description: 'Optional suffix appended to Velox image tags'
+      run_id_suffix:
+        description: 'Optional run ID suffix appended to Velox image tags'
         type: string
         required: false
         default: ''
@@ -62,7 +62,7 @@ jobs:
     outputs:
       velox_short_sha: ${{ steps.resolve.outputs.velox_short_sha }}
       date: ${{ steps.resolve.outputs.date }}
-      image_tag_suffix: ${{ inputs.image_tag_suffix || steps.resolve.outputs.image_tag_suffix }}
+      run_id_suffix: ${{ inputs.run_id_suffix || steps.resolve.outputs.run_id_suffix }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
@@ -151,10 +151,10 @@ jobs:
           VELOX_SHORT_SHA: ${{ needs.resolve-inputs.outputs.velox_short_sha }}
           BUILD_DATE: ${{ needs.resolve-inputs.outputs.date }}
           CUDA_VERSION: ${{ matrix.cuda_version }}
-          IMAGE_TAG_SUFFIX: ${{ needs.resolve-inputs.outputs.image_tag_suffix }}
+          RUN_ID_SUFFIX: ${{ needs.resolve-inputs.outputs.run_id_suffix }}
         working-directory: velox/scripts
         run: |
-          IMAGE="${REGISTRY}/${IMAGE_NAME}:velox-${VELOX_SHORT_SHA}-gpu-cuda${CUDA_VERSION}-${BUILD_DATE}${IMAGE_TAG_SUFFIX}"
+          IMAGE="${REGISTRY}/${IMAGE_NAME}:velox-${VELOX_SHORT_SHA}-gpu-cuda${CUDA_VERSION}-${BUILD_DATE}${RUN_ID_SUFFIX}"
           ./benchmark_velox.sh \
             --image "${IMAGE}" \
             --benchmark-type tpch \

--- a/.github/workflows/velox-benchmark.yml
+++ b/.github/workflows/velox-benchmark.yml
@@ -16,6 +16,11 @@ on:
         type: string
         required: false
         default: ''
+      image_tag_suffix:
+        description: 'Optional suffix appended to Velox image tags'
+        type: string
+        required: false
+        default: ''
 
   workflow_dispatch:
     inputs:
@@ -39,6 +44,11 @@ on:
         type: string
         required: false
         default: ''
+      image_tag_suffix:
+        description: 'Optional suffix appended to Velox image tags'
+        type: string
+        required: false
+        default: ''
 
 env:
   REGISTRY: ghcr.io
@@ -52,6 +62,7 @@ jobs:
     outputs:
       velox_short_sha: ${{ steps.resolve.outputs.velox_short_sha }}
       date: ${{ steps.resolve.outputs.date }}
+      image_tag_suffix: ${{ inputs.image_tag_suffix || steps.resolve.outputs.image_tag_suffix }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
@@ -140,9 +151,10 @@ jobs:
           VELOX_SHORT_SHA: ${{ needs.resolve-inputs.outputs.velox_short_sha }}
           BUILD_DATE: ${{ needs.resolve-inputs.outputs.date }}
           CUDA_VERSION: ${{ matrix.cuda_version }}
+          IMAGE_TAG_SUFFIX: ${{ needs.resolve-inputs.outputs.image_tag_suffix }}
         working-directory: velox/scripts
         run: |
-          IMAGE="${REGISTRY}/${IMAGE_NAME}:velox-${VELOX_SHORT_SHA}-gpu-cuda${CUDA_VERSION}-${BUILD_DATE}"
+          IMAGE="${REGISTRY}/${IMAGE_NAME}:velox-${VELOX_SHORT_SHA}-gpu-cuda${CUDA_VERSION}-${BUILD_DATE}${IMAGE_TAG_SUFFIX}"
           ./benchmark_velox.sh \
             --image "${IMAGE}" \
             --benchmark-type tpch \

--- a/.github/workflows/velox-build.yml
+++ b/.github/workflows/velox-build.yml
@@ -29,6 +29,19 @@ on:
         type: string
         required: false
         default: 'manual'
+      github_run_id:
+        description: 'GitHub Actions run ID used to isolate temporary tags'
+        type: string
+        required: true
+      github_run_attempt:
+        description: 'GitHub Actions run attempt used to isolate temporary tags'
+        type: string
+        required: true
+      final_image_tag_suffix:
+        description: 'Optional suffix appended to final multi-arch image tags'
+        type: string
+        required: false
+        default: ''
 
 env:
   REGISTRY: ghcr.io
@@ -116,7 +129,7 @@ jobs:
           outputs: type=registry,compression=zstd,force-compression=true,compression-level=15
           push: true
           tags: |
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:velox-deps-${{ inputs.velox_short_sha }}-cuda${{ matrix.cuda_version }}-${{ inputs.date }}-${{ matrix.arch }}
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:velox-deps-${{ inputs.velox_short_sha }}-cuda${{ matrix.cuda_version }}-${{ inputs.date }}-${{ inputs.github_run_id }}-${{ inputs.github_run_attempt }}-${{ matrix.arch }}
 
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@96278af6caaf10aea03fd8d33a09a777ca52d62f  # v3.2.0
@@ -207,24 +220,28 @@ jobs:
         env:
           VELOX_SHORT_SHA: ${{ inputs.velox_short_sha }}
           BUILD_DATE: ${{ inputs.date }}
+          GITHUB_RUN_ID: ${{ inputs.github_run_id }}
+          GITHUB_RUN_ATTEMPT: ${{ inputs.github_run_attempt }}
           ARCH: ${{ matrix.arch }}
           CUDA: ${{ matrix.cuda_version || '12.9' }}
         run: |
-          echo "image=${REGISTRY}/${IMAGE_NAME}:velox-deps-${VELOX_SHORT_SHA}-cuda${CUDA}-${BUILD_DATE}-${ARCH}" >> "$GITHUB_OUTPUT"
+          echo "image=${REGISTRY}/${IMAGE_NAME}:velox-deps-${VELOX_SHORT_SHA}-cuda${CUDA}-${BUILD_DATE}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${ARCH}" >> "$GITHUB_OUTPUT"
 
       - name: Determine image tag
         id: tag
         env:
           VELOX_SHORT_SHA: ${{ inputs.velox_short_sha }}
           BUILD_DATE: ${{ inputs.date }}
+          GITHUB_RUN_ID: ${{ inputs.github_run_id }}
+          GITHUB_RUN_ATTEMPT: ${{ inputs.github_run_attempt }}
           ARCH: ${{ matrix.arch }}
           BUILD_TYPE: ${{ matrix.build_type }}
           CUDA_VERSION: ${{ matrix.cuda_version }}
         run: |
           if [[ "${BUILD_TYPE}" == "cpu" ]]; then
-            echo "tag=velox-${VELOX_SHORT_SHA}-cpu-${BUILD_DATE}-${ARCH}" >> "$GITHUB_OUTPUT"
+            echo "tag=velox-${VELOX_SHORT_SHA}-cpu-${BUILD_DATE}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${ARCH}" >> "$GITHUB_OUTPUT"
           else
-            echo "tag=velox-${VELOX_SHORT_SHA}-gpu-cuda${CUDA_VERSION}-${BUILD_DATE}-${ARCH}" >> "$GITHUB_OUTPUT"
+            echo "tag=velox-${VELOX_SHORT_SHA}-gpu-cuda${CUDA_VERSION}-${BUILD_DATE}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${ARCH}" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Build and push Velox image
@@ -277,23 +294,27 @@ jobs:
           BUILD_DATE: ${{ inputs.date }}
           BUILD_TYPE: ${{ inputs.build_type }}
           BUILD_VARIANT: ${{ inputs.build_variant }}
+          GITHUB_RUN_ID: ${{ inputs.github_run_id }}
+          GITHUB_RUN_ATTEMPT: ${{ inputs.github_run_attempt }}
+          FINAL_IMAGE_TAG_SUFFIX: ${{ inputs.final_image_tag_suffix }}
         run: |
           create_manifest() {
             local tag="$1"
+            local final_tag="${tag}${FINAL_IMAGE_TAG_SUFFIX}"
             echo "Creating multi-arch manifest: ${tag}"
-            docker buildx imagetools create -t "${REGISTRY}/${IMAGE_NAME}:${tag}" \
-              "${REGISTRY}/${IMAGE_NAME}:${tag}-amd64" \
-              "${REGISTRY}/${IMAGE_NAME}:${tag}-arm64"
+            docker buildx imagetools create -t "${REGISTRY}/${IMAGE_NAME}:${final_tag}" \
+              "${REGISTRY}/${IMAGE_NAME}:${tag}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-amd64" \
+              "${REGISTRY}/${IMAGE_NAME}:${tag}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-arm64"
           }
           for cuda in 12.9 13.1; do
             create_manifest "velox-deps-${VELOX_SHORT_SHA}-cuda${cuda}-${BUILD_DATE}"
           done
-          if [[ "${BUILD_TYPE}" == "nightly" && "${BUILD_VARIANT}" == "upstream" ]]; then
+          if [[ "${BUILD_TYPE}" == "nightly" && "${BUILD_VARIANT}" == "upstream" && -z "${FINAL_IMAGE_TAG_SUFFIX}" ]]; then
             for cuda in 12.9 13.1; do
               docker buildx imagetools create \
                 -t "${REGISTRY}/${IMAGE_NAME}:velox-deps-latest-cuda${cuda}" \
-                "${REGISTRY}/${IMAGE_NAME}:velox-deps-${VELOX_SHORT_SHA}-cuda${cuda}-${BUILD_DATE}-amd64" \
-                "${REGISTRY}/${IMAGE_NAME}:velox-deps-${VELOX_SHORT_SHA}-cuda${cuda}-${BUILD_DATE}-arm64"
+                "${REGISTRY}/${IMAGE_NAME}:velox-deps-${VELOX_SHORT_SHA}-cuda${cuda}-${BUILD_DATE}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-amd64" \
+                "${REGISTRY}/${IMAGE_NAME}:velox-deps-${VELOX_SHORT_SHA}-cuda${cuda}-${BUILD_DATE}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-arm64"
             done
           fi
   merge-velox-build:
@@ -315,29 +336,33 @@ jobs:
           BUILD_DATE: ${{ inputs.date }}
           BUILD_TYPE: ${{ inputs.build_type }}
           BUILD_VARIANT: ${{ inputs.build_variant }}
+          GITHUB_RUN_ID: ${{ inputs.github_run_id }}
+          GITHUB_RUN_ATTEMPT: ${{ inputs.github_run_attempt }}
+          FINAL_IMAGE_TAG_SUFFIX: ${{ inputs.final_image_tag_suffix }}
         run: |
           create_manifest() {
             local tag="$1"
+            local final_tag="${tag}${FINAL_IMAGE_TAG_SUFFIX}"
             echo "Creating multi-arch manifest: ${tag}"
-            docker buildx imagetools create -t "${REGISTRY}/${IMAGE_NAME}:${tag}" \
-              "${REGISTRY}/${IMAGE_NAME}:${tag}-amd64" \
-              "${REGISTRY}/${IMAGE_NAME}:${tag}-arm64"
+            docker buildx imagetools create -t "${REGISTRY}/${IMAGE_NAME}:${final_tag}" \
+              "${REGISTRY}/${IMAGE_NAME}:${tag}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-amd64" \
+              "${REGISTRY}/${IMAGE_NAME}:${tag}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-arm64"
           }
           for cuda in 12.9 13.1; do
             create_manifest "velox-${VELOX_SHORT_SHA}-gpu-cuda${cuda}-${BUILD_DATE}"
           done
           create_manifest "velox-${VELOX_SHORT_SHA}-cpu-${BUILD_DATE}"
-          if [[ "${BUILD_TYPE}" == "nightly" && "${BUILD_VARIANT}" == "upstream" ]]; then
+          if [[ "${BUILD_TYPE}" == "nightly" && "${BUILD_VARIANT}" == "upstream" && -z "${FINAL_IMAGE_TAG_SUFFIX}" ]]; then
             for cuda in 12.9 13.1; do
               docker buildx imagetools create \
                 -t "${REGISTRY}/${IMAGE_NAME}:velox-latest-gpu-cuda${cuda}" \
-                "${REGISTRY}/${IMAGE_NAME}:velox-${VELOX_SHORT_SHA}-gpu-cuda${cuda}-${BUILD_DATE}-amd64" \
-                "${REGISTRY}/${IMAGE_NAME}:velox-${VELOX_SHORT_SHA}-gpu-cuda${cuda}-${BUILD_DATE}-arm64"
+                "${REGISTRY}/${IMAGE_NAME}:velox-${VELOX_SHORT_SHA}-gpu-cuda${cuda}-${BUILD_DATE}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-amd64" \
+                "${REGISTRY}/${IMAGE_NAME}:velox-${VELOX_SHORT_SHA}-gpu-cuda${cuda}-${BUILD_DATE}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-arm64"
             done
             docker buildx imagetools create \
               -t "${REGISTRY}/${IMAGE_NAME}:velox-latest-cpu" \
-              "${REGISTRY}/${IMAGE_NAME}:velox-${VELOX_SHORT_SHA}-cpu-${BUILD_DATE}-amd64" \
-              "${REGISTRY}/${IMAGE_NAME}:velox-${VELOX_SHORT_SHA}-cpu-${BUILD_DATE}-arm64"
+              "${REGISTRY}/${IMAGE_NAME}:velox-${VELOX_SHORT_SHA}-cpu-${BUILD_DATE}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-amd64" \
+              "${REGISTRY}/${IMAGE_NAME}:velox-${VELOX_SHORT_SHA}-cpu-${BUILD_DATE}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-arm64"
           fi
       - name: Delete intermediate arch-specific tags
         continue-on-error: true
@@ -346,8 +371,8 @@ jobs:
           registry: ${{ env.REGISTRY }}
           image-name: ${{ env.IMAGE_NAME }}
           base-tags: |
-            velox-${{ inputs.velox_short_sha }}-gpu-cuda12.9-${{ inputs.date }}
-            velox-${{ inputs.velox_short_sha }}-gpu-cuda13.1-${{ inputs.date }}
-            velox-${{ inputs.velox_short_sha }}-cpu-${{ inputs.date }}
-            velox-deps-${{ inputs.velox_short_sha }}-cuda12.9-${{ inputs.date }}
-            velox-deps-${{ inputs.velox_short_sha }}-cuda13.1-${{ inputs.date }}
+            velox-${{ inputs.velox_short_sha }}-gpu-cuda12.9-${{ inputs.date }}-${{ inputs.github_run_id }}-${{ inputs.github_run_attempt }}
+            velox-${{ inputs.velox_short_sha }}-gpu-cuda13.1-${{ inputs.date }}-${{ inputs.github_run_id }}-${{ inputs.github_run_attempt }}
+            velox-${{ inputs.velox_short_sha }}-cpu-${{ inputs.date }}-${{ inputs.github_run_id }}-${{ inputs.github_run_attempt }}
+            velox-deps-${{ inputs.velox_short_sha }}-cuda12.9-${{ inputs.date }}-${{ inputs.github_run_id }}-${{ inputs.github_run_attempt }}
+            velox-deps-${{ inputs.velox_short_sha }}-cuda13.1-${{ inputs.date }}-${{ inputs.github_run_id }}-${{ inputs.github_run_attempt }}

--- a/.github/workflows/velox-build.yml
+++ b/.github/workflows/velox-build.yml
@@ -30,7 +30,7 @@ on:
         required: false
         default: 'manual'
       github_run_id:
-        description: 'GitHub Actions run ID used to make temporary tags unique'
+        description: 'Caller workflow run ID used to make temporary tags unique'
         type: string
         required: true
       run_id_suffix:

--- a/.github/workflows/velox-build.yml
+++ b/.github/workflows/velox-build.yml
@@ -29,15 +29,15 @@ on:
         type: string
         required: false
         default: 'manual'
-      github_run_id:
-        description: 'Caller workflow run ID used to make temporary tags unique'
-        type: string
-        required: true
       run_id_suffix:
         description: 'Optional run ID suffix appended to image tags'
         type: string
         required: false
         default: ''
+      intermediate_tag_suffix:
+        description: 'Run-scoped suffix appended to intermediate arch-specific tags'
+        type: string
+        required: true
 
 env:
   REGISTRY: ghcr.io
@@ -125,7 +125,7 @@ jobs:
           outputs: type=registry,compression=zstd,force-compression=true,compression-level=15
           push: true
           tags: |
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:velox-deps-${{ inputs.velox_short_sha }}-cuda${{ matrix.cuda_version }}-${{ inputs.date }}-${{ inputs.github_run_id }}-${{ matrix.arch }}
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:velox-deps-${{ inputs.velox_short_sha }}-cuda${{ matrix.cuda_version }}-${{ inputs.date }}${{ inputs.intermediate_tag_suffix }}-${{ matrix.arch }}
 
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@96278af6caaf10aea03fd8d33a09a777ca52d62f  # v3.2.0
@@ -216,26 +216,26 @@ jobs:
         env:
           VELOX_SHORT_SHA: ${{ inputs.velox_short_sha }}
           BUILD_DATE: ${{ inputs.date }}
-          GITHUB_RUN_ID: ${{ inputs.github_run_id }}
+          INTERMEDIATE_TAG_SUFFIX: ${{ inputs.intermediate_tag_suffix }}
           ARCH: ${{ matrix.arch }}
           CUDA: ${{ matrix.cuda_version || '12.9' }}
         run: |
-          echo "image=${REGISTRY}/${IMAGE_NAME}:velox-deps-${VELOX_SHORT_SHA}-cuda${CUDA}-${BUILD_DATE}-${GITHUB_RUN_ID}-${ARCH}" >> "$GITHUB_OUTPUT"
+          echo "image=${REGISTRY}/${IMAGE_NAME}:velox-deps-${VELOX_SHORT_SHA}-cuda${CUDA}-${BUILD_DATE}${INTERMEDIATE_TAG_SUFFIX}-${ARCH}" >> "$GITHUB_OUTPUT"
 
       - name: Determine image tag
         id: tag
         env:
           VELOX_SHORT_SHA: ${{ inputs.velox_short_sha }}
           BUILD_DATE: ${{ inputs.date }}
-          GITHUB_RUN_ID: ${{ inputs.github_run_id }}
+          INTERMEDIATE_TAG_SUFFIX: ${{ inputs.intermediate_tag_suffix }}
           ARCH: ${{ matrix.arch }}
           BUILD_TYPE: ${{ matrix.build_type }}
           CUDA_VERSION: ${{ matrix.cuda_version }}
         run: |
           if [[ "${BUILD_TYPE}" == "cpu" ]]; then
-            echo "tag=velox-${VELOX_SHORT_SHA}-cpu-${BUILD_DATE}-${GITHUB_RUN_ID}-${ARCH}" >> "$GITHUB_OUTPUT"
+            echo "tag=velox-${VELOX_SHORT_SHA}-cpu-${BUILD_DATE}${INTERMEDIATE_TAG_SUFFIX}-${ARCH}" >> "$GITHUB_OUTPUT"
           else
-            echo "tag=velox-${VELOX_SHORT_SHA}-gpu-cuda${CUDA_VERSION}-${BUILD_DATE}-${GITHUB_RUN_ID}-${ARCH}" >> "$GITHUB_OUTPUT"
+            echo "tag=velox-${VELOX_SHORT_SHA}-gpu-cuda${CUDA_VERSION}-${BUILD_DATE}${INTERMEDIATE_TAG_SUFFIX}-${ARCH}" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Build and push Velox image
@@ -288,16 +288,16 @@ jobs:
           BUILD_DATE: ${{ inputs.date }}
           BUILD_TYPE: ${{ inputs.build_type }}
           BUILD_VARIANT: ${{ inputs.build_variant }}
-          GITHUB_RUN_ID: ${{ inputs.github_run_id }}
           RUN_ID_SUFFIX: ${{ inputs.run_id_suffix }}
+          INTERMEDIATE_TAG_SUFFIX: ${{ inputs.intermediate_tag_suffix }}
         run: |
           create_manifest() {
             local tag="$1"
             local final_tag="$2"
             echo "Creating multi-arch manifest: ${tag}"
             docker buildx imagetools create -t "${REGISTRY}/${IMAGE_NAME}:${final_tag}" \
-              "${REGISTRY}/${IMAGE_NAME}:${tag}-${GITHUB_RUN_ID}-amd64" \
-              "${REGISTRY}/${IMAGE_NAME}:${tag}-${GITHUB_RUN_ID}-arm64"
+              "${REGISTRY}/${IMAGE_NAME}:${tag}${INTERMEDIATE_TAG_SUFFIX}-amd64" \
+              "${REGISTRY}/${IMAGE_NAME}:${tag}${INTERMEDIATE_TAG_SUFFIX}-arm64"
           }
           for cuda in 12.9 13.1; do
             tag="velox-deps-${VELOX_SHORT_SHA}-cuda${cuda}-${BUILD_DATE}"
@@ -307,8 +307,8 @@ jobs:
             for cuda in 12.9 13.1; do
               docker buildx imagetools create \
                 -t "${REGISTRY}/${IMAGE_NAME}:velox-deps-latest-cuda${cuda}" \
-                "${REGISTRY}/${IMAGE_NAME}:velox-deps-${VELOX_SHORT_SHA}-cuda${cuda}-${BUILD_DATE}-${GITHUB_RUN_ID}-amd64" \
-                "${REGISTRY}/${IMAGE_NAME}:velox-deps-${VELOX_SHORT_SHA}-cuda${cuda}-${BUILD_DATE}-${GITHUB_RUN_ID}-arm64"
+                "${REGISTRY}/${IMAGE_NAME}:velox-deps-${VELOX_SHORT_SHA}-cuda${cuda}-${BUILD_DATE}${INTERMEDIATE_TAG_SUFFIX}-amd64" \
+                "${REGISTRY}/${IMAGE_NAME}:velox-deps-${VELOX_SHORT_SHA}-cuda${cuda}-${BUILD_DATE}${INTERMEDIATE_TAG_SUFFIX}-arm64"
             done
           fi
   merge-velox-build:
@@ -330,16 +330,16 @@ jobs:
           BUILD_DATE: ${{ inputs.date }}
           BUILD_TYPE: ${{ inputs.build_type }}
           BUILD_VARIANT: ${{ inputs.build_variant }}
-          GITHUB_RUN_ID: ${{ inputs.github_run_id }}
           RUN_ID_SUFFIX: ${{ inputs.run_id_suffix }}
+          INTERMEDIATE_TAG_SUFFIX: ${{ inputs.intermediate_tag_suffix }}
         run: |
           create_manifest() {
             local tag="$1"
             local final_tag="$2"
             echo "Creating multi-arch manifest: ${tag}"
             docker buildx imagetools create -t "${REGISTRY}/${IMAGE_NAME}:${final_tag}" \
-              "${REGISTRY}/${IMAGE_NAME}:${tag}-${GITHUB_RUN_ID}-amd64" \
-              "${REGISTRY}/${IMAGE_NAME}:${tag}-${GITHUB_RUN_ID}-arm64"
+              "${REGISTRY}/${IMAGE_NAME}:${tag}${INTERMEDIATE_TAG_SUFFIX}-amd64" \
+              "${REGISTRY}/${IMAGE_NAME}:${tag}${INTERMEDIATE_TAG_SUFFIX}-arm64"
           }
           for cuda in 12.9 13.1; do
             tag="velox-${VELOX_SHORT_SHA}-gpu-cuda${cuda}-${BUILD_DATE}"
@@ -351,13 +351,13 @@ jobs:
             for cuda in 12.9 13.1; do
               docker buildx imagetools create \
                 -t "${REGISTRY}/${IMAGE_NAME}:velox-latest-gpu-cuda${cuda}" \
-                "${REGISTRY}/${IMAGE_NAME}:velox-${VELOX_SHORT_SHA}-gpu-cuda${cuda}-${BUILD_DATE}-${GITHUB_RUN_ID}-amd64" \
-                "${REGISTRY}/${IMAGE_NAME}:velox-${VELOX_SHORT_SHA}-gpu-cuda${cuda}-${BUILD_DATE}-${GITHUB_RUN_ID}-arm64"
+                "${REGISTRY}/${IMAGE_NAME}:velox-${VELOX_SHORT_SHA}-gpu-cuda${cuda}-${BUILD_DATE}${INTERMEDIATE_TAG_SUFFIX}-amd64" \
+                "${REGISTRY}/${IMAGE_NAME}:velox-${VELOX_SHORT_SHA}-gpu-cuda${cuda}-${BUILD_DATE}${INTERMEDIATE_TAG_SUFFIX}-arm64"
             done
             docker buildx imagetools create \
               -t "${REGISTRY}/${IMAGE_NAME}:velox-latest-cpu" \
-              "${REGISTRY}/${IMAGE_NAME}:velox-${VELOX_SHORT_SHA}-cpu-${BUILD_DATE}-${GITHUB_RUN_ID}-amd64" \
-              "${REGISTRY}/${IMAGE_NAME}:velox-${VELOX_SHORT_SHA}-cpu-${BUILD_DATE}-${GITHUB_RUN_ID}-arm64"
+              "${REGISTRY}/${IMAGE_NAME}:velox-${VELOX_SHORT_SHA}-cpu-${BUILD_DATE}${INTERMEDIATE_TAG_SUFFIX}-amd64" \
+              "${REGISTRY}/${IMAGE_NAME}:velox-${VELOX_SHORT_SHA}-cpu-${BUILD_DATE}${INTERMEDIATE_TAG_SUFFIX}-arm64"
           fi
       - name: Delete intermediate arch-specific tags
         continue-on-error: true
@@ -366,8 +366,8 @@ jobs:
           registry: ${{ env.REGISTRY }}
           image-name: ${{ env.IMAGE_NAME }}
           base-tags: |
-            velox-${{ inputs.velox_short_sha }}-gpu-cuda12.9-${{ inputs.date }}-${{ inputs.github_run_id }}
-            velox-${{ inputs.velox_short_sha }}-gpu-cuda13.1-${{ inputs.date }}-${{ inputs.github_run_id }}
-            velox-${{ inputs.velox_short_sha }}-cpu-${{ inputs.date }}-${{ inputs.github_run_id }}
-            velox-deps-${{ inputs.velox_short_sha }}-cuda12.9-${{ inputs.date }}-${{ inputs.github_run_id }}
-            velox-deps-${{ inputs.velox_short_sha }}-cuda13.1-${{ inputs.date }}-${{ inputs.github_run_id }}
+            velox-${{ inputs.velox_short_sha }}-gpu-cuda12.9-${{ inputs.date }}${{ inputs.intermediate_tag_suffix }}
+            velox-${{ inputs.velox_short_sha }}-gpu-cuda13.1-${{ inputs.date }}${{ inputs.intermediate_tag_suffix }}
+            velox-${{ inputs.velox_short_sha }}-cpu-${{ inputs.date }}${{ inputs.intermediate_tag_suffix }}
+            velox-deps-${{ inputs.velox_short_sha }}-cuda12.9-${{ inputs.date }}${{ inputs.intermediate_tag_suffix }}
+            velox-deps-${{ inputs.velox_short_sha }}-cuda13.1-${{ inputs.date }}${{ inputs.intermediate_tag_suffix }}

--- a/.github/workflows/velox-build.yml
+++ b/.github/workflows/velox-build.yml
@@ -25,20 +25,16 @@ on:
         required: false
         default: 'manual'
       build_variant:
-        description: 'One of: [upstream, staging, manual]'
+        description: 'One of: [upstream, manual]'
         type: string
         required: false
         default: 'manual'
       github_run_id:
-        description: 'GitHub Actions run ID used to isolate temporary tags'
+        description: 'GitHub Actions run ID used to make temporary tags unique'
         type: string
         required: true
-      github_run_attempt:
-        description: 'GitHub Actions run attempt used to isolate temporary tags'
-        type: string
-        required: true
-      final_image_tag_suffix:
-        description: 'Optional suffix appended to final multi-arch image tags'
+      final_run_id_suffix:
+        description: 'Optional run ID suffix appended to final multi-arch image tags'
         type: string
         required: false
         default: ''
@@ -129,7 +125,7 @@ jobs:
           outputs: type=registry,compression=zstd,force-compression=true,compression-level=15
           push: true
           tags: |
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:velox-deps-${{ inputs.velox_short_sha }}-cuda${{ matrix.cuda_version }}-${{ inputs.date }}-${{ inputs.github_run_id }}-${{ inputs.github_run_attempt }}-${{ matrix.arch }}
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:velox-deps-${{ inputs.velox_short_sha }}-cuda${{ matrix.cuda_version }}-${{ inputs.date }}-${{ inputs.github_run_id }}-${{ matrix.arch }}
 
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@96278af6caaf10aea03fd8d33a09a777ca52d62f  # v3.2.0
@@ -221,11 +217,10 @@ jobs:
           VELOX_SHORT_SHA: ${{ inputs.velox_short_sha }}
           BUILD_DATE: ${{ inputs.date }}
           GITHUB_RUN_ID: ${{ inputs.github_run_id }}
-          GITHUB_RUN_ATTEMPT: ${{ inputs.github_run_attempt }}
           ARCH: ${{ matrix.arch }}
           CUDA: ${{ matrix.cuda_version || '12.9' }}
         run: |
-          echo "image=${REGISTRY}/${IMAGE_NAME}:velox-deps-${VELOX_SHORT_SHA}-cuda${CUDA}-${BUILD_DATE}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${ARCH}" >> "$GITHUB_OUTPUT"
+          echo "image=${REGISTRY}/${IMAGE_NAME}:velox-deps-${VELOX_SHORT_SHA}-cuda${CUDA}-${BUILD_DATE}-${GITHUB_RUN_ID}-${ARCH}" >> "$GITHUB_OUTPUT"
 
       - name: Determine image tag
         id: tag
@@ -233,15 +228,14 @@ jobs:
           VELOX_SHORT_SHA: ${{ inputs.velox_short_sha }}
           BUILD_DATE: ${{ inputs.date }}
           GITHUB_RUN_ID: ${{ inputs.github_run_id }}
-          GITHUB_RUN_ATTEMPT: ${{ inputs.github_run_attempt }}
           ARCH: ${{ matrix.arch }}
           BUILD_TYPE: ${{ matrix.build_type }}
           CUDA_VERSION: ${{ matrix.cuda_version }}
         run: |
           if [[ "${BUILD_TYPE}" == "cpu" ]]; then
-            echo "tag=velox-${VELOX_SHORT_SHA}-cpu-${BUILD_DATE}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${ARCH}" >> "$GITHUB_OUTPUT"
+            echo "tag=velox-${VELOX_SHORT_SHA}-cpu-${BUILD_DATE}-${GITHUB_RUN_ID}-${ARCH}" >> "$GITHUB_OUTPUT"
           else
-            echo "tag=velox-${VELOX_SHORT_SHA}-gpu-cuda${CUDA_VERSION}-${BUILD_DATE}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${ARCH}" >> "$GITHUB_OUTPUT"
+            echo "tag=velox-${VELOX_SHORT_SHA}-gpu-cuda${CUDA_VERSION}-${BUILD_DATE}-${GITHUB_RUN_ID}-${ARCH}" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Build and push Velox image
@@ -295,26 +289,25 @@ jobs:
           BUILD_TYPE: ${{ inputs.build_type }}
           BUILD_VARIANT: ${{ inputs.build_variant }}
           GITHUB_RUN_ID: ${{ inputs.github_run_id }}
-          GITHUB_RUN_ATTEMPT: ${{ inputs.github_run_attempt }}
-          FINAL_IMAGE_TAG_SUFFIX: ${{ inputs.final_image_tag_suffix }}
+          FINAL_RUN_ID_SUFFIX: ${{ inputs.final_run_id_suffix }}
         run: |
           create_manifest() {
             local tag="$1"
-            local final_tag="${tag}${FINAL_IMAGE_TAG_SUFFIX}"
+            local final_tag="${tag}${FINAL_RUN_ID_SUFFIX}"
             echo "Creating multi-arch manifest: ${tag}"
             docker buildx imagetools create -t "${REGISTRY}/${IMAGE_NAME}:${final_tag}" \
-              "${REGISTRY}/${IMAGE_NAME}:${tag}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-amd64" \
-              "${REGISTRY}/${IMAGE_NAME}:${tag}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-arm64"
+              "${REGISTRY}/${IMAGE_NAME}:${tag}-${GITHUB_RUN_ID}-amd64" \
+              "${REGISTRY}/${IMAGE_NAME}:${tag}-${GITHUB_RUN_ID}-arm64"
           }
           for cuda in 12.9 13.1; do
             create_manifest "velox-deps-${VELOX_SHORT_SHA}-cuda${cuda}-${BUILD_DATE}"
           done
-          if [[ "${BUILD_TYPE}" == "nightly" && "${BUILD_VARIANT}" == "upstream" && -z "${FINAL_IMAGE_TAG_SUFFIX}" ]]; then
+          if [[ "${BUILD_TYPE}" == "nightly" && "${BUILD_VARIANT}" == "upstream" && -z "${FINAL_RUN_ID_SUFFIX}" ]]; then
             for cuda in 12.9 13.1; do
               docker buildx imagetools create \
                 -t "${REGISTRY}/${IMAGE_NAME}:velox-deps-latest-cuda${cuda}" \
-                "${REGISTRY}/${IMAGE_NAME}:velox-deps-${VELOX_SHORT_SHA}-cuda${cuda}-${BUILD_DATE}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-amd64" \
-                "${REGISTRY}/${IMAGE_NAME}:velox-deps-${VELOX_SHORT_SHA}-cuda${cuda}-${BUILD_DATE}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-arm64"
+                "${REGISTRY}/${IMAGE_NAME}:velox-deps-${VELOX_SHORT_SHA}-cuda${cuda}-${BUILD_DATE}-${GITHUB_RUN_ID}-amd64" \
+                "${REGISTRY}/${IMAGE_NAME}:velox-deps-${VELOX_SHORT_SHA}-cuda${cuda}-${BUILD_DATE}-${GITHUB_RUN_ID}-arm64"
             done
           fi
   merge-velox-build:
@@ -337,32 +330,31 @@ jobs:
           BUILD_TYPE: ${{ inputs.build_type }}
           BUILD_VARIANT: ${{ inputs.build_variant }}
           GITHUB_RUN_ID: ${{ inputs.github_run_id }}
-          GITHUB_RUN_ATTEMPT: ${{ inputs.github_run_attempt }}
-          FINAL_IMAGE_TAG_SUFFIX: ${{ inputs.final_image_tag_suffix }}
+          FINAL_RUN_ID_SUFFIX: ${{ inputs.final_run_id_suffix }}
         run: |
           create_manifest() {
             local tag="$1"
-            local final_tag="${tag}${FINAL_IMAGE_TAG_SUFFIX}"
+            local final_tag="${tag}${FINAL_RUN_ID_SUFFIX}"
             echo "Creating multi-arch manifest: ${tag}"
             docker buildx imagetools create -t "${REGISTRY}/${IMAGE_NAME}:${final_tag}" \
-              "${REGISTRY}/${IMAGE_NAME}:${tag}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-amd64" \
-              "${REGISTRY}/${IMAGE_NAME}:${tag}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-arm64"
+              "${REGISTRY}/${IMAGE_NAME}:${tag}-${GITHUB_RUN_ID}-amd64" \
+              "${REGISTRY}/${IMAGE_NAME}:${tag}-${GITHUB_RUN_ID}-arm64"
           }
           for cuda in 12.9 13.1; do
             create_manifest "velox-${VELOX_SHORT_SHA}-gpu-cuda${cuda}-${BUILD_DATE}"
           done
           create_manifest "velox-${VELOX_SHORT_SHA}-cpu-${BUILD_DATE}"
-          if [[ "${BUILD_TYPE}" == "nightly" && "${BUILD_VARIANT}" == "upstream" && -z "${FINAL_IMAGE_TAG_SUFFIX}" ]]; then
+          if [[ "${BUILD_TYPE}" == "nightly" && "${BUILD_VARIANT}" == "upstream" && -z "${FINAL_RUN_ID_SUFFIX}" ]]; then
             for cuda in 12.9 13.1; do
               docker buildx imagetools create \
                 -t "${REGISTRY}/${IMAGE_NAME}:velox-latest-gpu-cuda${cuda}" \
-                "${REGISTRY}/${IMAGE_NAME}:velox-${VELOX_SHORT_SHA}-gpu-cuda${cuda}-${BUILD_DATE}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-amd64" \
-                "${REGISTRY}/${IMAGE_NAME}:velox-${VELOX_SHORT_SHA}-gpu-cuda${cuda}-${BUILD_DATE}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-arm64"
+                "${REGISTRY}/${IMAGE_NAME}:velox-${VELOX_SHORT_SHA}-gpu-cuda${cuda}-${BUILD_DATE}-${GITHUB_RUN_ID}-amd64" \
+                "${REGISTRY}/${IMAGE_NAME}:velox-${VELOX_SHORT_SHA}-gpu-cuda${cuda}-${BUILD_DATE}-${GITHUB_RUN_ID}-arm64"
             done
             docker buildx imagetools create \
               -t "${REGISTRY}/${IMAGE_NAME}:velox-latest-cpu" \
-              "${REGISTRY}/${IMAGE_NAME}:velox-${VELOX_SHORT_SHA}-cpu-${BUILD_DATE}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-amd64" \
-              "${REGISTRY}/${IMAGE_NAME}:velox-${VELOX_SHORT_SHA}-cpu-${BUILD_DATE}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-arm64"
+              "${REGISTRY}/${IMAGE_NAME}:velox-${VELOX_SHORT_SHA}-cpu-${BUILD_DATE}-${GITHUB_RUN_ID}-amd64" \
+              "${REGISTRY}/${IMAGE_NAME}:velox-${VELOX_SHORT_SHA}-cpu-${BUILD_DATE}-${GITHUB_RUN_ID}-arm64"
           fi
       - name: Delete intermediate arch-specific tags
         continue-on-error: true
@@ -371,8 +363,8 @@ jobs:
           registry: ${{ env.REGISTRY }}
           image-name: ${{ env.IMAGE_NAME }}
           base-tags: |
-            velox-${{ inputs.velox_short_sha }}-gpu-cuda12.9-${{ inputs.date }}-${{ inputs.github_run_id }}-${{ inputs.github_run_attempt }}
-            velox-${{ inputs.velox_short_sha }}-gpu-cuda13.1-${{ inputs.date }}-${{ inputs.github_run_id }}-${{ inputs.github_run_attempt }}
-            velox-${{ inputs.velox_short_sha }}-cpu-${{ inputs.date }}-${{ inputs.github_run_id }}-${{ inputs.github_run_attempt }}
-            velox-deps-${{ inputs.velox_short_sha }}-cuda12.9-${{ inputs.date }}-${{ inputs.github_run_id }}-${{ inputs.github_run_attempt }}
-            velox-deps-${{ inputs.velox_short_sha }}-cuda13.1-${{ inputs.date }}-${{ inputs.github_run_id }}-${{ inputs.github_run_attempt }}
+            velox-${{ inputs.velox_short_sha }}-gpu-cuda12.9-${{ inputs.date }}-${{ inputs.github_run_id }}
+            velox-${{ inputs.velox_short_sha }}-gpu-cuda13.1-${{ inputs.date }}-${{ inputs.github_run_id }}
+            velox-${{ inputs.velox_short_sha }}-cpu-${{ inputs.date }}-${{ inputs.github_run_id }}
+            velox-deps-${{ inputs.velox_short_sha }}-cuda12.9-${{ inputs.date }}-${{ inputs.github_run_id }}
+            velox-deps-${{ inputs.velox_short_sha }}-cuda13.1-${{ inputs.date }}-${{ inputs.github_run_id }}

--- a/.github/workflows/velox-build.yml
+++ b/.github/workflows/velox-build.yml
@@ -33,8 +33,8 @@ on:
         description: 'GitHub Actions run ID used to make temporary tags unique'
         type: string
         required: true
-      final_run_id_suffix:
-        description: 'Optional run ID suffix appended to final multi-arch image tags'
+      run_id_suffix:
+        description: 'Optional run ID suffix appended to image tags'
         type: string
         required: false
         default: ''
@@ -289,20 +289,21 @@ jobs:
           BUILD_TYPE: ${{ inputs.build_type }}
           BUILD_VARIANT: ${{ inputs.build_variant }}
           GITHUB_RUN_ID: ${{ inputs.github_run_id }}
-          FINAL_RUN_ID_SUFFIX: ${{ inputs.final_run_id_suffix }}
+          RUN_ID_SUFFIX: ${{ inputs.run_id_suffix }}
         run: |
           create_manifest() {
             local tag="$1"
-            local final_tag="${tag}${FINAL_RUN_ID_SUFFIX}"
+            local final_tag="$2"
             echo "Creating multi-arch manifest: ${tag}"
             docker buildx imagetools create -t "${REGISTRY}/${IMAGE_NAME}:${final_tag}" \
               "${REGISTRY}/${IMAGE_NAME}:${tag}-${GITHUB_RUN_ID}-amd64" \
               "${REGISTRY}/${IMAGE_NAME}:${tag}-${GITHUB_RUN_ID}-arm64"
           }
           for cuda in 12.9 13.1; do
-            create_manifest "velox-deps-${VELOX_SHORT_SHA}-cuda${cuda}-${BUILD_DATE}"
+            tag="velox-deps-${VELOX_SHORT_SHA}-cuda${cuda}-${BUILD_DATE}"
+            create_manifest "${tag}" "${tag}${RUN_ID_SUFFIX}"
           done
-          if [[ "${BUILD_TYPE}" == "nightly" && "${BUILD_VARIANT}" == "upstream" && -z "${FINAL_RUN_ID_SUFFIX}" ]]; then
+          if [[ "${BUILD_TYPE}" == "nightly" && "${BUILD_VARIANT}" == "upstream" && -z "${RUN_ID_SUFFIX}" ]]; then
             for cuda in 12.9 13.1; do
               docker buildx imagetools create \
                 -t "${REGISTRY}/${IMAGE_NAME}:velox-deps-latest-cuda${cuda}" \
@@ -330,21 +331,23 @@ jobs:
           BUILD_TYPE: ${{ inputs.build_type }}
           BUILD_VARIANT: ${{ inputs.build_variant }}
           GITHUB_RUN_ID: ${{ inputs.github_run_id }}
-          FINAL_RUN_ID_SUFFIX: ${{ inputs.final_run_id_suffix }}
+          RUN_ID_SUFFIX: ${{ inputs.run_id_suffix }}
         run: |
           create_manifest() {
             local tag="$1"
-            local final_tag="${tag}${FINAL_RUN_ID_SUFFIX}"
+            local final_tag="$2"
             echo "Creating multi-arch manifest: ${tag}"
             docker buildx imagetools create -t "${REGISTRY}/${IMAGE_NAME}:${final_tag}" \
               "${REGISTRY}/${IMAGE_NAME}:${tag}-${GITHUB_RUN_ID}-amd64" \
               "${REGISTRY}/${IMAGE_NAME}:${tag}-${GITHUB_RUN_ID}-arm64"
           }
           for cuda in 12.9 13.1; do
-            create_manifest "velox-${VELOX_SHORT_SHA}-gpu-cuda${cuda}-${BUILD_DATE}"
+            tag="velox-${VELOX_SHORT_SHA}-gpu-cuda${cuda}-${BUILD_DATE}"
+            create_manifest "${tag}" "${tag}${RUN_ID_SUFFIX}"
           done
-          create_manifest "velox-${VELOX_SHORT_SHA}-cpu-${BUILD_DATE}"
-          if [[ "${BUILD_TYPE}" == "nightly" && "${BUILD_VARIANT}" == "upstream" && -z "${FINAL_RUN_ID_SUFFIX}" ]]; then
+          tag="velox-${VELOX_SHORT_SHA}-cpu-${BUILD_DATE}"
+          create_manifest "${tag}" "${tag}${RUN_ID_SUFFIX}"
+          if [[ "${BUILD_TYPE}" == "nightly" && "${BUILD_VARIANT}" == "upstream" && -z "${RUN_ID_SUFFIX}" ]]; then
             for cuda in 12.9 13.1; do
               docker buildx imagetools create \
                 -t "${REGISTRY}/${IMAGE_NAME}:velox-latest-gpu-cuda${cuda}" \

--- a/.github/workflows/velox-nightly.yml
+++ b/.github/workflows/velox-nightly.yml
@@ -12,7 +12,22 @@ concurrency:
 permissions: {}
 
 jobs:
+  resolve-run-id-suffix:
+    runs-on: ubuntu-latest
+    outputs:
+      run_id_suffix: ${{ steps.resolve.outputs.run_id_suffix }}
+    steps:
+      - name: Resolve run ID suffix
+        id: resolve
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            echo "run_id_suffix=-${{ github.run_id }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "run_id_suffix=" >> "$GITHUB_OUTPUT"
+          fi
+
   upstream:
+    needs: [resolve-run-id-suffix]
     permissions:
       contents: read
       id-token: write
@@ -27,5 +42,5 @@ jobs:
       run_tests: true
       build_type: nightly
       build_variant: upstream
-      run_id_suffix: ${{ github.event_name == 'workflow_dispatch' && format('-{0}', github.run_id) || '' }}
+      run_id_suffix: ${{ needs.resolve-run-id-suffix.outputs.run_id_suffix }}
     secrets: inherit  # zizmor: ignore[secrets-inherit]

--- a/.github/workflows/velox-nightly.yml
+++ b/.github/workflows/velox-nightly.yml
@@ -27,21 +27,5 @@ jobs:
       run_tests: true
       build_type: nightly
       build_variant: upstream
-    secrets: inherit  # zizmor: ignore[secrets-inherit]
-
-  staging:
-    permissions:
-      contents: read
-      id-token: write
-      packages: write
-      attestations: write
-      artifact-metadata: write
-    uses: ./.github/workflows/velox.yml
-    with:
-      variant_label: staging
-      velox_repository: ${{ vars.STABLE_VELOX_REPO }}
-      velox_commit: ${{ vars.STABLE_VELOX_COMMIT }}
-      run_tests: true
-      build_type: nightly
-      build_variant: staging
+      final_image_tag_suffix: ${{ github.event_name == 'workflow_dispatch' && format('-{0}', github.run_id) || '' }}
     secrets: inherit  # zizmor: ignore[secrets-inherit]

--- a/.github/workflows/velox-nightly.yml
+++ b/.github/workflows/velox-nightly.yml
@@ -27,5 +27,5 @@ jobs:
       run_tests: true
       build_type: nightly
       build_variant: upstream
-      final_image_tag_suffix: ${{ github.event_name == 'workflow_dispatch' && format('-{0}', github.run_id) || '' }}
+      final_run_id_suffix: ${{ github.event_name == 'workflow_dispatch' && format('-{0}', github.run_id) || '' }}
     secrets: inherit  # zizmor: ignore[secrets-inherit]

--- a/.github/workflows/velox-nightly.yml
+++ b/.github/workflows/velox-nightly.yml
@@ -27,5 +27,5 @@ jobs:
       run_tests: true
       build_type: nightly
       build_variant: upstream
-      final_run_id_suffix: ${{ github.event_name == 'workflow_dispatch' && format('-{0}', github.run_id) || '' }}
+      run_id_suffix: ${{ github.event_name == 'workflow_dispatch' && format('-{0}', github.run_id) || '' }}
     secrets: inherit  # zizmor: ignore[secrets-inherit]

--- a/.github/workflows/velox-test.yml
+++ b/.github/workflows/velox-test.yml
@@ -11,8 +11,8 @@ on:
         description: 'Build date (YYYYMMDD)'
         type: string
         required: true
-      image_tag_suffix:
-        description: 'Optional suffix appended to Velox image tags'
+      run_id_suffix:
+        description: 'Optional run ID suffix appended to Velox image tags'
         type: string
         required: false
         default: ''
@@ -34,8 +34,8 @@ on:
         type: string
         required: false
         default: ''
-      image_tag_suffix:
-        description: 'Optional suffix appended to Velox image tags'
+      run_id_suffix:
+        description: 'Optional run ID suffix appended to Velox image tags'
         type: string
         required: false
         default: ''
@@ -53,7 +53,7 @@ jobs:
       velox_short_sha: ${{ steps.resolve.outputs.velox_short_sha }}
       presto_short_sha: ${{ steps.resolve.outputs.presto_short_sha }}
       date: ${{ steps.resolve.outputs.date }}
-      image_tag_suffix: ${{ inputs.image_tag_suffix || steps.resolve.outputs.image_tag_suffix }}
+      run_id_suffix: ${{ inputs.run_id_suffix || steps.resolve.outputs.run_id_suffix }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
@@ -93,9 +93,9 @@ jobs:
           VELOX_SHORT_SHA: ${{ needs.resolve-inputs.outputs.velox_short_sha }}
           BUILD_DATE: ${{ needs.resolve-inputs.outputs.date }}
           IMAGE_TAG: ${{ matrix.image_tag }}
-          IMAGE_TAG_SUFFIX: ${{ needs.resolve-inputs.outputs.image_tag_suffix }}
+          RUN_ID_SUFFIX: ${{ needs.resolve-inputs.outputs.run_id_suffix }}
         run: |
-          IMAGE="${REGISTRY}/${IMAGE_NAME}:velox-${VELOX_SHORT_SHA}-${IMAGE_TAG}-${BUILD_DATE}${IMAGE_TAG_SUFFIX}"
+          IMAGE="${REGISTRY}/${IMAGE_NAME}:velox-${VELOX_SHORT_SHA}-${IMAGE_TAG}-${BUILD_DATE}${RUN_ID_SUFFIX}"
           echo "Testing image: ${IMAGE}"
           docker pull "${IMAGE}"
           docker run --rm "${IMAGE}" bash -c \
@@ -156,9 +156,9 @@ jobs:
           VELOX_SHORT_SHA: ${{ needs.resolve-inputs.outputs.velox_short_sha }}
           BUILD_DATE: ${{ needs.resolve-inputs.outputs.date }}
           IMAGE_TAG: ${{ matrix.image_tag }}
-          IMAGE_TAG_SUFFIX: ${{ needs.resolve-inputs.outputs.image_tag_suffix }}
+          RUN_ID_SUFFIX: ${{ needs.resolve-inputs.outputs.run_id_suffix }}
         run: |
-          IMAGE="${REGISTRY}/${IMAGE_NAME}:velox-${VELOX_SHORT_SHA}-gpu-cuda${IMAGE_TAG}-${BUILD_DATE}${IMAGE_TAG_SUFFIX}"
+          IMAGE="${REGISTRY}/${IMAGE_NAME}:velox-${VELOX_SHORT_SHA}-gpu-cuda${IMAGE_TAG}-${BUILD_DATE}${RUN_ID_SUFFIX}"
           echo "Testing image: ${IMAGE}"
           docker pull "${IMAGE}"
           docker run --rm --gpus all "${IMAGE}" bash -c \

--- a/.github/workflows/velox-test.yml
+++ b/.github/workflows/velox-test.yml
@@ -11,6 +11,11 @@ on:
         description: 'Build date (YYYYMMDD)'
         type: string
         required: true
+      image_tag_suffix:
+        description: 'Optional suffix appended to Velox image tags'
+        type: string
+        required: false
+        default: ''
 
   workflow_dispatch:
     inputs:
@@ -29,6 +34,11 @@ on:
         type: string
         required: false
         default: ''
+      image_tag_suffix:
+        description: 'Optional suffix appended to Velox image tags'
+        type: string
+        required: false
+        default: ''
 
 env:
   REGISTRY: ghcr.io
@@ -43,6 +53,7 @@ jobs:
       velox_short_sha: ${{ steps.resolve.outputs.velox_short_sha }}
       presto_short_sha: ${{ steps.resolve.outputs.presto_short_sha }}
       date: ${{ steps.resolve.outputs.date }}
+      image_tag_suffix: ${{ inputs.image_tag_suffix || steps.resolve.outputs.image_tag_suffix }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
@@ -82,8 +93,9 @@ jobs:
           VELOX_SHORT_SHA: ${{ needs.resolve-inputs.outputs.velox_short_sha }}
           BUILD_DATE: ${{ needs.resolve-inputs.outputs.date }}
           IMAGE_TAG: ${{ matrix.image_tag }}
+          IMAGE_TAG_SUFFIX: ${{ needs.resolve-inputs.outputs.image_tag_suffix }}
         run: |
-          IMAGE="${REGISTRY}/${IMAGE_NAME}:velox-${VELOX_SHORT_SHA}-${IMAGE_TAG}-${BUILD_DATE}"
+          IMAGE="${REGISTRY}/${IMAGE_NAME}:velox-${VELOX_SHORT_SHA}-${IMAGE_TAG}-${BUILD_DATE}${IMAGE_TAG_SUFFIX}"
           echo "Testing image: ${IMAGE}"
           docker pull "${IMAGE}"
           docker run --rm "${IMAGE}" bash -c \
@@ -144,8 +156,9 @@ jobs:
           VELOX_SHORT_SHA: ${{ needs.resolve-inputs.outputs.velox_short_sha }}
           BUILD_DATE: ${{ needs.resolve-inputs.outputs.date }}
           IMAGE_TAG: ${{ matrix.image_tag }}
+          IMAGE_TAG_SUFFIX: ${{ needs.resolve-inputs.outputs.image_tag_suffix }}
         run: |
-          IMAGE="${REGISTRY}/${IMAGE_NAME}:velox-${VELOX_SHORT_SHA}-gpu-cuda${IMAGE_TAG}-${BUILD_DATE}"
+          IMAGE="${REGISTRY}/${IMAGE_NAME}:velox-${VELOX_SHORT_SHA}-gpu-cuda${IMAGE_TAG}-${BUILD_DATE}${IMAGE_TAG_SUFFIX}"
           echo "Testing image: ${IMAGE}"
           docker pull "${IMAGE}"
           docker run --rm --gpus all "${IMAGE}" bash -c \

--- a/.github/workflows/velox.yml
+++ b/.github/workflows/velox.yml
@@ -52,6 +52,24 @@ on:
 permissions: {}
 
 jobs:
+  resolve-run-id-suffix:
+    runs-on: ubuntu-latest
+    outputs:
+      run_id_suffix: ${{ steps.resolve.outputs.run_id_suffix }}
+    steps:
+      - name: Resolve run ID suffix
+        id: resolve
+        env:
+          INPUT_RUN_ID_SUFFIX: ${{ inputs.run_id_suffix || '' }}
+        run: |
+          if [[ -n "${INPUT_RUN_ID_SUFFIX}" ]]; then
+            echo "run_id_suffix=${INPUT_RUN_ID_SUFFIX}" >> "$GITHUB_OUTPUT"
+          elif [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            echo "run_id_suffix=-${{ github.run_id }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "run_id_suffix=" >> "$GITHUB_OUTPUT"
+          fi
+
   resolve-commits:
     runs-on: ubuntu-latest
     permissions:
@@ -72,7 +90,7 @@ jobs:
           github_token: ${{ github.token }}
 
   velox-build:
-    needs: [resolve-commits]
+    needs: [resolve-commits, resolve-run-id-suffix]
     permissions:
       contents: read
       id-token: write
@@ -88,11 +106,11 @@ jobs:
       build_type: ${{ inputs.build_type }}
       build_variant: ${{ inputs.build_variant }}
       github_run_id: ${{ github.run_id }}
-      run_id_suffix: ${{ inputs.run_id_suffix || (github.event_name == 'workflow_dispatch' && format('-{0}', github.run_id) || '') }}
+      run_id_suffix: ${{ needs.resolve-run-id-suffix.outputs.run_id_suffix }}
     secrets: inherit  # zizmor: ignore[secrets-inherit]
 
   velox-test:
-    needs: [resolve-commits, velox-build]
+    needs: [resolve-commits, resolve-run-id-suffix, velox-build]
     if: ${{ inputs.run_tests }}
     permissions:
       contents: read
@@ -101,10 +119,10 @@ jobs:
     with:
       velox_short_sha: ${{ needs.resolve-commits.outputs.velox_short_sha }}
       date: ${{ needs.resolve-commits.outputs.date }}
-      run_id_suffix: ${{ inputs.run_id_suffix || (github.event_name == 'workflow_dispatch' && format('-{0}', github.run_id) || '') }}
+      run_id_suffix: ${{ needs.resolve-run-id-suffix.outputs.run_id_suffix }}
 
   velox-benchmark:
-    needs: [resolve-commits, velox-build]
+    needs: [resolve-commits, resolve-run-id-suffix, velox-build]
     permissions:
       contents: read
       packages: read
@@ -112,5 +130,5 @@ jobs:
     with:
       velox_short_sha: ${{ needs.resolve-commits.outputs.velox_short_sha }}
       date: ${{ needs.resolve-commits.outputs.date }}
-      run_id_suffix: ${{ inputs.run_id_suffix || (github.event_name == 'workflow_dispatch' && format('-{0}', github.run_id) || '') }}
+      run_id_suffix: ${{ needs.resolve-run-id-suffix.outputs.run_id_suffix }}
       variant_label: ${{ inputs.variant_label }}

--- a/.github/workflows/velox.yml
+++ b/.github/workflows/velox.yml
@@ -43,6 +43,11 @@ on:
       run_tests: *run_tests
       build_type: *build_type
       build_variant: *build_variant
+      final_image_tag_suffix:
+        description: 'Optional suffix appended to final multi-arch image tags'
+        type: string
+        required: false
+        default: ''
 
 permissions: {}
 
@@ -82,6 +87,9 @@ jobs:
       date: ${{ needs.resolve-commits.outputs.date }}
       build_type: ${{ inputs.build_type }}
       build_variant: ${{ inputs.build_variant }}
+      github_run_id: ${{ github.run_id }}
+      github_run_attempt: ${{ github.run_attempt }}
+      final_image_tag_suffix: ${{ inputs.final_image_tag_suffix || (github.event_name == 'workflow_dispatch' && format('-{0}', github.run_id) || '') }}
     secrets: inherit  # zizmor: ignore[secrets-inherit]
 
   velox-test:
@@ -94,6 +102,7 @@ jobs:
     with:
       velox_short_sha: ${{ needs.resolve-commits.outputs.velox_short_sha }}
       date: ${{ needs.resolve-commits.outputs.date }}
+      image_tag_suffix: ${{ inputs.final_image_tag_suffix || (github.event_name == 'workflow_dispatch' && format('-{0}', github.run_id) || '') }}
 
   velox-benchmark:
     needs: [resolve-commits, velox-build]
@@ -104,4 +113,5 @@ jobs:
     with:
       velox_short_sha: ${{ needs.resolve-commits.outputs.velox_short_sha }}
       date: ${{ needs.resolve-commits.outputs.date }}
+      image_tag_suffix: ${{ inputs.final_image_tag_suffix || (github.event_name == 'workflow_dispatch' && format('-{0}', github.run_id) || '') }}
       variant_label: ${{ inputs.variant_label }}

--- a/.github/workflows/velox.yml
+++ b/.github/workflows/velox.yml
@@ -56,11 +56,16 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       run_id_suffix: ${{ steps.resolve.outputs.run_id_suffix }}
+      intermediate_tag_suffix: ${{ steps.resolve.outputs.intermediate_tag_suffix }}
     steps:
       - name: Resolve run ID suffix
         id: resolve
         env:
           INPUT_RUN_ID_SUFFIX: ${{ inputs.run_id_suffix || '' }}
+          VARIANT_LABEL: ${{ inputs.variant_label || '' }}
+          BUILD_VARIANT: ${{ inputs.build_variant || '' }}
+          GITHUB_RUN_ID_VALUE: ${{ github.run_id }}
+          GITHUB_RUN_ATTEMPT_VALUE: ${{ github.run_attempt }}
         run: |
           if [[ -n "${INPUT_RUN_ID_SUFFIX}" ]]; then
             echo "run_id_suffix=${INPUT_RUN_ID_SUFFIX}" >> "$GITHUB_OUTPUT"
@@ -69,6 +74,17 @@ jobs:
           else
             echo "run_id_suffix=" >> "$GITHUB_OUTPUT"
           fi
+
+          label="$(printf '%s' "${VARIANT_LABEL:-${BUILD_VARIANT:-manual}}" \
+            | tr '[:upper:]' '[:lower:]' \
+            | sed -E 's/[^a-z0-9_.-]+/-/g; s/^-+//; s/-+$//; s/-+/-/g' \
+            | cut -c1-40 \
+            | sed -E 's/^-+//; s/-+$//')"
+          if [[ -z "${label}" ]]; then
+            label="manual"
+          fi
+          namespace="${GITHUB_RUN_ID_VALUE}-${GITHUB_RUN_ATTEMPT_VALUE}-${label}"
+          echo "intermediate_tag_suffix=-${namespace}" >> "$GITHUB_OUTPUT"
 
   resolve-commits:
     runs-on: ubuntu-latest
@@ -105,8 +121,8 @@ jobs:
       date: ${{ needs.resolve-commits.outputs.date }}
       build_type: ${{ inputs.build_type }}
       build_variant: ${{ inputs.build_variant }}
-      github_run_id: ${{ github.run_id }}
       run_id_suffix: ${{ needs.resolve-run-id-suffix.outputs.run_id_suffix }}
+      intermediate_tag_suffix: ${{ needs.resolve-run-id-suffix.outputs.intermediate_tag_suffix }}
     secrets: inherit  # zizmor: ignore[secrets-inherit]
 
   velox-test:

--- a/.github/workflows/velox.yml
+++ b/.github/workflows/velox.yml
@@ -43,8 +43,8 @@ on:
       run_tests: *run_tests
       build_type: *build_type
       build_variant: *build_variant
-      final_run_id_suffix:
-        description: 'Optional run ID suffix appended to final multi-arch image tags'
+      run_id_suffix:
+        description: 'Optional run ID suffix appended to image tags'
         type: string
         required: false
         default: ''
@@ -88,7 +88,7 @@ jobs:
       build_type: ${{ inputs.build_type }}
       build_variant: ${{ inputs.build_variant }}
       github_run_id: ${{ github.run_id }}
-      final_run_id_suffix: ${{ inputs.final_run_id_suffix || (github.event_name == 'workflow_dispatch' && format('-{0}', github.run_id) || '') }}
+      run_id_suffix: ${{ inputs.run_id_suffix || (github.event_name == 'workflow_dispatch' && format('-{0}', github.run_id) || '') }}
     secrets: inherit  # zizmor: ignore[secrets-inherit]
 
   velox-test:
@@ -101,7 +101,7 @@ jobs:
     with:
       velox_short_sha: ${{ needs.resolve-commits.outputs.velox_short_sha }}
       date: ${{ needs.resolve-commits.outputs.date }}
-      run_id_suffix: ${{ inputs.final_run_id_suffix || (github.event_name == 'workflow_dispatch' && format('-{0}', github.run_id) || '') }}
+      run_id_suffix: ${{ inputs.run_id_suffix || (github.event_name == 'workflow_dispatch' && format('-{0}', github.run_id) || '') }}
 
   velox-benchmark:
     needs: [resolve-commits, velox-build]
@@ -112,5 +112,5 @@ jobs:
     with:
       velox_short_sha: ${{ needs.resolve-commits.outputs.velox_short_sha }}
       date: ${{ needs.resolve-commits.outputs.date }}
-      run_id_suffix: ${{ inputs.final_run_id_suffix || (github.event_name == 'workflow_dispatch' && format('-{0}', github.run_id) || '') }}
+      run_id_suffix: ${{ inputs.run_id_suffix || (github.event_name == 'workflow_dispatch' && format('-{0}', github.run_id) || '') }}
       variant_label: ${{ inputs.variant_label }}

--- a/.github/workflows/velox.yml
+++ b/.github/workflows/velox.yml
@@ -30,7 +30,7 @@ on:
         required: false
         default: 'manual'
       build_variant: &build_variant
-        description: 'One of: [upstream, staging, manual]'
+        description: 'One of: [upstream, manual]'
         type: string
         required: false
         default: 'manual'
@@ -43,8 +43,8 @@ on:
       run_tests: *run_tests
       build_type: *build_type
       build_variant: *build_variant
-      final_image_tag_suffix:
-        description: 'Optional suffix appended to final multi-arch image tags'
+      final_run_id_suffix:
+        description: 'Optional run ID suffix appended to final multi-arch image tags'
         type: string
         required: false
         default: ''
@@ -88,8 +88,7 @@ jobs:
       build_type: ${{ inputs.build_type }}
       build_variant: ${{ inputs.build_variant }}
       github_run_id: ${{ github.run_id }}
-      github_run_attempt: ${{ github.run_attempt }}
-      final_image_tag_suffix: ${{ inputs.final_image_tag_suffix || (github.event_name == 'workflow_dispatch' && format('-{0}', github.run_id) || '') }}
+      final_run_id_suffix: ${{ inputs.final_run_id_suffix || (github.event_name == 'workflow_dispatch' && format('-{0}', github.run_id) || '') }}
     secrets: inherit  # zizmor: ignore[secrets-inherit]
 
   velox-test:
@@ -102,7 +101,7 @@ jobs:
     with:
       velox_short_sha: ${{ needs.resolve-commits.outputs.velox_short_sha }}
       date: ${{ needs.resolve-commits.outputs.date }}
-      image_tag_suffix: ${{ inputs.final_image_tag_suffix || (github.event_name == 'workflow_dispatch' && format('-{0}', github.run_id) || '') }}
+      run_id_suffix: ${{ inputs.final_run_id_suffix || (github.event_name == 'workflow_dispatch' && format('-{0}', github.run_id) || '') }}
 
   velox-benchmark:
     needs: [resolve-commits, velox-build]
@@ -113,5 +112,5 @@ jobs:
     with:
       velox_short_sha: ${{ needs.resolve-commits.outputs.velox_short_sha }}
       date: ${{ needs.resolve-commits.outputs.date }}
-      image_tag_suffix: ${{ inputs.final_image_tag_suffix || (github.event_name == 'workflow_dispatch' && format('-{0}', github.run_id) || '') }}
+      run_id_suffix: ${{ inputs.final_run_id_suffix || (github.event_name == 'workflow_dispatch' && format('-{0}', github.run_id) || '') }}
       variant_label: ${{ inputs.variant_label }}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Builds on #333 by replacing run-ID-only intermediate tags with a per-call suffix that includes run ID, run attempt, and sanitized/truncated variant label.
- Keeps scheduled nightly final image tags stable and manual final image tags run-ID suffixed.
- Updates merge-manifest inputs and arch-tag cleanup to use the same per-call intermediate suffix.

## Validation
- Parsed workflow YAML files with PyYAML.
- Checked suffix sanitization for representative labels.
- Checked intermediate suffix propagation through Velox/Presto build, merge, and cleanup references.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://nvidia.slack.com/archives/C09KKD896EQ/p1778672744232989?thread_ts=1778672744.232989&cid=C09KKD896EQ)

<div><a href="https://cursor.com/agents/bc-5d764ef2-043d-57e8-bda7-d8e1ebf92d01"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5d764ef2-043d-57e8-bda7-d8e1ebf92d01"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

