### PR TITLE
enable auto-mergers

### DIFF
--- a/.github/ops-bot.yaml
+++ b/.github/ops-bot.yaml
@@ -1,0 +1,9 @@
+# This file controls which features from the `ops-bot` repository below are enabled.
+# - https://github.com/rapidsai/ops-bot
+
+auto_merger: true
+branch_checker: false
+label_checker: false
+release_drafter: false
+forward_merger: false
+merge_barriers: true


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/github-infrastructure/issues/115 (private issue, sorry)

Enables the RAPIDS ops-bot (docs: https://docs.rapids.ai/resources/auto-merger/).

Once this is merged, merging PRs here will require commenting `/merge` instead of clicking a button.

## Benefits of this change

* can "queue" a merge (no need to wait for CI to finish to click a button)
* standardized commit message and merge type (squash)
* makes this work like most other RAPIDS repos