### PR TITLE
Fix manual run IDs and speed up arch tag cleanup

### DIFF
--- a/.github/actions/delete-arch-tags/action.yml
+++ b/.github/actions/delete-arch-tags/action.yml
@@ -23,10 +23,13 @@ runs:
         IMAGE_NAME: ${{ inputs.image-name }}
         GITHUB_TOKEN: ${{ github.token }}
       run: |
-        # Process each base tag line
+        tags=()
         while IFS= read -r base_tag; do
           [[ -z "${base_tag}" ]] && continue
           for arch in amd64 arm64; do
-            ./ci/delete-arch-tags.sh "${base_tag}-${arch}"
+            tags+=("${base_tag}-${arch}")
           done
         done <<< "${BASE_TAGS}"
+        if [[ "${#tags[@]}" -gt 0 ]]; then
+          ./ci/delete-arch-tags.sh "${tags[@]}"
+        fi

--- a/.github/workflows/presto-build.yml
+++ b/.github/workflows/presto-build.yml
@@ -219,7 +219,7 @@ jobs:
 
   presto-build:
     name: presto-build (${{ matrix.build_type }}, ${{ matrix.arch }})
-    needs: [presto-deps]
+    needs: [merge-presto-deps]
     runs-on: linux-${{ matrix.arch }}-cpu32
     permissions:
       contents: read
@@ -296,10 +296,9 @@ jobs:
           BUILD_DATE: ${{ inputs.date }}
           BUILD_VARIANT: ${{ inputs.build_variant }}
           GITHUB_RUN_ID: ${{ github.run_id }}
-          ARCH: ${{ matrix.arch }}
           CUDA: ${{ matrix.cuda_version || '12.9' }}
         run: |
-          echo "image=${REGISTRY}/${IMAGE_NAME}:presto-deps-${PRESTO_SHORT_SHA}-velox-${VELOX_SHORT_SHA}-cuda${CUDA}-${BUILD_DATE}-${BUILD_VARIANT}-${GITHUB_RUN_ID}-${ARCH}" >> "$GITHUB_OUTPUT"
+          echo "image=${REGISTRY}/${IMAGE_NAME}:presto-deps-${PRESTO_SHORT_SHA}-velox-${VELOX_SHORT_SHA}-cuda${CUDA}-${BUILD_DATE}-${BUILD_VARIANT}-${GITHUB_RUN_ID}" >> "$GITHUB_OUTPUT"
 
       - name: Determine image tag
         id: tag
@@ -357,7 +356,7 @@ jobs:
 
   merge-presto-deps:
     name: merge-manifests (presto-deps)
-    needs: [presto-deps, presto-build]
+    needs: [presto-deps]
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/presto-build.yml
+++ b/.github/workflows/presto-build.yml
@@ -357,7 +357,7 @@ jobs:
 
   merge-presto-deps:
     name: merge-manifests (presto-deps)
-    needs: [presto-deps]
+    needs: [presto-deps, presto-build]
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -393,6 +393,15 @@ jobs:
               create_manifest_alias "${tag}" "presto-deps-latest-cuda${cuda}"
             done
           fi
+      - name: Delete intermediate arch-specific tags
+        continue-on-error: true
+        uses: ./.github/actions/delete-arch-tags
+        with:
+          registry: ${{ env.REGISTRY }}
+          image-name: ${{ env.IMAGE_NAME }}
+          base-tags: |
+            presto-deps-${{ inputs.presto_short_sha }}-velox-${{ inputs.velox_short_sha }}-cuda12.9-${{ inputs.date }}-${{ inputs.build_variant }}-${{ github.run_id }}
+            presto-deps-${{ inputs.presto_short_sha }}-velox-${{ inputs.velox_short_sha }}-cuda13.1-${{ inputs.date }}-${{ inputs.build_variant }}-${{ github.run_id }}
   merge-presto-build:
     name: merge-manifests (presto-build)
     needs: [presto-build]
@@ -445,8 +454,6 @@ jobs:
             presto-${{ inputs.presto_short_sha }}-velox-${{ inputs.velox_short_sha }}-gpu-cuda12.9-${{ inputs.date }}-${{ inputs.build_variant }}-${{ github.run_id }}
             presto-${{ inputs.presto_short_sha }}-velox-${{ inputs.velox_short_sha }}-gpu-cuda13.1-${{ inputs.date }}-${{ inputs.build_variant }}-${{ github.run_id }}
             presto-${{ inputs.presto_short_sha }}-velox-${{ inputs.velox_short_sha }}-cpu-${{ inputs.date }}-${{ inputs.build_variant }}-${{ github.run_id }}
-            presto-deps-${{ inputs.presto_short_sha }}-velox-${{ inputs.velox_short_sha }}-cuda12.9-${{ inputs.date }}-${{ inputs.build_variant }}-${{ github.run_id }}
-            presto-deps-${{ inputs.presto_short_sha }}-velox-${{ inputs.velox_short_sha }}-cuda13.1-${{ inputs.date }}-${{ inputs.build_variant }}-${{ github.run_id }}
 
   merge-presto-coordinator:
     name: merge-manifests (presto-coordinator)

--- a/.github/workflows/presto-test.yml
+++ b/.github/workflows/presto-test.yml
@@ -19,6 +19,11 @@ on:
         description: 'Build variant used in final image tags'
         type: string
         required: true
+      run_id:
+        description: 'GitHub run ID for manual build image tags'
+        type: string
+        required: false
+        default: ''
   workflow_dispatch:
     inputs:
       velox_short_sha:

--- a/.github/workflows/presto.yml
+++ b/.github/workflows/presto.yml
@@ -115,3 +115,4 @@ jobs:
       presto_short_sha: ${{ needs.resolve-commits.outputs.presto_short_sha }}
       date: ${{ needs.resolve-commits.outputs.date }}
       build_variant: ${{ inputs.build_variant }}
+      run_id: ${{ github.run_id }}

--- a/.github/workflows/velox-benchmark.yml
+++ b/.github/workflows/velox-benchmark.yml
@@ -15,6 +15,11 @@ on:
         description: 'Build variant used in final image tags'
         type: string
         required: true
+      run_id:
+        description: 'GitHub run ID for manual build image tags'
+        type: string
+        required: false
+        default: ''
   workflow_dispatch:
     inputs:
       velox_short_sha:

--- a/.github/workflows/velox-build.yml
+++ b/.github/workflows/velox-build.yml
@@ -119,7 +119,7 @@ jobs:
 
   velox-build:
     name: velox-build (${{ matrix.build_type }}, ${{ matrix.arch }})
-    needs: [velox-deps]
+    needs: [merge-velox-deps]
     runs-on: linux-${{ matrix.arch }}-cpu32
     permissions:
       contents: read
@@ -200,10 +200,9 @@ jobs:
           BUILD_DATE: ${{ inputs.date }}
           BUILD_VARIANT: ${{ inputs.build_variant }}
           GITHUB_RUN_ID: ${{ github.run_id }}
-          ARCH: ${{ matrix.arch }}
           CUDA: ${{ matrix.cuda_version || '12.9' }}
         run: |
-          echo "image=${REGISTRY}/${IMAGE_NAME}:velox-deps-${VELOX_SHORT_SHA}-cuda${CUDA}-${BUILD_DATE}-${BUILD_VARIANT}-${GITHUB_RUN_ID}-${ARCH}" >> "$GITHUB_OUTPUT"
+          echo "image=${REGISTRY}/${IMAGE_NAME}:velox-deps-${VELOX_SHORT_SHA}-cuda${CUDA}-${BUILD_DATE}-${BUILD_VARIANT}-${GITHUB_RUN_ID}" >> "$GITHUB_OUTPUT"
 
       - name: Determine image tag
         id: tag
@@ -255,7 +254,7 @@ jobs:
 
   merge-velox-deps:
     name: merge-manifests (velox-deps)
-    needs: [velox-deps, velox-build]
+    needs: [velox-deps]
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/velox-build.yml
+++ b/.github/workflows/velox-build.yml
@@ -255,7 +255,7 @@ jobs:
 
   merge-velox-deps:
     name: merge-manifests (velox-deps)
-    needs: [velox-deps]
+    needs: [velox-deps, velox-build]
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -285,6 +285,15 @@ jobs:
               create_manifest_alias "${tag}" "velox-deps-latest-cuda${cuda}"
             done
           fi
+      - name: Delete intermediate arch-specific tags
+        continue-on-error: true
+        uses: ./.github/actions/delete-arch-tags
+        with:
+          registry: ${{ env.REGISTRY }}
+          image-name: ${{ env.IMAGE_NAME }}
+          base-tags: |
+            velox-deps-${{ inputs.velox_short_sha }}-cuda12.9-${{ inputs.date }}-${{ inputs.build_variant }}-${{ github.run_id }}
+            velox-deps-${{ inputs.velox_short_sha }}-cuda13.1-${{ inputs.date }}-${{ inputs.build_variant }}-${{ github.run_id }}
   merge-velox-build:
     name: merge-manifests (velox-build)
     needs: [velox-build]
@@ -331,5 +340,3 @@ jobs:
             velox-${{ inputs.velox_short_sha }}-gpu-cuda12.9-${{ inputs.date }}-${{ inputs.build_variant }}-${{ github.run_id }}
             velox-${{ inputs.velox_short_sha }}-gpu-cuda13.1-${{ inputs.date }}-${{ inputs.build_variant }}-${{ github.run_id }}
             velox-${{ inputs.velox_short_sha }}-cpu-${{ inputs.date }}-${{ inputs.build_variant }}-${{ github.run_id }}
-            velox-deps-${{ inputs.velox_short_sha }}-cuda12.9-${{ inputs.date }}-${{ inputs.build_variant }}-${{ github.run_id }}
-            velox-deps-${{ inputs.velox_short_sha }}-cuda13.1-${{ inputs.date }}-${{ inputs.build_variant }}-${{ github.run_id }}

--- a/.github/workflows/velox-test.yml
+++ b/.github/workflows/velox-test.yml
@@ -15,6 +15,11 @@ on:
         description: 'Build variant used in final image tags'
         type: string
         required: true
+      run_id:
+        description: 'GitHub run ID for manual build image tags'
+        type: string
+        required: false
+        default: ''
   workflow_dispatch:
     inputs:
       velox_short_sha:

--- a/.github/workflows/velox.yml
+++ b/.github/workflows/velox.yml
@@ -95,6 +95,7 @@ jobs:
       velox_short_sha: ${{ needs.resolve-commits.outputs.velox_short_sha }}
       date: ${{ needs.resolve-commits.outputs.date }}
       build_variant: ${{ inputs.build_variant }}
+      run_id: ${{ github.run_id }}
 
   velox-benchmark:
     needs: [resolve-commits, velox-build]
@@ -106,3 +107,4 @@ jobs:
       velox_short_sha: ${{ needs.resolve-commits.outputs.velox_short_sha }}
       date: ${{ needs.resolve-commits.outputs.date }}
       build_variant: ${{ inputs.build_variant }}
+      run_id: ${{ github.run_id }}

--- a/ci/delete-arch-tags.sh
+++ b/ci/delete-arch-tags.sh
@@ -10,22 +10,21 @@ set -euo pipefail
 # REST API is the supported way to remove tags/versions.
 #
 # Usage:
-#   ./ci/delete-arch-tags.sh TAG
+#   ./ci/delete-arch-tags.sh TAG [TAG ...]
 #
 # Example:
 #   IMAGE_NAME=rapidsai/velox-testing-images GITHUB_TOKEN=ghp_... \
-#     ./ci/delete-arch-tags.sh velox-deps-abc123-cuda12.9-20260319-amd64
+#     ./ci/delete-arch-tags.sh velox-deps-abc123-cuda12.9-20260319-amd64 velox-deps-abc123-cuda12.9-20260319-arm64
 #
 # Environment:
 #   IMAGE_NAME   - Full image name without registry prefix (e.g. rapidsai/velox-testing-images)
 #   GITHUB_TOKEN - GitHub token with write:packages scope
 #   REGISTRY     - Unused; kept for compatibility with the action that sets it
 
-if [[ $# -ne 1 ]]; then
-  echo "Usage: $0 TAG" >&2
+if [[ $# -lt 1 ]]; then
+  echo "Usage: $0 TAG [TAG ...]" >&2
   exit 1
 fi
-TAG="$1"
 
 if [[ -z "${IMAGE_NAME:-}" ]]; then
   echo "Error: IMAGE_NAME is required" >&2
@@ -40,19 +39,26 @@ fi
 ORG="${IMAGE_NAME%%/*}"
 PACKAGE="${IMAGE_NAME#*/}"
 
-echo "Looking up tag '${TAG}' in ${ORG}/${PACKAGE}..."
-VERSION_ID=$(GH_TOKEN="${GITHUB_TOKEN}" gh api --paginate \
-  "orgs/${ORG}/packages/container/${PACKAGE}/versions" \
-  | jq -r --arg tag "${TAG}" \
-      '.[] | select(.metadata.container.tags | contains([$tag])) | .id' \
-  | head -n 1)
+versions_file=$(mktemp)
+trap 'rm -f "${versions_file}"' EXIT
 
-if [[ -z "${VERSION_ID}" ]]; then
-  echo "  Tag '${TAG}' not found. Skipping."
-  exit 0
-fi
+echo "Looking up ${#} tag(s) in ${ORG}/${PACKAGE}..."
+GH_TOKEN="${GITHUB_TOKEN}" gh api --paginate \
+  "orgs/${ORG}/packages/container/${PACKAGE}/versions?per_page=100" \
+  > "${versions_file}"
 
-echo "  Found version ID: ${VERSION_ID}. Deleting..."
-GH_TOKEN="${GITHUB_TOKEN}" gh api --method DELETE \
-  "orgs/${ORG}/packages/container/${PACKAGE}/versions/${VERSION_ID}"
-echo "  -> Deleted tag '${TAG}' (version ${VERSION_ID})"
+for tag in "$@"; do
+  VERSION_ID=$(jq -r --arg tag "${tag}" \
+    'first(.[] | select((.metadata.container.tags // []) | index($tag)) | .id) // empty' \
+    "${versions_file}")
+
+  if [[ -z "${VERSION_ID}" ]]; then
+    echo "  Tag '${tag}' not found. Skipping."
+    continue
+  fi
+
+  echo "  Found version ID for '${tag}': ${VERSION_ID}. Deleting..."
+  GH_TOKEN="${GITHUB_TOKEN}" gh api --method DELETE \
+    "orgs/${ORG}/packages/container/${PACKAGE}/versions/${VERSION_ID}"
+  echo "  -> Deleted tag '${tag}' (version ${VERSION_ID})"
+done

--- a/ci/delete-arch-tags.sh
+++ b/ci/delete-arch-tags.sh
@@ -43,9 +43,42 @@ versions_file=$(mktemp)
 trap 'rm -f "${versions_file}"' EXIT
 
 echo "Looking up ${#} tag(s) in ${ORG}/${PACKAGE}..."
-GH_TOKEN="${GITHUB_TOKEN}" gh api --paginate \
-  "orgs/${ORG}/packages/container/${PACKAGE}/versions?per_page=100" \
-  > "${versions_file}"
+page=1
+while :; do
+  page_file=$(mktemp)
+  response_file=$(mktemp)
+  # Fetch one page at a time so cleanup can stop once all requested tags are found.
+  GH_TOKEN="${GITHUB_TOKEN}" gh api -i \
+    "orgs/${ORG}/packages/container/${PACKAGE}/versions?per_page=100&page=${page}" \
+    > "${response_file}"
+  awk 'body { print } /^\r?$/ { body=1 }' "${response_file}" > "${page_file}"
+  # Keep the existing jq lookup below simple by accumulating the pages already fetched.
+  jq -s 'add' "${versions_file}" "${page_file}" > "${versions_file}.next"
+  mv "${versions_file}.next" "${versions_file}"
+  rm -f "${page_file}"
+
+  missing=0
+  for tag in "$@"; do
+    if ! jq -e --arg tag "${tag}" \
+      'any(.[]; (.metadata.container.tags // []) | index($tag))' \
+      "${versions_file}" >/dev/null; then
+      missing=1
+      break
+    fi
+  done
+  if [[ "${missing}" -eq 0 ]]; then
+    rm -f "${response_file}"
+    break
+  fi
+
+  # The GitHub Packages API exposes the next page only through the Link header.
+  if ! grep -qi 'rel="next"' "${response_file}"; then
+    rm -f "${response_file}"
+    break
+  fi
+  rm -f "${response_file}"
+  page=$((page + 1))
+done
 
 for tag in "$@"; do
   VERSION_ID=$(jq -r --arg tag "${tag}" \


### PR DESCRIPTION
## Summary
- Pass the parent run ID into called test and benchmark workflows so manual build images resolve to the run that produced them.
- Speed up arch-specific tag cleanup by resolving multiple tags in one lookup path and stopping package-version pagination once all requested tags are found.
- Use merged multi-arch deps images as build contexts so deps arch-specific intermediates can be cleaned up in the deps merge jobs.

The cleanup step was taking more than **6 minutes** to run because it was fetching _all_ pages of the container registry, once for _every_ image being deleted. The updates in `ci/delete-arch-tags.sh` now fetch only enough pages needed to resolve the IDs for the desired tags, which now only takes a second or two to run.

Since that is so much faster, I also moved the `presto-deps` image cleanup and refactored the other `presto` image builds to use the merged manifests rather than the arch-specific intermediates.

## Testing
- Presto manual dispatch: https://github.com/rapidsai/velox-testing/actions/runs/25946083183
- Velox manual dispatch: https://github.com/rapidsai/velox-testing/actions/runs/25946083203