### PR TITLE
CI - Retry docker pull on transient ghcr.io failures

### DIFF
--- a/.github/workflows/presto-test.yml
+++ b/.github/workflows/presto-test.yml
@@ -219,12 +219,14 @@ jobs:
           CUDA_VERSION: ${{ matrix.cuda_version }}
           RUN_ID_SUFFIX: ${{ needs.resolve-run-id-suffix.outputs.run_id_suffix }}
         run: |
+          source scripts/common.sh
+
           COORD_IMAGE="${REGISTRY}/${IMAGE_NAME}:presto-coordinator-${PRESTO_SHORT_SHA}-${BUILD_DATE}${RUN_ID_SUFFIX}"
-          docker pull "${COORD_IMAGE}"
+          docker_pull_with_retry "${COORD_IMAGE}"
           docker tag "${COORD_IMAGE}" "presto-coordinator:ci"
 
           WORKER_IMAGE="${REGISTRY}/${IMAGE_NAME}:presto-${PRESTO_SHORT_SHA}-velox-${VELOX_SHORT_SHA}-gpu-cuda${CUDA_VERSION}-${BUILD_DATE}${RUN_ID_SUFFIX}"
-          docker pull "${WORKER_IMAGE}"
+          docker_pull_with_retry "${WORKER_IMAGE}"
           docker tag "${WORKER_IMAGE}" "presto-native-worker-gpu:ci"
 
       - name: Smoke test

--- a/.github/workflows/velox-compute-sanitizer-run.yaml
+++ b/.github/workflows/velox-compute-sanitizer-run.yaml
@@ -63,7 +63,9 @@ jobs:
           TOOL_NAME: ${{ inputs.tool_name }}
           TEST_NAME: ${{ matrix.test_name }}
         run: |
-          docker pull "${IMAGE}"
+          source scripts/common.sh
+
+          docker_pull_with_retry "${IMAGE}"
           docker run --rm --gpus all \
             -v "${GITHUB_WORKSPACE}/ci/run_compute_sanitizer_test.sh:/tmp/run_compute_sanitizer_test.sh:ro" \
             "${IMAGE}" bash /tmp/run_compute_sanitizer_test.sh "${TOOL_NAME}" "${TEST_NAME}"

--- a/.github/workflows/velox-compute-sanitizer-trigger.yaml
+++ b/.github/workflows/velox-compute-sanitizer-trigger.yaml
@@ -52,7 +52,9 @@ jobs:
         env:
           IMAGE: ${{ steps.resolve-image.outputs.velox_image }}
         run: |
-          docker pull "${IMAGE}"
+          source scripts/common.sh
+
+          docker_pull_with_retry "${IMAGE}"
           docker run --rm \
             -v "${GITHUB_WORKSPACE}/ci/discover_velox_cudf_tests.sh:/tmp/discover.sh:ro" \
             -e GITHUB_OUTPUT=/tmp/gh_output \

--- a/.github/workflows/velox-test.yml
+++ b/.github/workflows/velox-test.yml
@@ -92,9 +92,11 @@ jobs:
           IMAGE_TAG: ${{ matrix.image_tag }}
           RUN_ID_SUFFIX: ${{ needs.resolve-run-id-suffix.outputs.run_id_suffix }}
         run: |
+          source scripts/common.sh
+
           IMAGE="${REGISTRY}/${IMAGE_NAME}:velox-${VELOX_SHORT_SHA}-${IMAGE_TAG}-${BUILD_DATE}${RUN_ID_SUFFIX}"
           echo "Testing image: ${IMAGE}"
-          docker pull "${IMAGE}"
+          docker_pull_with_retry "${IMAGE}"
           docker run --rm "${IMAGE}" bash -c \
             "cd /opt/velox-build/release && ctest -j 16 --label-exclude cuda_driver --output-on-failure --no-tests=error"
 
@@ -151,8 +153,10 @@ jobs:
           IMAGE_TAG: ${{ matrix.image_tag }}
           RUN_ID_SUFFIX: ${{ needs.resolve-run-id-suffix.outputs.run_id_suffix }}
         run: |
+          source scripts/common.sh
+
           IMAGE="${REGISTRY}/${IMAGE_NAME}:velox-${VELOX_SHORT_SHA}-gpu-cuda${IMAGE_TAG}-${BUILD_DATE}${RUN_ID_SUFFIX}"
           echo "Testing image: ${IMAGE}"
-          docker pull "${IMAGE}"
+          docker_pull_with_retry "${IMAGE}"
           docker run --rm --gpus all "${IMAGE}" bash -c \
             "cd /opt/velox-build/release && ctest -j 8 --label-regex cuda_driver --output-on-failure --no-tests=error"

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -14,3 +14,28 @@ validate_docker_image() {
   fi
   echo "✓ Docker image exists"
 }
+
+# Retry `docker pull` with exponential backoff. Useful for shrugging off
+# transient registry errors (ghcr.io 502s, brief network blips).
+#
+# Usage: docker_pull_with_retry IMAGE
+# Override attempt count / initial backoff via DOCKER_PULL_ATTEMPTS and
+# DOCKER_PULL_BACKOFF_INITIAL (defaults: 5 attempts, 10s initial, doubling).
+docker_pull_with_retry() {
+  local image=$1
+  local attempts=${DOCKER_PULL_ATTEMPTS:-5}
+  local delay=${DOCKER_PULL_BACKOFF_INITIAL:-10}
+  local i
+  for ((i = 1; i <= attempts; i++)); do
+    if docker pull "${image}"; then
+      return 0
+    fi
+    if (( i < attempts )); then
+      echo "docker pull '${image}' failed (attempt ${i}/${attempts}); retrying in ${delay}s..."
+      sleep "${delay}"
+      delay=$((delay * 2))
+    fi
+  done
+  echo "ERROR: docker pull '${image}' failed after ${attempts} attempts" >&2
+  return 1
+}


### PR DESCRIPTION
## Summary

- Wrap `docker pull` in `presto-test.yml`'s "Pull and retag images" step in a small exponential-backoff retry helper, so a one-off `ghcr.io 502` no longer fails the whole integration matrix.

- Add the helper as `docker_pull_with_retry` in `scripts/common.sh` so other workflow steps can reuse it via `source scripts/common.sh`. 
