### PR TITLE
Retry docker pull in benchmark_velox.sh on transient registry failures

### DIFF
--- a/velox/scripts/benchmark_velox.sh
+++ b/velox/scripts/benchmark_velox.sh
@@ -13,6 +13,8 @@ REPO_ROOT="$(git -C "${SCRIPT_DIR}" rev-parse --show-toplevel)"
 
 # Source benchmark-specific libraries
 source "${SCRIPT_DIR}/../benchmarks/tpch.sh"
+# Shared helpers (docker_pull_with_retry, validate_docker_image, ...)
+source "${REPO_ROOT}/scripts/common.sh"
 
 # Default values
 BENCHMARK_TYPE="tpch"
@@ -322,7 +324,7 @@ check_benchmark_data
 
 if [[ -n "${DOCKER_IMAGE}" ]]; then
   echo "Using pre-built image: ${DOCKER_IMAGE}"
-  docker pull "${DOCKER_IMAGE}"
+  docker_pull_with_retry "${DOCKER_IMAGE}"
   BUILD_TYPE="release"
   export BUILD_TYPE
 else


### PR DESCRIPTION
## Summary

- Follow-up to #353. Apply `docker_pull_with_retry` (from `scripts/common.sh`) to the last remaining plain `docker pull` caller in the repo: `velox/scripts/benchmark_velox.sh`, used by `velox-benchmark.yml`'s
  `run-velox-benchmark` job.
- Source `scripts/common.sh` next to the existing benchmark library include so the helper (and any future helpers added to `common.sh`) are available.

After this PR every `docker pull` call site in the repo goes through the retry helper, so a one-off `ghcr.io 502` during the benchmark image fetch no longer fails the run.
