### PR TITLE
Improve compute sanitizer workflow

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -24,8 +24,8 @@ This directory contains GitHub Actions workflows for automated testing, benchmar
 | `presto-test.yml` | Reusable workflow for Presto CI image tests | Smoke + integration tests; supports `workflow_dispatch` for test-only runs |
 | `ci-image-cleanup.yml` | Deletes CI images older than 30 days from GHCR | Weekly (Tuesdays) + manual dispatch |
 | **Compute Sanitizer** |||
-| `velox-compute-sanitizer-trigger.yaml` | Discovers cuDF tests and runs compute-sanitizer tools | Weekly (Saturdays) + manual dispatch |
-| `velox-compute-sanitizer-run.yaml` | Reusable workflow to run a sanitizer tool on a matrix of tests | Called by trigger; also supports `workflow_dispatch` |
+| `velox-compute-sanitizer-trigger.yaml` | Triggers compute-sanitizer tool workflows | Weekly (Saturdays) + manual dispatch |
+| `velox-compute-sanitizer-run.yaml` | Discovers cuDF tests and runs one sanitizer tool over the matrix | Triggered by schedule workflow; supports targeted manual dispatch |
 
 ---
 
@@ -231,8 +231,9 @@ presto-test.yml (workflow_dispatch) ──► [test images by SHA/date/variant]
 
 COMPUTE SANITIZER
 ─────────────────
-velox-compute-sanitizer-trigger.yaml ──► [discover cuda_driver tests] ──► velox-compute-sanitizer-run.yaml (racecheck)
-                                                                      └─► velox-compute-sanitizer-run.yaml (synccheck)
+velox-compute-sanitizer-trigger.yaml ──► velox-compute-sanitizer-run.yaml (memcheck) ──► [discover cuda_driver tests]
+                                      ├─► velox-compute-sanitizer-run.yaml (racecheck) ──► [discover cuda_driver tests]
+                                      └─► velox-compute-sanitizer-run.yaml (synccheck) ──► [discover cuda_driver tests]
 
 CLEANUP
 ───────

--- a/.github/workflows/velox-compute-sanitizer-run.yaml
+++ b/.github/workflows/velox-compute-sanitizer-run.yaml
@@ -33,7 +33,7 @@ on:
       velox_image:
         required: true
         type: string
-        description: "Full Velox GPU container image reference"
+        description: 'Velox GPU image to test (e.g. ghcr.io/rapidsai/velox-testing-images:velox-e0169a0-gpu-cuda13.1-20260318). Leave empty to use velox-latest-gpu-cuda13.1.'
 
 env:
   REGISTRY: ghcr.io

--- a/.github/workflows/velox-compute-sanitizer-run.yaml
+++ b/.github/workflows/velox-compute-sanitizer-run.yaml
@@ -1,20 +1,7 @@
-name: compute-sanitizer-run
+name: Compute Sanitizer
+run-name: "Compute Sanitizer ${{ inputs.tool_name }}"
 
 on:
-  workflow_call:
-    inputs:
-      tool_name:
-        required: true
-        type: string
-        description: "Compute sanitizer tool to run (memcheck, racecheck, initcheck, synccheck)"
-      test_names:
-        required: true
-        type: string
-        description: "JSON array of test names to run"
-      velox_image:
-        required: true
-        type: string
-        description: "Full Velox GPU container image reference"
   workflow_dispatch:
     inputs:
       tool_name:
@@ -27,20 +14,74 @@ on:
           - initcheck
           - synccheck
       test_names:
-        required: true
+        required: false
         type: string
-        description: "JSON array of test names to run"
+        description: "JSON array of test names to run (discovers all tests if empty)"
+        default: ""
       velox_image:
-        required: true
+        required: false
         type: string
-        description: 'Velox GPU image to test (e.g. ghcr.io/rapidsai/velox-testing-images:velox-e0169a0-gpu-cuda13.1-20260318). Leave empty to use velox-latest-gpu-cuda13.1.'
+        description: "Velox GPU image to test (e.g. ghcr.io/rapidsai/velox-testing-images:velox-e0169a0-gpu-cuda13.1-20260318). Leave empty to use velox-latest-gpu-cuda13.1."
+        default: ""
+
+permissions: {}
 
 env:
   REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}-images
 
 jobs:
+  resolve-image:
+    runs-on: ubuntu-latest
+    outputs:
+      velox_image: ${{ steps.resolve-image.outputs.velox_image }}
+    steps:
+      - name: Resolve image
+        id: resolve-image
+        env:
+          VELOX_IMAGE: ${{ inputs.velox_image }}
+        run: |
+          if [ -n "${VELOX_IMAGE}" ]; then
+            echo "velox_image=${VELOX_IMAGE}" >> "${GITHUB_OUTPUT}"
+          else
+            echo "velox_image=${REGISTRY}/${IMAGE_NAME}:velox-latest-gpu-cuda13.1" >> "${GITHUB_OUTPUT}"
+          fi
+
+  discover-sanitizer-tests:
+    if: ${{ !inputs.test_names }}
+    needs: resolve-image
+    runs-on: linux-amd64-cpu4
+    permissions:
+      contents: read
+      packages: read
+    outputs:
+      tests: ${{ steps.find-tests.outputs.tests }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Log in to the Container registry
+        uses: ./.github/actions/container-registry-login
+      - name: Discover test executables
+        id: find-tests
+        env:
+          IMAGE: ${{ needs.resolve-image.outputs.velox_image }}
+        run: |
+          source scripts/common.sh
+
+          docker_pull_with_retry "${IMAGE}"
+          docker run --rm \
+            -v "${GITHUB_WORKSPACE}/ci/discover_velox_cudf_tests.sh:/tmp/discover.sh:ro" \
+            -e GITHUB_OUTPUT=/tmp/gh_output \
+            "${IMAGE}" bash -c "bash /tmp/discover.sh && cat /tmp/gh_output" >> "${GITHUB_OUTPUT}"
+
   run-sanitizer-tests:
-    name: ${{ inputs.tool_name }} / ${{ matrix.test_name }}
+    name: Run ${{ inputs.tool_name }} on ${{ matrix.test_name }}
+    needs:
+      - resolve-image
+      - discover-sanitizer-tests
+    if: ${{ !cancelled() }}
     runs-on: linux-amd64-gpu-l4-latest-1
     permissions:
       contents: read
@@ -49,7 +90,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        test_name: ${{ fromJson(inputs.test_names) }}
+        test_name: ${{ fromJson(inputs.test_names || needs.discover-sanitizer-tests.outputs.tests) }}
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -59,7 +100,7 @@ jobs:
         uses: ./.github/actions/container-registry-login
       - name: Run compute-sanitizer ${{ inputs.tool_name }} on ${{ matrix.test_name }}
         env:
-          IMAGE: ${{ inputs.velox_image }}
+          IMAGE: ${{ needs.resolve-image.outputs.velox_image }}
           TOOL_NAME: ${{ inputs.tool_name }}
           TEST_NAME: ${{ matrix.test_name }}
         run: |

--- a/.github/workflows/velox-compute-sanitizer-trigger.yaml
+++ b/.github/workflows/velox-compute-sanitizer-trigger.yaml
@@ -1,97 +1,48 @@
-name: compute-sanitizer-trigger
+name: Trigger Compute Sanitizer
 
-# Runs compute-sanitizer tools on all Velox cuDF (cuda_driver) tests.
+# This workflow triggers compute-sanitizer runs for all Velox cuDF (cuda_driver) tests weekly.
 # WARNING: This is resource intensive and runs many GPU jobs.
-# For targeted testing, manually trigger compute-sanitizer-run.yaml with specific inputs.
+# For targeted testing, manually trigger velox-compute-sanitizer-run.yaml with specific tool_name and test_names.
 
 on:
   schedule:
-    - cron: '0 10 * * 6'  # Weekly on Saturday at 10:00 UTC
+    - cron: "0 10 * * 6"  # Weekly on Saturday at 10:00 UTC
   workflow_dispatch:
     inputs:
       velox_image:
-        description: 'Velox GPU image to test (e.g. ghcr.io/rapidsai/velox-testing-images:velox-e0169a0-gpu-cuda13.1-20260318). Leave empty to use velox-latest-gpu-cuda13.1.'
+        description: "Velox GPU image to test (e.g. ghcr.io/rapidsai/velox-testing-images:velox-e0169a0-gpu-cuda13.1-20260318). Leave empty to use velox-latest-gpu-cuda13.1."
         type: string
         required: false
-        default: ''
+        default: ""
 
 permissions: {}
 
-env:
-  REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}-images
-
 jobs:
-  discover-tests:
-    runs-on: linux-amd64-cpu4
+  trigger-sanitizer:
+    name: Trigger ${{ matrix.tool_name }}
+    runs-on: ubuntu-latest
     permissions:
+      actions: write
       contents: read
-      packages: read
-    outputs:
-      tests: ${{ steps.find-tests.outputs.tests }}
-      velox_image: ${{ steps.resolve-image.outputs.velox_image }}
+    strategy:
+      fail-fast: false
+      matrix:
+        tool_name:
+          - memcheck
+          - racecheck
+          - synccheck
     steps:
-      - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           persist-credentials: false
-      - name: Log in to the Container registry
-        uses: ./.github/actions/container-registry-login
-      - name: Resolve image
-        id: resolve-image
+      - name: Trigger ${{ matrix.tool_name }}
         env:
-          VELOX_IMAGE: ${{ inputs.velox_image }}
+          GH_TOKEN: ${{ github.token }}
+          TOOL_NAME: ${{ matrix.tool_name }}
+          VELOX_IMAGE: ${{ github.event.inputs.velox_image }}
         run: |
+          args=(--ref "${GITHUB_REF_NAME}" -f tool_name="${TOOL_NAME}")
           if [ -n "${VELOX_IMAGE}" ]; then
-            echo "velox_image=${VELOX_IMAGE}" >> "${GITHUB_OUTPUT}"
-          else
-            echo "velox_image=${REGISTRY}/${IMAGE_NAME}:velox-latest-gpu-cuda13.1" >> "${GITHUB_OUTPUT}"
+            args+=(-f velox_image="${VELOX_IMAGE}")
           fi
-      - name: Discover test executables
-        id: find-tests
-        env:
-          IMAGE: ${{ steps.resolve-image.outputs.velox_image }}
-        run: |
-          source scripts/common.sh
-
-          docker_pull_with_retry "${IMAGE}"
-          docker run --rm \
-            -v "${GITHUB_WORKSPACE}/ci/discover_velox_cudf_tests.sh:/tmp/discover.sh:ro" \
-            -e GITHUB_OUTPUT=/tmp/gh_output \
-            "${IMAGE}" bash -c "bash /tmp/discover.sh && cat /tmp/gh_output" >> "${GITHUB_OUTPUT}"
-
-  run-sanitizer-tests-memcheck:
-    name: compute-sanitizer memcheck
-    needs: discover-tests
-    permissions:
-      contents: read
-      packages: read
-    uses: ./.github/workflows/velox-compute-sanitizer-run.yaml
-    with:
-      tool_name: "memcheck"
-      test_names: ${{ needs.discover-tests.outputs.tests }}
-      velox_image: ${{ needs.discover-tests.outputs.velox_image }}
-
-  run-sanitizer-tests-racecheck:
-    name: compute-sanitizer racecheck
-    needs: discover-tests
-    permissions:
-      contents: read
-      packages: read
-    uses: ./.github/workflows/velox-compute-sanitizer-run.yaml
-    with:
-      tool_name: "racecheck"
-      test_names: ${{ needs.discover-tests.outputs.tests }}
-      velox_image: ${{ needs.discover-tests.outputs.velox_image }}
-
-  run-sanitizer-tests-synccheck:
-    name: compute-sanitizer synccheck
-    needs: discover-tests
-    permissions:
-      contents: read
-      packages: read
-    uses: ./.github/workflows/velox-compute-sanitizer-run.yaml
-    with:
-      tool_name: "synccheck"
-      test_names: ${{ needs.discover-tests.outputs.tests }}
-      velox_image: ${{ needs.discover-tests.outputs.velox_image }}
+          gh workflow run velox-compute-sanitizer-run.yaml "${args[@]}"

--- a/.github/workflows/velox-compute-sanitizer-trigger.yaml
+++ b/.github/workflows/velox-compute-sanitizer-trigger.yaml
@@ -10,7 +10,7 @@ on:
   workflow_dispatch:
     inputs:
       velox_image:
-        description: 'Velox GPU image to test (e.g. ghcr.io/rapidsai/velox-testing-images:velox-e0169a0-gpu-cuda13.1-20260318). Leave empty to use velox-latest-gpu-cuda12.9.'
+        description: 'Velox GPU image to test (e.g. ghcr.io/rapidsai/velox-testing-images:velox-e0169a0-gpu-cuda13.1-20260318). Leave empty to use velox-latest-gpu-cuda13.1.'
         type: string
         required: false
         default: ''
@@ -45,7 +45,7 @@ jobs:
           if [ -n "${VELOX_IMAGE}" ]; then
             echo "velox_image=${VELOX_IMAGE}" >> "${GITHUB_OUTPUT}"
           else
-            echo "velox_image=${REGISTRY}/${IMAGE_NAME}:velox-latest-gpu-cuda12.9" >> "${GITHUB_OUTPUT}"
+            echo "velox_image=${REGISTRY}/${IMAGE_NAME}:velox-latest-gpu-cuda13.1" >> "${GITHUB_OUTPUT}"
           fi
       - name: Discover test executables
         id: find-tests


### PR DESCRIPTION
## Summary

- Change `velox-compute-sanitizer-trigger.yaml` into a lightweight scheduler/manual dispatcher that starts separate `velox-compute-sanitizer-run.yaml` workflows for `memcheck`, `racecheck`, and `synccheck`.
- Move test discovery into `velox-compute-sanitizer-run.yaml`, matching the cuDF pattern where the run workflow owns discovery and execution.
- Keep the compute-sanitizer default image on `velox-latest-gpu-cuda13.1` and copy the clearer GHCR image guidance into the manual dispatch inputs.
- Update the workflow README to describe the new split.

## Context

The previous `trigger` workflow was not just a trigger: it discovered tests and ran the full weekly sanitizer matrix through reusable workflow calls. The cuDF workflow uses a cleaner split where the trigger workflow schedules separate run workflows, and the run workflow handles discovery plus execution. This PR reshapes Velox in that direction while preserving its current weekly tool coverage.

## Validation

- `yq e . .github/workflows/velox-compute-sanitizer-trigger.yaml`
- `yq e . .github/workflows/velox-compute-sanitizer-run.yaml`
- `git diff --check`
- Commit hooks: whitespace, EOF, codespell, zizmor

`actionlint` was not installed in this local environment.