### PR TITLE
Forward TPC-H scale factor to benchmark pytest runner

### DIFF
--- a/common/testing/test_utils.py
+++ b/common/testing/test_utils.py
@@ -17,7 +17,12 @@ def get_queries(benchmark_type, queries_file=None):
 def get_scale_factor_from_file(file):
     with open(get_abs_file_path(__file__, file), "r") as file:
         metadata = json.load(file)
-        return metadata["scale_factor"]
+        scale_factor = metadata.get("scale_factor")
+        if scale_factor is None:
+            scale_factor = metadata.get("options", {}).get("scale_factor")
+        if scale_factor is None:
+            raise KeyError("scale_factor")
+        return scale_factor
 
 
 def get_abs_file_path(file_path, relative_path):

--- a/presto/scripts/run_benchmark.sh
+++ b/presto/scripts/run_benchmark.sh
@@ -14,6 +14,8 @@ export LOGS_DIR="${LOGS_DIR:-${SCRIPT_DIR}/presto_logs}"
 
 source "${SCRIPT_DIR}/presto_connection_defaults.sh"
 
+BENCHMARK_SCALE_FACTOR=""
+
 print_help() {
   cat << EOF
 
@@ -33,6 +35,8 @@ OPTIONS:
     -u, --user              User who queries will be executed as.
     -s, --schema-name       Name of the schema containing the tables that will be queried. This must be an existing
                             schema that contains the benchmark tables.
+    --scale-factor          Scale factor of the benchmark dataset. If omitted, pytest reads it from metadata.json
+                            next to the table data.
     -o, --output-dir        Directory path that will contain the output files from the benchmark run.
                             By default, output files are written to "$(pwd)/benchmark_output".
     -i, --iterations        Number of query run iterations. By default, 5 iterations are run.
@@ -140,6 +144,15 @@ parse_args() {
           shift 2
         else
           echo "Error: --schema-name requires a value"
+          exit 1
+        fi
+        ;;
+      --scale-factor)
+        if [[ -n $2 ]]; then
+          BENCHMARK_SCALE_FACTOR=$2
+          shift 2
+        else
+          echo "Error: --scale-factor requires a value"
           exit 1
         fi
         ;;
@@ -261,6 +274,10 @@ fi
 
 if [[ -n ${USER_NAME} ]]; then
   PYTEST_ARGS+=("--user ${USER_NAME}")
+fi
+
+if [[ -n ${BENCHMARK_SCALE_FACTOR} ]]; then
+  PYTEST_ARGS+=("--scale-factor ${BENCHMARK_SCALE_FACTOR}")
 fi
 
 if [[ -n ${OUTPUT_DIR} ]]; then

--- a/presto/slurm/presto-nvl72/functions.sh
+++ b/presto/slurm/presto-nvl72/functions.sh
@@ -500,7 +500,7 @@ function run_queries {
     export MINIFORGE_HOME=/workspace/miniforge3; \
     export HOME=/workspace; \
     cd /workspace/presto/scripts; \
-    ./run_benchmark.sh -b tpch -s tpchsf${scale_factor} -i ${num_iterations} ${extra_args[*]} \
+    ./run_benchmark.sh -b tpch -s tpchsf${scale_factor} --scale-factor ${scale_factor} -i ${num_iterations} ${extra_args[*]} \
         --hostname ${COORD} --port $PORT -o /workspace/presto/slurm/presto-nvl72/result_dir --skip-drop-cache" "cli"
 }
 


### PR DESCRIPTION
This fixes NVL72 Presto benchmark runs where `launch-run.sh -s <SF>` correctly sets the schema/launcher scale factor, but `run_benchmark.sh` does not forward that value to pytest.

Without this, the TPC-H query fixture falls back to reading `metadata.json` next to the mounted dataset and can fail with `KeyError: 'scale_factor'` before any query runs.

Changes:
- Add `--scale-factor` support to `presto/scripts/run_benchmark.sh`.
- Pass the SLURM launcher scale factor through `presto/slurm/presto-nvl72/functions.sh`.
- Make `get_scale_factor_from_file()` accept both top-level `scale_factor` and nested `options.scale_factor`.