### PR TITLE
Add Presto image pull helper

### DIFF
--- a/presto/README.md
+++ b/presto/README.md
@@ -52,11 +52,63 @@ All three repositories must be checked out as sibling directories. **Important:*
    ```
    > **Tip:** Add this export to your `~/.bashrc` to avoid setting it each time.
 
-3. Build dependencies (first time only):
+3. Prepare Presto images.
+
+   For a local source build, first build the dependency image. The start script
+   will lazily build the coordinator and worker images if they are missing.
    ```bash
    ./build_centos_deps_image.sh
    ```
-   > **Note:** Only internal team members with credentials can fetch a pre-built image (`./fetch_centos_deps_image.sh`). For most users, building locally is required.
+   > **Note:** `./fetch_centos_deps_image.sh` fetches the dependency image from
+   > internal storage and requires credentials.
+
+   Alternatively, pull prebuilt GPU images and retag them for the local start scripts:
+   ```bash
+   ./pull_presto_images.sh
+   ```
+
+   The PrestoDB defaults are:
+   - Coordinator: `prestodb/presto:coordinator-gpu-nightly`
+   - Worker: `prestodb/presto-native:gpu-nightly`
+
+   To use a different PrestoDB tag:
+   ```bash
+   ./pull_presto_images.sh --tag latest
+   ```
+   This pulls `prestodb/presto:latest` and `prestodb/presto-native:latest`.
+
+   RAPIDS CI images can also be pulled from GHCR:
+   ```bash
+   ./pull_presto_images.sh --source ci
+   ```
+
+   The CI defaults are:
+   - Coordinator: `ghcr.io/rapidsai/velox-testing-images:presto-coordinator-latest`
+   - Worker: `ghcr.io/rapidsai/velox-testing-images:presto-latest-gpu-cuda13.1`
+
+   To use a specific CI Presto/Velox tag body:
+   ```bash
+   ./pull_presto_images.sh --source ci --tag c0de72d-velox-f374779-20260616-manual-27588892754
+   ```
+   This pulls `presto-coordinator-c0de72d-20260616-manual-27588892754`
+   and `presto-c0de72d-velox-f374779-gpu-cuda13.1-20260616-manual-27588892754`.
+
+   Use `--cuda-version` to select a different CI GPU worker CUDA tag:
+   ```bash
+   ./pull_presto_images.sh --source ci --cuda-version 12.8
+   ```
+
+   Use `--no-coordinator` if you only need to refresh the worker image:
+   ```bash
+   ./pull_presto_images.sh --no-coordinator
+   ```
+
+   By default, pulled images are retagged with `${USER}`. Set `PRESTO_IMAGE_TAG`
+   or pass `--local-tag` if you want the start scripts to use a different tag:
+   ```bash
+   PRESTO_IMAGE_TAG=ci ./pull_presto_images.sh
+   PRESTO_IMAGE_TAG=ci ./start_native_gpu_presto.sh
+   ```
 
 4. Start Presto with GPU workers:
    ```bash

--- a/presto/docker/docker-compose.common.yml
+++ b/presto/docker/docker-compose.common.yml
@@ -6,6 +6,7 @@ services:
       - ${PRESTO_DATA_DIR:-/dev/null}:/var/lib/presto/data/hive/data/user_data
       - ${LOGS_DIR:-/dev/null}:/opt/presto-server/logs
       - ./launch_presto_servers.sh:/opt/launch_presto_servers.sh:ro
+      - ./presto_profiling_wrapper.sh:/opt/presto_profiling_wrapper.sh:ro
 
   presto-base-java:
     extends:

--- a/presto/docker/docker-compose/template/docker-compose.native-gpu.yml.jinja
+++ b/presto/docker/docker-compose/template/docker-compose.native-gpu.yml.jinja
@@ -12,6 +12,7 @@ x-presto-native-worker-gpu: &gpu_worker_base
       - github_token
       - aws_credentials
 {% endif %}
+  entrypoint: ["bash", "/opt/presto_profiling_wrapper.sh"]
   runtime: nvidia
   cap_add:
     - IPC_LOCK
@@ -98,7 +99,7 @@ services:
     <<: *gpu_worker_base
     container_name: presto-native-worker-gpu
 {%- if workers %}
-    command: ["bash", "/opt/presto_profiling_wrapper.sh"{% for gpu_id in workers %}, "{{ gpu_id }}"{% endfor %}]
+    command: [{% for gpu_id in workers %}"{{ gpu_id }}"{% if not loop.last %}, {% endif %}{% endfor %}]
     environment:
       NVIDIA_VISIBLE_DEVICES: all
       PROFILE: ${PROFILE:-}

--- a/presto/docker/launch_presto_servers.sh
+++ b/presto/docker/launch_presto_servers.sh
@@ -33,13 +33,15 @@ launch_worker() {
     cpu_numa=$(echo "$topo" | awk -F: '/NUMA IDs of closest CPU/{ gsub(/ /,"",$2); print $2 }')
     mem_numa=$(echo "$topo" | awk -F: '/NUMA IDs of closest memory/{ gsub(/ /,"",$2); print $2 }')
 
-    if [[ $cpu_numa =~ ^[0-9]+$ ]]; then
+    if [[ $cpu_numa =~ ^[0-9]+$ ]] && command -v numactl &> /dev/null; then
       launcher=(numactl --cpunodebind="$cpu_numa")
       if [[ $mem_numa =~ ^[0-9]+$ ]]; then
         launcher+=(--membind="$mem_numa")
       else
         launcher+=(--membind="$cpu_numa")
       fi
+    elif [[ $cpu_numa =~ ^[0-9]+$ ]]; then
+      echo "numactl is not available; launching worker $worker_id without NUMA binding"
     fi
 
     cuda_env=("CUDA_VISIBLE_DEVICES=$worker_id")

--- a/presto/scripts/pull_presto_images.sh
+++ b/presto/scripts/pull_presto_images.sh
@@ -1,0 +1,252 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+# SPDX-License-Identifier: Apache-2.0
+
+# Pulls prebuilt Presto images and retags them with the local image names used
+# by the start_*_presto.sh scripts.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(git -C "${SCRIPT_DIR}" rev-parse --show-toplevel 2>/dev/null || realpath "${SCRIPT_DIR}/../..")"
+
+source "${REPO_ROOT}/scripts/common.sh"
+
+SOURCE="prestodb"
+IMAGE_TAG=""
+LOCAL_TAG="${PRESTO_IMAGE_TAG:-${USER:-latest}}"
+CUDA_VERSION="13.1"
+CUDA_VERSION_SET=false
+DRY_RUN=false
+INCLUDE_COORDINATOR=true
+
+REGISTRY="${REGISTRY:-ghcr.io}"
+PACKAGE_REPO="${PACKAGE_REPO:-rapidsai}"
+PACKAGE_NAME="${PACKAGE_NAME:-velox-testing-images}"
+CI_IMAGE_BASE="${CI_IMAGE_BASE:-${REGISTRY}/${PACKAGE_REPO}/${PACKAGE_NAME}}"
+
+COORDINATOR_IMAGE=""
+GPU_WORKER_IMAGE=""
+
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") [OPTIONS]
+
+Pull Presto images from a supported source and retag them for local use by the
+start_*_presto.sh scripts.
+
+Sources:
+  prestodb  Pull PrestoDB Docker Hub native GPU worker and coordinator images.
+  ci        Pull RAPIDS CI native GPU worker and coordinator images from GHCR.
+
+Options:
+  --source SOURCE              Image source: prestodb or ci (default: prestodb).
+  --tag TAG                    Source image tag to pull.
+                               prestodb default: gpu-nightly.
+                               ci default: latest.
+  --local-tag TAG              Local tag to create (default: PRESTO_IMAGE_TAG or USER).
+                               Start scripts use this tag through PRESTO_IMAGE_TAG.
+  --cuda-version VERSION       CI GPU CUDA version to pull (default: 13.1).
+  --no-coordinator             Do not pull or retag the coordinator image.
+  --dry-run                    Print the pull/tag actions without running Docker.
+  -h, --help                   Show this help.
+
+Examples:
+  # PrestoDB defaults:
+  #   prestodb/presto:coordinator-gpu-nightly
+  #   prestodb/presto-native:gpu-nightly
+  $(basename "$0")
+
+  # Use a different PrestoDB tag.
+  $(basename "$0") --tag latest
+
+  # RAPIDS CI stable latest GPU images.
+  $(basename "$0") --source ci
+
+  # Use a specific RAPIDS CI Presto/Velox tag body.
+  $(basename "$0") --source ci --tag c0de72d-velox-f374779-20260616-manual-27588892754
+
+  # Pull a CI worker built with a different CUDA version.
+  $(basename "$0") --source ci --cuda-version 12.8
+
+Local image names created:
+  presto-coordinator:<tag>
+  presto-native-worker-gpu:<tag>
+EOF
+}
+
+require_value() {
+  local option=$1
+  local value=${2:-}
+  if [[ -z "${value}" ]]; then
+    echo "ERROR: ${option} requires a value." >&2
+    exit 1
+  fi
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --source)
+      require_value "$1" "${2:-}"
+      SOURCE="$2"
+      shift 2
+      ;;
+    --tag)
+      require_value "$1" "${2:-}"
+      IMAGE_TAG="$2"
+      shift 2
+      ;;
+    --local-tag)
+      require_value "$1" "${2:-}"
+      LOCAL_TAG="$2"
+      shift 2
+      ;;
+    --cuda-version)
+      require_value "$1" "${2:-}"
+      CUDA_VERSION="$2"
+      CUDA_VERSION_SET=true
+      shift 2
+      ;;
+    --no-coordinator)
+      INCLUDE_COORDINATOR=false
+      shift
+      ;;
+    --dry-run)
+      DRY_RUN=true
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "ERROR: Unknown argument: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+case "${SOURCE}" in
+  prestodb|ci) ;;
+  *)
+    echo "ERROR: --source must be one of: prestodb, ci." >&2
+    exit 1
+    ;;
+esac
+
+if [[ -z "${LOCAL_TAG}" ]]; then
+  echo "ERROR: local tag cannot be empty." >&2
+  exit 1
+fi
+
+if [[ "${SOURCE}" == "prestodb" && "${CUDA_VERSION_SET}" == true ]]; then
+  echo "ERROR: --cuda-version is only valid with --source ci." >&2
+  exit 1
+fi
+
+want_role() {
+  local role=$1
+  case "${role}" in
+    coordinator) [[ "${INCLUDE_COORDINATOR}" == true ]] ;;
+    gpu_worker) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+set_preset_images() {
+  case "${SOURCE}" in
+    prestodb)
+      IMAGE_TAG="${IMAGE_TAG:-gpu-nightly}"
+      if [[ "${IMAGE_TAG}" == "gpu-nightly" ]]; then
+        COORDINATOR_IMAGE="prestodb/presto:coordinator-gpu-nightly"
+      else
+        COORDINATOR_IMAGE="prestodb/presto:${IMAGE_TAG}"
+      fi
+      GPU_WORKER_IMAGE="prestodb/presto-native:${IMAGE_TAG}"
+      ;;
+    ci)
+      IMAGE_TAG="${IMAGE_TAG:-latest}"
+      if [[ "${IMAGE_TAG}" == "latest" ]]; then
+        COORDINATOR_IMAGE="${CI_IMAGE_BASE}:presto-coordinator-latest"
+        GPU_WORKER_IMAGE="${CI_IMAGE_BASE}:presto-latest-gpu-cuda${CUDA_VERSION}"
+      else
+        local presto_short_sha velox_short_sha tag_suffix coordinator_suffix worker_suffix
+        if [[ ! "${IMAGE_TAG}" =~ ^([0-9a-fA-F]+)-velox-([0-9a-fA-F]+)(-(.+))?$ ]]; then
+          echo "ERROR: custom CI tags must use '<presto_sha>-velox-<velox_sha>[-<suffix>]'." >&2
+          exit 1
+        fi
+        presto_short_sha="${BASH_REMATCH[1]}"
+        velox_short_sha="${BASH_REMATCH[2]}"
+        tag_suffix="${BASH_REMATCH[4]:-}"
+        coordinator_suffix=""
+        worker_suffix=""
+        if [[ -n "${tag_suffix}" ]]; then
+          coordinator_suffix="-${tag_suffix}"
+          worker_suffix="-${tag_suffix}"
+        fi
+        COORDINATOR_IMAGE="${CI_IMAGE_BASE}:presto-coordinator-${presto_short_sha}${coordinator_suffix}"
+        GPU_WORKER_IMAGE="${CI_IMAGE_BASE}:presto-${presto_short_sha}-velox-${velox_short_sha}-gpu-cuda${CUDA_VERSION}${worker_suffix}"
+      fi
+      ;;
+  esac
+}
+
+require_source_image() {
+  local role=$1
+  local image=$2
+  if [[ -z "${image}" ]]; then
+    echo "ERROR: source '${SOURCE}' does not define an image for ${role}." >&2
+    exit 1
+  fi
+}
+
+pull_and_tag() {
+  local source_image=$1
+  local local_repo=$2
+  local local_image="${local_repo}:${LOCAL_TAG}"
+
+  if [[ "${DRY_RUN}" == true ]]; then
+    echo "Would pull ${source_image}"
+    echo "Would tag  ${source_image} -> ${local_image}"
+    return
+  fi
+
+  echo "Pulling ${source_image}..."
+  docker_pull_with_retry "${source_image}"
+  echo "Tagging ${source_image} -> ${local_image}"
+  docker tag "${source_image}" "${local_image}"
+}
+
+validate_requested_images() {
+  if want_role coordinator; then
+    require_source_image "coordinator" "${COORDINATOR_IMAGE}"
+  fi
+
+  if want_role gpu_worker; then
+    require_source_image "gpu-worker" "${GPU_WORKER_IMAGE}"
+  fi
+}
+
+set_preset_images
+validate_requested_images
+
+echo "Source:    ${SOURCE}"
+echo "Tag:       ${IMAGE_TAG}"
+if [[ "${SOURCE}" == "ci" ]]; then
+  echo "CUDA:      ${CUDA_VERSION}"
+fi
+echo "Local tag: ${LOCAL_TAG}"
+echo ""
+
+if want_role coordinator; then
+  pull_and_tag "${COORDINATOR_IMAGE}" "presto-coordinator"
+fi
+
+if want_role gpu_worker; then
+  pull_and_tag "${GPU_WORKER_IMAGE}" "presto-native-worker-gpu"
+fi
+
+echo ""
+echo "Done. Start scripts will use these images when PRESTO_IMAGE_TAG=${LOCAL_TAG}."


### PR DESCRIPTION
## Summary
- Add `presto/scripts/pull_presto_images.sh` to pull prebuilt Presto coordinator/native GPU worker images and retag them for the existing start scripts.
- Keep the user-facing image pull surface small: default PrestoDB images, `--source ci`, `--tag`, `--local-tag`, `--cuda-version`, `--no-coordinator`, and `--dry-run`.
- Support custom PrestoDB tags such as `latest`, plus suffixed RAPIDS CI tag bodies such as `c0de72d-velox-f374779-20260616-manual-27588892754`.
- Launch upstream PrestoDB GPU worker images through the velox-testing profiling/config wrapper and tolerate images that do not include `numactl`.
- Document the simplified PrestoDB and RAPIDS CI image workflows in `presto/README.md`.

## Test plan
- [x] `bash -n presto/scripts/pull_presto_images.sh`
- [x] `./presto/scripts/pull_presto_images.sh --help`
- [x] Dry-run default PrestoDB image resolution.
- [x] Dry-run custom PrestoDB tag resolution with `--tag latest`.
- [x] Dry-run default RAPIDS CI image resolution with `--source ci`.
- [x] Dry-run custom RAPIDS CI tag resolution with `--source ci --tag c0de72d-velox-f374779-20260616-manual-27588892754`.
- [x] Dry-run retained options: `--source ci --cuda-version 12.8`, `--no-coordinator`, and `--source ci --no-coordinator`.
- [x] Verify expected failures for invalid source, invalid custom CI tag, and `--cuda-version` without `--source ci`.
- [x] `git diff --check`
- [x] Pull default PrestoDB images, start native GPU Presto, and run TPC-H Q1: passed, 469 ms.
- [x] Pull default RAPIDS CI images, start native GPU Presto, and run TPC-H Q1: passed, 519 ms.
- [x] Pull custom PrestoDB images with `--tag latest`, start native GPU Presto, and run TPC-H Q1: passed, 533 ms.
- [x] Pull custom RAPIDS CI images with `--source ci --tag c0de72d-velox-f374779-20260616-manual-27588892754`, start native GPU Presto, and run TPC-H Q1: passed, 539 ms.
