### PR TITLE
Derive Presto integration schemas from Parquet data

### DIFF
--- a/presto/testing/integration_tests/common_fixtures.py
+++ b/presto/testing/integration_tests/common_fixtures.py
@@ -28,9 +28,11 @@ def setup_and_teardown(request, presto_cursor):
 
     should_create_tables = not has_schema_name
     if should_create_tables:
-        schemas_dir = get_abs_file_path(__file__, f"../common/schemas/{benchmark_type}")
         data_sub_directory = f"integration_test/{benchmark_type}"
-        create_hive_tables.create_tables(presto_cursor, schema_name, schemas_dir, data_sub_directory)
+        data_dir = get_abs_file_path(__file__, f"../../../common/testing/integration_tests/data/{benchmark_type}")
+        create_hive_tables.create_tables_from_data(
+            presto_cursor, schema_name, benchmark_type, data_dir, data_sub_directory
+        )
 
     tables = presto_cursor.execute(f"SHOW TABLES in {schema_name}").fetchall()
     for (table,) in tables:

--- a/presto/testing/integration_tests/create_hive_tables.py
+++ b/presto/testing/integration_tests/create_hive_tables.py
@@ -3,8 +3,15 @@
 
 import argparse
 import os
+import sys
+import tempfile
+from pathlib import Path
 
 import prestodb
+
+sys.path.append(str(Path(__file__).resolve().parents[3] / "benchmark_data_tools"))
+
+from generate_table_schemas import generate_table_schemas
 
 
 def create_tables(presto_cursor, schema_name, schemas_dir_path, data_sub_directory):
@@ -18,6 +25,12 @@ def create_tables(presto_cursor, schema_name, schemas_dir_path, data_sub_directo
                 file_path=f"/var/lib/presto/data/hive/data/{data_sub_directory}/{table_name}", schema=schema_name
             )
         )
+
+
+def create_tables_from_data(presto_cursor, schema_name, benchmark_type, data_dir_path, data_sub_directory):
+    with tempfile.TemporaryDirectory() as schemas_dir:
+        generate_table_schemas(benchmark_type, schemas_dir, data_dir_path, False)
+        create_tables(presto_cursor, schema_name, schemas_dir, data_sub_directory)
 
 
 def get_table_schemas(schemas_dir):


### PR DESCRIPTION
Auto-created Presto integration test tables now derive their Hive schema from the generated Parquet data instead of static SQL files. This keeps the table schema aligned with the generated data when decimal columns are preserved or converted to doubles.

Validated locally with the TPCH decimal repro path against the CI image stack.