### PR TITLE
Add --push flag to install_tpchgen_cli.sh to publish builder image

### DIFF
--- a/benchmark_data_tools/scripts/install_tpchgen_cli.sh
+++ b/benchmark_data_tools/scripts/install_tpchgen_cli.sh
@@ -11,6 +11,21 @@ INSTALL_DIR="$SCRIPT_DIR/../.local_installs/bin"
 REPO_URL="https://github.com/TomAugspurger/tpchgen-rs.git"
 REPO_BRANCH="tom/sync-upstream-clean"
 IMAGE_NAME="tpchgen-cli-builder"
+REGISTRY_IMAGE="ghcr.io/rapidsai/velox-testing-images:tpchgen-cli"
+PUSH=false
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --push)
+            PUSH=true
+            shift
+            ;;
+        *)
+            echo "Unknown argument: $1"
+            exit 1
+            ;;
+    esac
+done
 
 TEMP_DIR=$(mktemp -d)
 trap 'rm -rf $TEMP_DIR' EXIT
@@ -25,9 +40,17 @@ echo "Extracting tpchgen-cli binary..."
 CONTAINER_ID=$(docker create "$IMAGE_NAME")
 mkdir -p "$INSTALL_DIR"
 docker cp "$CONTAINER_ID:/usr/local/bin/tpchgen-cli" "$INSTALL_DIR/tpchgen-cli"
-
-echo "Cleaning up..."
 docker rm "$CONTAINER_ID"
-docker rmi "$IMAGE_NAME"
+
+if [[ "$PUSH" == true ]]; then
+    echo "Tagging image as $REGISTRY_IMAGE..."
+    docker tag "$IMAGE_NAME" "$REGISTRY_IMAGE"
+    docker rmi "$IMAGE_NAME"
+    echo "Pushing $REGISTRY_IMAGE..."
+    docker push "$REGISTRY_IMAGE"
+else
+    echo "Cleaning up..."
+    docker rmi "$IMAGE_NAME"
+fi
 
 echo "tpchgen-cli installed at $INSTALL_DIR/tpchgen-cli"

--- a/benchmark_data_tools/scripts/install_tpchgen_cli.sh
+++ b/benchmark_data_tools/scripts/install_tpchgen_cli.sh
@@ -48,6 +48,8 @@ if [[ "$PUSH" == true ]]; then
     docker rmi "$IMAGE_NAME"
     echo "Pushing $REGISTRY_IMAGE..."
     docker push "$REGISTRY_IMAGE"
+    echo "Cleaning up..."
+    docker rmi "$REGISTRY_IMAGE"
 else
     echo "Cleaning up..."
     docker rmi "$IMAGE_NAME"


### PR DESCRIPTION
## Summary
- Adds a `--push` flag to `install_tpchgen_cli.sh` that tags the `tpchgen-cli-builder` image as `ghcr.io/rapidsai/velox-testing-images:tpchgen-cli` and pushes it to GHCR, instead of always deleting it after extracting the binary.

The motivation for this change is to enable the use of this binary in environments that don't support docker for a local build.  Our Slurm environments can pull the docker image from the registry as an Enroot image and get access to the binary that way; but can't build it directly.

## Test plan
- [x] Run `install_tpchgen_cli.sh` without `--push` and confirm the builder image is still cleaned up as before
- [x] Run `install_tpchgen_cli.sh --push` and confirm the image is tagged and pushed to `ghcr.io/rapidsai/velox-testing-images:tpchgen-cli`