### PR TITLE
Only detect CUDA_ARCHITECTURES when building Presto images

### DIFF
--- a/presto/scripts/start_presto_helper.sh
+++ b/presto/scripts/start_presto_helper.sh
@@ -160,23 +160,7 @@ if [[ "${SKIP_GENERATE_CONFIG:-false}" != "true" ]]; then
   "${SCRIPT_DIR}/generate_presto_config.sh"
 fi
 
-# must determine CUDA_ARCHITECTURES here as nvidia-smi is not available in the docker build context
-CUDA_ARCHITECTURES=""
-if [[ "$VARIANT_TYPE" == "gpu" && "$ALL_CUDA_ARCHS" == "true" ]]; then
-  # build for all supported CUDA architectures
-  CUDA_ARCHITECTURES="75;80;86;90;100;120"
-  echo "Building GPU with all supported CUDA architectures"
-elif [[ "$VARIANT_TYPE" == "gpu" ]]; then
-  # check that nvidia-smi is available
-  if ! command -v nvidia-smi &> /dev/null; then
-    echo "ERROR: nvidia-smi could not be found. Please ensure that the NVIDIA drivers and Docker runtime are properly installed."
-    exit 1
-  fi
-  # build for the native compute capability of the first GPU (assuming all GPUs are the same)
-  CUDA_ARCHITECTURES="$(nvidia-smi --query-gpu=compute_cap --format=csv,noheader | head -n 1 | sed 's/\.//g')"
-  echo "Building GPU with CUDA_ARCHITECTURES=$CUDA_ARCHITECTURES"
-elif [[ "$ALL_CUDA_ARCHS" == "true" ]]; then
-  # invalid options combination
+if [[ "$ALL_CUDA_ARCHS" == "true" && "$VARIANT_TYPE" != "gpu" ]]; then
   echo "ERROR: --all-cuda-archs specified but VARIANT_TYPE is not 'gpu'."
   exit 1
 fi
@@ -200,6 +184,21 @@ if [[ "$VARIANT_TYPE" == "gpu" ]]; then
   DOCKER_COMPOSE_FILE_PATH="$RENDERED_PATH"
 fi
 if (( ${#BUILD_TARGET_ARG[@]} )); then
+  # must determine CUDA_ARCHITECTURES here as nvidia-smi is not available in the docker build context
+  CUDA_ARCHITECTURES=""
+  if [[ "$VARIANT_TYPE" == "gpu" && "$ALL_CUDA_ARCHS" == "true" ]]; then
+    CUDA_ARCHITECTURES="75;80;86;90;100;120"
+    echo "Building GPU with all supported CUDA architectures"
+  elif [[ "$VARIANT_TYPE" == "gpu" ]]; then
+    if ! command -v nvidia-smi &> /dev/null; then
+      echo "ERROR: nvidia-smi could not be found. Please ensure that the NVIDIA drivers and Docker runtime are properly installed."
+      exit 1
+    fi
+    # build for the native compute capability of the first GPU (assuming all GPUs are the same)
+    CUDA_ARCHITECTURES="$(nvidia-smi --query-gpu=compute_cap --format=csv,noheader | head -n 1 | sed 's/\.//g')"
+    echo "Building GPU with CUDA_ARCHITECTURES=$CUDA_ARCHITECTURES"
+  fi
+
   validate_sibling_repos
   if [[ ${BUILD_TARGET_ARG[@]} =~ ($CPU_WORKER_SERVICE|$GPU_WORKER_SERVICE) ]] && is_image_missing ${DEPS_IMAGE}; then
     echo "ERROR: Presto dependencies/run-time image '${DEPS_IMAGE}' not found!"


### PR DESCRIPTION
## Summary

Move the `nvidia-smi`-based `CUDA_ARCHITECTURES` detection in `start_presto_helper.sh` into the build-target block so it only runs when a Presto image is actually built.

## Motivation

`CUDA_ARCHITECTURES` is only consumed by the `docker compose ... build` command, which lives inside the `if (( ${#BUILD_TARGET_ARG[@]} ))` block. Previously the detection ran unconditionally near the top of the script, so a **GPU-variant startup with no build target** (e.g. launching an already-built image) would still call `nvidia-smi` and `exit 1` if it wasn't available — a spurious failure, since the value isn't needed when not building.

This particular failure was occurring when trying to run cpu-only images on cpu-only machines - which should be a supported case; and should not fail if nvidia-smi was not installed.

This decouples GPU hardware detection from cluster startup: you can launch GPU Presto on a host without `nvidia-smi` unless you're building images.

## Details

- Detection logic moved inside the build block, next to its only consumer.
- The `--all-cuda-archs` without a GPU variant guard stays at the top as an early fast-fail argument validation.