### PR TITLE
Add missing boost-iostreams and bundle s2geometry for Presto build

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -21,6 +21,7 @@ RUN apt-get update -y && \
     libc-ares-dev \
     libboost-context-dev \
     libboost-filesystem-dev \
+    libboost-iostreams-dev \
     libboost-program-options-dev \
     libboost-regex-dev \
     libboost-url-dev \

--- a/scripts/devcontainer/build-presto
+++ b/scripts/devcontainer/build-presto
@@ -293,6 +293,7 @@ EXTRA_CMAKE_FLAGS+=" -DgRPC_SOURCE=BUNDLED"
 EXTRA_CMAKE_FLAGS+=" -Dxsimd_SOURCE=SYSTEM"
 EXTRA_CMAKE_FLAGS+=" -DArrow_SOURCE=BUNDLED"
 EXTRA_CMAKE_FLAGS+=" -Dgeos_SOURCE=BUNDLED"
+EXTRA_CMAKE_FLAGS+=" -Ds2geometry_SOURCE=BUNDLED"
 
 # Auto-detect pre-built RAPIDS libraries (cudf, rmm, kvikio)
 append_rapids_cmake_flags EXTRA_CMAKE_FLAGS


### PR DESCRIPTION
This PR makes two fixes for `build-presto` to complete on a fresh cuda13.1 devcontainer.

- Dockerfile: add `libboost-iostreams-dev` to the apt install list.
- scripts/devcontainer/build-presto: pass `-Ds2geometry_SOURCE=BUNDLED` to the Velox CMake configure.
