### PR TITLE
[Wrong remote] Enable AWS S3 remote data source for Presto GPU benchmarks

### DIFF
--- a/benchmark_data_tools/duckdb_utils.py
+++ b/benchmark_data_tools/duckdb_utils.py
@@ -1,9 +1,48 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 
+import json
+import os
 import re
 
 import duckdb
+
+_s3_configured = False
+
+
+def ensure_remote_access(path) -> None:
+    """Configure DuckDB to read from a remote object store if ``path`` needs it.
+
+    The region must be provided via AWS_DEFAULT_REGION (or AWS_REGION). Do nothing for local
+    paths.
+    """
+    global _s3_configured
+    if _s3_configured or not str(path).startswith("s3://"):
+        return
+    region = os.environ.get("AWS_DEFAULT_REGION") or os.environ.get("AWS_REGION")
+    if not region:
+        raise RuntimeError(
+            "Reading s3:// data requires the AWS region: set AWS_DEFAULT_REGION "
+            "(or AWS_REGION), e.g. `export AWS_DEFAULT_REGION=us-east-2`."
+        )
+    # Enable DuckDB to access S3 storage
+    duckdb.sql("INSTALL httpfs; LOAD httpfs; INSTALL aws; LOAD aws;")
+    # Register an S3 access profile named s3_from_env that pulls credentials from the
+    # standard AWS chain and targets region <region>.
+    duckdb.sql(f"CREATE SECRET IF NOT EXISTS s3_from_env (TYPE s3, PROVIDER credential_chain, REGION '{region}')")
+    _s3_configured = True
+
+
+def read_scale_factor(metadata_uri: str):
+    """Read the scale_factor field from a metadata.json at ``metadata_uri``.
+    """
+    # For local data
+    if not str(metadata_uri).startswith("s3://"):
+        with open(metadata_uri) as file:
+            return json.load(file)["scale_factor"]
+    # For remote data
+    ensure_remote_access(metadata_uri)
+    return duckdb.sql(f"SELECT scale_factor FROM read_json_auto('{metadata_uri}')").fetchone()[0]
 
 
 def quote_ident(name: str) -> str:
@@ -30,6 +69,7 @@ def drop_benchmark_tables():
 
 
 def create_table(table_name, data_path):
+    ensure_remote_access(data_path)
     duckdb.sql(f"DROP TABLE IF EXISTS {quote_ident(table_name)}")
     duckdb.sql(f"CREATE TABLE {quote_ident(table_name)} AS SELECT * FROM '{data_path}/*.parquet';")
 
@@ -37,6 +77,7 @@ def create_table(table_name, data_path):
 # Generates a sample table with a small limit.
 # This is mainly used to extract the schema from the parquet files.
 def create_not_null_table_from_sample(table_name, data_path):
+    ensure_remote_access(data_path)
     duckdb.sql(f"DROP TABLE IF EXISTS {quote_ident(table_name)}")
     duckdb.sql(f"CREATE TABLE {quote_ident(table_name)} AS SELECT * FROM '{data_path}/*.parquet' LIMIT 10;")
     ret = duckdb.sql(f"DESCRIBE TABLE {quote_ident(table_name)}").fetchall()
@@ -45,6 +86,7 @@ def create_not_null_table_from_sample(table_name, data_path):
 
 
 def create_table_from_sample(table_name, data_path):
+    ensure_remote_access(data_path)
     duckdb.sql(f"DROP TABLE IF EXISTS {quote_ident(table_name)}")
     duckdb.sql(f"CREATE TABLE {quote_ident(table_name)} AS SELECT * FROM '{data_path}/*.parquet' LIMIT 10;")
 

--- a/benchmark_data_tools/generate_table_schemas.py
+++ b/benchmark_data_tools/generate_table_schemas.py
@@ -40,7 +40,7 @@ def get_table_schema(benchmark_type, table_name):
     ]
     columns_text = ",\n".join(columns_ddl_list)
     schema = f"CREATE TABLE hive.{{schema}}.{table_name} (\n{columns_text}\n) \
-WITH (FORMAT = 'PARQUET', EXTERNAL_LOCATION = 'file:{{file_path}}')"
+WITH (FORMAT = 'PARQUET', EXTERNAL_LOCATION = '{{location}}')"
     return schema
 
 

--- a/common/testing/integration_tests/test_utils.py
+++ b/common/testing/integration_tests/test_utils.py
@@ -71,7 +71,10 @@ def write_query_engine_rows(output_dir, result_file_name, rows, columns, query_e
 
 
 def create_duckdb_table(table_name, data_path):
-    create_table(table_name, get_abs_file_path(__file__, data_path))
+    # Only resolve local path
+    if "://" not in data_path:
+        data_path = get_abs_file_path(__file__, data_path)
+    create_table(table_name, data_path)
 
 
 def initialize_output_dir(config, query_engine):

--- a/presto/docker/config/template/etc_coordinator/catalog/hive.properties
+++ b/presto/docker/config/template/etc_coordinator/catalog/hive.properties
@@ -39,8 +39,9 @@ hive.split-loader-concurrency=16
 # Affinity scheduling
 hive.node-selection-strategy=SOFT_AFFINITY
 
-# AWS S3
-hive.s3.endpoint=s3.us-east-2.amazonaws.com
+# AWS S3. The region (and thus the endpoint) is resolved from the AWS_DEFAULT_REGION
+# env var that docker-compose passes into the container — the single source of truth.
+# No hardcoded hive.s3.endpoint here, so it can't drift from the configured region.
 hive.s3.ssl.enabled=true
 hive.s3.path-style-access=false
 hive.s3.use-instance-credentials=false

--- a/presto/docker/config/template/etc_coordinator/catalog/hive.properties
+++ b/presto/docker/config/template/etc_coordinator/catalog/hive.properties
@@ -38,3 +38,9 @@ hive.split-loader-concurrency=16
 
 # Affinity scheduling
 hive.node-selection-strategy=SOFT_AFFINITY
+
+# AWS S3
+hive.s3.endpoint=s3.us-east-2.amazonaws.com
+hive.s3.ssl.enabled=true
+hive.s3.path-style-access=false
+hive.s3.use-instance-credentials=false

--- a/presto/docker/config/template/etc_worker/catalog/hive.properties
+++ b/presto/docker/config/template/etc_worker/catalog/hive.properties
@@ -14,8 +14,9 @@ hive.metastore.catalog.dir=file:/var/lib/presto/data/hive/metastore
 # state and clean up artifacts without manual intervention.
 hive.allow-drop-table=true
 
-# AWS S3
-hive.s3.endpoint=s3.us-east-2.amazonaws.com
+# AWS S3. The region (and thus the endpoint) is resolved from the AWS_DEFAULT_REGION
+# env var that docker-compose passes into the container — the single source of truth.
+# No hardcoded hive.s3.endpoint here, so it can't drift from the configured region.
 hive.s3.ssl.enabled=true
 hive.s3.path-style-access=false
 hive.s3.use-instance-credentials=false

--- a/presto/docker/config/template/etc_worker/catalog/hive.properties
+++ b/presto/docker/config/template/etc_worker/catalog/hive.properties
@@ -13,3 +13,9 @@ hive.metastore.catalog.dir=file:/var/lib/presto/data/hive/metastore
 # Allow DROP TABLE statements. Enabled to make smoke/perf tests able to reset
 # state and clean up artifacts without manual intervention.
 hive.allow-drop-table=true
+
+# AWS S3
+hive.s3.endpoint=s3.us-east-2.amazonaws.com
+hive.s3.ssl.enabled=true
+hive.s3.path-style-access=false
+hive.s3.use-instance-credentials=false

--- a/presto/docker/docker-compose.common.yml
+++ b/presto/docker/docker-compose.common.yml
@@ -22,9 +22,15 @@ services:
       - 8080:8080
     environment:
       - SERVER_START_TIMESTAMP=${SERVER_START_TIMESTAMP:-}
+      - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID:-}
+      - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY:-}
+      - AWS_SESSION_TOKEN=${AWS_SESSION_TOKEN:-}
+      # Region for the AWS default chain. Must match the data bucket / hive.s3.endpoint.
+      - AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION:-us-east-2}
+      - AWS_REGION=${AWS_REGION:-us-east-2}
     volumes:
       - ./launch_coordinator.sh:/opt/launch_coordinator.sh:ro
-    entrypoint: ["bash", "/opt/launch_coordinator.sh"]
+    entrypoint: [ "bash", "/opt/launch_coordinator.sh" ]
     command: []
 
   presto-base-native-worker:
@@ -44,3 +50,10 @@ services:
     environment:
       - GLOG_logtostderr=1
       - SERVER_START_TIMESTAMP=${SERVER_START_TIMESTAMP:-}
+      - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID:-}
+      - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY:-}
+      - AWS_SESSION_TOKEN=${AWS_SESSION_TOKEN:-}
+      # KvikIO's S3 endpoint builds https://<bucket>.s3.<region>.amazonaws.com/<obj>
+      # from an s3:// URL and REQUIRES a region. Must match the data bucket / hive.s3.endpoint.
+      - AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION:-us-east-2}
+      - AWS_REGION=${AWS_REGION:-us-east-2}

--- a/presto/docker/docker-compose.common.yml
+++ b/presto/docker/docker-compose.common.yml
@@ -25,9 +25,8 @@ services:
       - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID:-}
       - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY:-}
       - AWS_SESSION_TOKEN=${AWS_SESSION_TOKEN:-}
-      # Region for the AWS default chain. Must match the data bucket / hive.s3.endpoint.
-      - AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION:-us-east-2}
-      - AWS_REGION=${AWS_REGION:-us-east-2}
+      - AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION:-}
+      - AWS_REGION=${AWS_REGION:-}
     volumes:
       - ./launch_coordinator.sh:/opt/launch_coordinator.sh:ro
     entrypoint: [ "bash", "/opt/launch_coordinator.sh" ]
@@ -53,7 +52,5 @@ services:
       - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID:-}
       - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY:-}
       - AWS_SESSION_TOKEN=${AWS_SESSION_TOKEN:-}
-      # KvikIO's S3 endpoint builds https://<bucket>.s3.<region>.amazonaws.com/<obj>
-      # from an s3:// URL and REQUIRES a region. Must match the data bucket / hive.s3.endpoint.
-      - AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION:-us-east-2}
-      - AWS_REGION=${AWS_REGION:-us-east-2}
+      - AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION:-}
+      - AWS_REGION=${AWS_REGION:-}

--- a/presto/scripts/register_external_tables.sh
+++ b/presto/scripts/register_external_tables.sh
@@ -1,0 +1,147 @@
+#!/bin/bash
+
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+# SPDX-License-Identifier: Apache-2.0
+
+set -e
+
+print_help() {
+  cat << EOF
+
+Usage: $0 [OPTIONS]
+
+Registers benchmark external tables in a Presto Hive schema whose data lives at an
+arbitrary EXTERNAL_LOCATION URI. The location scheme is not interpreted here, so any
+URI works (e.g. file:, s3://).
+
+The tables are created with EXTERNAL_LOCATION = <base>/<table_name>, where <base>
+is the --external-location-base value (which must already include the scale-factor
+directory, e.g. s3://bucket/prefix/sf100).
+
+NOTE: This script assumes a Presto server is already running.
+
+OPTIONS:
+    -h, --help                      Show this help message.
+    -b, --benchmark-type            Benchmark type: "tpch" or "tpcds" (required).
+    -s, --schema-name               Name of the Hive schema to (re)create tables in (required).
+                                    The schema is dropped and recreated.
+    -l, --external-location-base    Full URI base that contains one subdirectory per table,
+                                    e.g. s3://my-bucket/velox/sf100 (required). "/<table_name>"
+                                    will be appended per table.
+    -H, --hostname                  Hostname of the Presto coordinator (default: localhost).
+    -p, --port                      Port number of the Presto coordinator (default: 8080).
+
+EXAMPLES:
+    $0 -b tpch -s tpch_sf100_s3 -l s3://my-bucket/velox/sf100
+    $0 --benchmark-type tpch --schema-name tpch_sf100_s3 \\
+       --external-location-base s3://my-bucket/velox/sf100 -H localhost -p 8080
+
+EOF
+}
+
+parse_args() {
+  while [[ $# -gt 0 ]]; do
+    case $1 in
+      -h|--help)
+        print_help
+        exit 0
+        ;;
+      -b|--benchmark-type)
+        if [[ -n $2 ]]; then
+          BENCHMARK_TYPE=$2
+          shift 2
+        else
+          echo "Error: --benchmark-type requires a value"
+          exit 1
+        fi
+        ;;
+      -s|--schema-name)
+        if [[ -n $2 ]]; then
+          SCHEMA_NAME=$2
+          shift 2
+        else
+          echo "Error: --schema-name requires a value"
+          exit 1
+        fi
+        ;;
+      -l|--external-location-base)
+        if [[ -n $2 ]]; then
+          EXTERNAL_LOCATION_BASE=$2
+          shift 2
+        else
+          echo "Error: --external-location-base requires a value"
+          exit 1
+        fi
+        ;;
+      -H|--hostname)
+        if [[ -n $2 ]]; then
+          HOST_NAME=$2
+          shift 2
+        else
+          echo "Error: --hostname requires a value"
+          exit 1
+        fi
+        ;;
+      -p|--port)
+        if [[ -n $2 ]]; then
+          PORT=$2
+          shift 2
+        else
+          echo "Error: --port requires a value"
+          exit 1
+        fi
+        ;;
+      *)
+        echo "Error: Unknown argument $1"
+        print_help
+        exit 1
+        ;;
+    esac
+  done
+}
+
+parse_args "$@"
+
+if [[ -z ${BENCHMARK_TYPE} || ! ${BENCHMARK_TYPE} =~ ^tpc(h|ds)$ ]]; then
+  echo "Error: A valid benchmark type (tpch or tpcds) is required. Use the -b or --benchmark-type argument."
+  print_help
+  exit 1
+fi
+
+if [[ -z ${SCHEMA_NAME} ]]; then
+  echo "Error: A schema name is required. Use the -s or --schema-name argument."
+  print_help
+  exit 1
+fi
+
+if [[ -z ${EXTERNAL_LOCATION_BASE} ]]; then
+  echo "Error: An external location base is required. Use the -l or --external-location-base argument."
+  print_help
+  exit 1
+fi
+
+# Compute the directory where this script resides
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+source "${SCRIPT_DIR}/presto_connection_defaults.sh"
+set_presto_coordinator_defaults
+
+source "${SCRIPT_DIR}/common_functions.sh"
+wait_for_worker_node_registration "$HOST_NAME" "$PORT"
+
+SCHEMAS_DIR=$(readlink -f "${SCRIPT_DIR}/../testing/common/schemas/${BENCHMARK_TYPE}")
+CREATE_TABLES_SCRIPT_PATH=$(readlink -f "${SCRIPT_DIR}/../testing/integration_tests/create_hive_tables.py")
+REQUIREMENTS_PATH=$(readlink -f "${SCRIPT_DIR}/../testing/requirements.txt")
+
+echo "Registering ${BENCHMARK_TYPE} tables in schema '${SCHEMA_NAME}' at base: ${EXTERNAL_LOCATION_BASE}"
+
+# HOSTNAME/PORT are read by create_hive_tables.py to connect to the coordinator.
+HOSTNAME="$HOST_NAME" PORT="$PORT" "${SCRIPT_DIR}/../../scripts/run_py_script.sh" \
+  -p "$CREATE_TABLES_SCRIPT_PATH" \
+  -r "$REQUIREMENTS_PATH" \
+  -- \
+  --schema-name "$SCHEMA_NAME" \
+  --schemas-dir-path "$SCHEMAS_DIR" \
+  --external-location-base "$EXTERNAL_LOCATION_BASE"
+
+echo "Done registering ${BENCHMARK_TYPE} external tables in hive.${SCHEMA_NAME}"

--- a/presto/scripts/run_benchmark.sh
+++ b/presto/scripts/run_benchmark.sh
@@ -24,6 +24,8 @@ This script runs the specified type of benchmark.
 OPTIONS:
     -h, --help              Show this help message.
     -b, --benchmark-type    Type of benchmark to run. Only "tpch" and "tpcds" are currently supported.
+    -f, --scale-factor      Scale factor of the benchmark data. Required for remote (e.g. S3) tables to
+                            skip reading a local metadata.json to derive it. Optional for local tables.
     -q, --queries           Set of benchmark queries to run. This should be a comma separate list of query numbers.
                             By default, all benchmark queries are run.
     --queries-file          Path to a custom JSON file containing query definitions. When specified, queries are loaded
@@ -95,6 +97,15 @@ parse_args() {
           shift 2
         else
           echo "Error: --queries requires a value"
+          exit 1
+        fi
+        ;;
+      -f|--scale-factor)
+        if [[ -n $2 ]]; then
+          SCALE_FACTOR=$2
+          shift 2
+        else
+          echo "Error: --scale-factor requires a value"
           exit 1
         fi
         ;;
@@ -245,6 +256,10 @@ PYTEST_ARGS=("--schema-name ${SCHEMA_NAME}")
 
 if [[ -n ${QUERIES} ]]; then
   PYTEST_ARGS+=("--queries ${QUERIES}")
+fi
+
+if [[ -n ${SCALE_FACTOR} ]]; then
+  PYTEST_ARGS+=("--scale-factor ${SCALE_FACTOR}")
 fi
 
 if [[ -n ${QUERIES_FILE} ]]; then

--- a/presto/scripts/run_benchmark.sh
+++ b/presto/scripts/run_benchmark.sh
@@ -24,8 +24,6 @@ This script runs the specified type of benchmark.
 OPTIONS:
     -h, --help              Show this help message.
     -b, --benchmark-type    Type of benchmark to run. Only "tpch" and "tpcds" are currently supported.
-    -f, --scale-factor      Scale factor of the benchmark data. Required for remote (e.g. S3) tables to
-                            skip reading a local metadata.json to derive it. Optional for local tables.
     -q, --queries           Set of benchmark queries to run. This should be a comma separate list of query numbers.
                             By default, all benchmark queries are run.
     --queries-file          Path to a custom JSON file containing query definitions. When specified, queries are loaded
@@ -97,15 +95,6 @@ parse_args() {
           shift 2
         else
           echo "Error: --queries requires a value"
-          exit 1
-        fi
-        ;;
-      -f|--scale-factor)
-        if [[ -n $2 ]]; then
-          SCALE_FACTOR=$2
-          shift 2
-        else
-          echo "Error: --scale-factor requires a value"
           exit 1
         fi
         ;;
@@ -256,10 +245,6 @@ PYTEST_ARGS=("--schema-name ${SCHEMA_NAME}")
 
 if [[ -n ${QUERIES} ]]; then
   PYTEST_ARGS+=("--queries ${QUERIES}")
-fi
-
-if [[ -n ${SCALE_FACTOR} ]]; then
-  PYTEST_ARGS+=("--scale-factor ${SCALE_FACTOR}")
 fi
 
 if [[ -n ${QUERIES_FILE} ]]; then

--- a/presto/testing/common/schemas/tpcds/call_center.sql
+++ b/presto/testing/common/schemas/tpcds/call_center.sql
@@ -30,4 +30,4 @@ CREATE TABLE hive.{schema}.call_center (
     cc_country VARCHAR,
     cc_gmt_offset DOUBLE,
     cc_tax_percentage DOUBLE
-) WITH (FORMAT = 'PARQUET', EXTERNAL_LOCATION = 'file:{file_path}')
+) WITH (FORMAT = 'PARQUET', EXTERNAL_LOCATION = '{location}')

--- a/presto/testing/common/schemas/tpcds/catalog_page.sql
+++ b/presto/testing/common/schemas/tpcds/catalog_page.sql
@@ -8,4 +8,4 @@ CREATE TABLE hive.{schema}.catalog_page (
     cp_catalog_page_number INTEGER,
     cp_description VARCHAR,
     cp_type VARCHAR
-) WITH (FORMAT = 'PARQUET', EXTERNAL_LOCATION = 'file:{file_path}')
+) WITH (FORMAT = 'PARQUET', EXTERNAL_LOCATION = '{location}')

--- a/presto/testing/common/schemas/tpcds/catalog_returns.sql
+++ b/presto/testing/common/schemas/tpcds/catalog_returns.sql
@@ -26,4 +26,4 @@ CREATE TABLE hive.{schema}.catalog_returns (
     cr_reversed_charge DOUBLE,
     cr_store_credit DOUBLE,
     cr_net_loss DOUBLE
-) WITH (FORMAT = 'PARQUET', EXTERNAL_LOCATION = 'file:{file_path}')
+) WITH (FORMAT = 'PARQUET', EXTERNAL_LOCATION = '{location}')

--- a/presto/testing/common/schemas/tpcds/catalog_sales.sql
+++ b/presto/testing/common/schemas/tpcds/catalog_sales.sql
@@ -33,4 +33,4 @@ CREATE TABLE hive.{schema}.catalog_sales (
     cs_net_paid_inc_ship DOUBLE,
     cs_net_paid_inc_ship_tax DOUBLE,
     cs_net_profit DOUBLE
-) WITH (FORMAT = 'PARQUET', EXTERNAL_LOCATION = 'file:{file_path}')
+) WITH (FORMAT = 'PARQUET', EXTERNAL_LOCATION = '{location}')

--- a/presto/testing/common/schemas/tpcds/customer.sql
+++ b/presto/testing/common/schemas/tpcds/customer.sql
@@ -17,4 +17,4 @@ CREATE TABLE hive.{schema}.customer (
     c_login VARCHAR,
     c_email_address VARCHAR,
     c_last_review_date_sk INTEGER
-) WITH (FORMAT = 'PARQUET', EXTERNAL_LOCATION = 'file:{file_path}')
+) WITH (FORMAT = 'PARQUET', EXTERNAL_LOCATION = '{location}')

--- a/presto/testing/common/schemas/tpcds/customer_address.sql
+++ b/presto/testing/common/schemas/tpcds/customer_address.sql
@@ -12,4 +12,4 @@ CREATE TABLE hive.{schema}.customer_address (
     ca_country VARCHAR,
     ca_gmt_offset DOUBLE,
     ca_location_type VARCHAR
-) WITH (FORMAT = 'PARQUET', EXTERNAL_LOCATION = 'file:{file_path}')
+) WITH (FORMAT = 'PARQUET', EXTERNAL_LOCATION = '{location}')

--- a/presto/testing/common/schemas/tpcds/customer_demographics.sql
+++ b/presto/testing/common/schemas/tpcds/customer_demographics.sql
@@ -8,4 +8,4 @@ CREATE TABLE hive.{schema}.customer_demographics (
     cd_dep_count INTEGER,
     cd_dep_employed_count INTEGER,
     cd_dep_college_count INTEGER
-) WITH (FORMAT = 'PARQUET', EXTERNAL_LOCATION = 'file:{file_path}')
+) WITH (FORMAT = 'PARQUET', EXTERNAL_LOCATION = '{location}')

--- a/presto/testing/common/schemas/tpcds/date_dim.sql
+++ b/presto/testing/common/schemas/tpcds/date_dim.sql
@@ -27,4 +27,4 @@ CREATE TABLE hive.{schema}.date_dim (
     d_current_month VARCHAR,
     d_current_quarter VARCHAR,
     d_current_year VARCHAR
-) WITH (FORMAT = 'PARQUET', EXTERNAL_LOCATION = 'file:{file_path}')
+) WITH (FORMAT = 'PARQUET', EXTERNAL_LOCATION = '{location}')

--- a/presto/testing/common/schemas/tpcds/household_demographics.sql
+++ b/presto/testing/common/schemas/tpcds/household_demographics.sql
@@ -4,4 +4,4 @@ CREATE TABLE hive.{schema}.household_demographics (
     hd_buy_potential VARCHAR,
     hd_dep_count INTEGER,
     hd_vehicle_count INTEGER
-) WITH (FORMAT = 'PARQUET', EXTERNAL_LOCATION = 'file:{file_path}')
+) WITH (FORMAT = 'PARQUET', EXTERNAL_LOCATION = '{location}')

--- a/presto/testing/common/schemas/tpcds/income_band.sql
+++ b/presto/testing/common/schemas/tpcds/income_band.sql
@@ -2,4 +2,4 @@ CREATE TABLE hive.{schema}.income_band (
     ib_income_band_sk INTEGER,
     ib_lower_bound INTEGER,
     ib_upper_bound INTEGER
-) WITH (FORMAT = 'PARQUET', EXTERNAL_LOCATION = 'file:{file_path}')
+) WITH (FORMAT = 'PARQUET', EXTERNAL_LOCATION = '{location}')

--- a/presto/testing/common/schemas/tpcds/inventory.sql
+++ b/presto/testing/common/schemas/tpcds/inventory.sql
@@ -3,4 +3,4 @@ CREATE TABLE hive.{schema}.inventory (
     inv_item_sk INTEGER,
     inv_warehouse_sk INTEGER,
     inv_quantity_on_hand INTEGER
-) WITH (FORMAT = 'PARQUET', EXTERNAL_LOCATION = 'file:{file_path}')
+) WITH (FORMAT = 'PARQUET', EXTERNAL_LOCATION = '{location}')

--- a/presto/testing/common/schemas/tpcds/item.sql
+++ b/presto/testing/common/schemas/tpcds/item.sql
@@ -21,4 +21,4 @@ CREATE TABLE hive.{schema}.item (
     i_container VARCHAR,
     i_manager_id INTEGER,
     i_product_name VARCHAR
-) WITH (FORMAT = 'PARQUET', EXTERNAL_LOCATION = 'file:{file_path}')
+) WITH (FORMAT = 'PARQUET', EXTERNAL_LOCATION = '{location}')

--- a/presto/testing/common/schemas/tpcds/promotion.sql
+++ b/presto/testing/common/schemas/tpcds/promotion.sql
@@ -18,4 +18,4 @@ CREATE TABLE hive.{schema}.promotion (
     p_channel_details VARCHAR,
     p_purpose VARCHAR,
     p_discount_active VARCHAR
-) WITH (FORMAT = 'PARQUET', EXTERNAL_LOCATION = 'file:{file_path}')
+) WITH (FORMAT = 'PARQUET', EXTERNAL_LOCATION = '{location}')

--- a/presto/testing/common/schemas/tpcds/reason.sql
+++ b/presto/testing/common/schemas/tpcds/reason.sql
@@ -2,4 +2,4 @@ CREATE TABLE hive.{schema}.reason (
     r_reason_sk INTEGER,
     r_reason_id VARCHAR,
     r_reason_desc VARCHAR
-) WITH (FORMAT = 'PARQUET', EXTERNAL_LOCATION = 'file:{file_path}')
+) WITH (FORMAT = 'PARQUET', EXTERNAL_LOCATION = '{location}')

--- a/presto/testing/common/schemas/tpcds/ship_mode.sql
+++ b/presto/testing/common/schemas/tpcds/ship_mode.sql
@@ -5,4 +5,4 @@ CREATE TABLE hive.{schema}.ship_mode (
     sm_code VARCHAR,
     sm_carrier VARCHAR,
     sm_contract VARCHAR
-) WITH (FORMAT = 'PARQUET', EXTERNAL_LOCATION = 'file:{file_path}')
+) WITH (FORMAT = 'PARQUET', EXTERNAL_LOCATION = '{location}')

--- a/presto/testing/common/schemas/tpcds/store.sql
+++ b/presto/testing/common/schemas/tpcds/store.sql
@@ -28,4 +28,4 @@ CREATE TABLE hive.{schema}.store (
     s_country VARCHAR,
     s_gmt_offset DOUBLE,
     s_tax_percentage DOUBLE
-) WITH (FORMAT = 'PARQUET', EXTERNAL_LOCATION = 'file:{file_path}')
+) WITH (FORMAT = 'PARQUET', EXTERNAL_LOCATION = '{location}')

--- a/presto/testing/common/schemas/tpcds/store_returns.sql
+++ b/presto/testing/common/schemas/tpcds/store_returns.sql
@@ -19,4 +19,4 @@ CREATE TABLE hive.{schema}.store_returns (
     sr_reversed_charge DOUBLE,
     sr_store_credit DOUBLE,
     sr_net_loss DOUBLE
-) WITH (FORMAT = 'PARQUET', EXTERNAL_LOCATION = 'file:{file_path}')
+) WITH (FORMAT = 'PARQUET', EXTERNAL_LOCATION = '{location}')

--- a/presto/testing/common/schemas/tpcds/store_sales.sql
+++ b/presto/testing/common/schemas/tpcds/store_sales.sql
@@ -22,4 +22,4 @@ CREATE TABLE hive.{schema}.store_sales (
     ss_net_paid DOUBLE,
     ss_net_paid_inc_tax DOUBLE,
     ss_net_profit DOUBLE
-) WITH (FORMAT = 'PARQUET', EXTERNAL_LOCATION = 'file:{file_path}')
+) WITH (FORMAT = 'PARQUET', EXTERNAL_LOCATION = '{location}')

--- a/presto/testing/common/schemas/tpcds/time_dim.sql
+++ b/presto/testing/common/schemas/tpcds/time_dim.sql
@@ -9,4 +9,4 @@ CREATE TABLE hive.{schema}.time_dim (
     t_shift VARCHAR,
     t_sub_shift VARCHAR,
     t_meal_time VARCHAR
-) WITH (FORMAT = 'PARQUET', EXTERNAL_LOCATION = 'file:{file_path}')
+) WITH (FORMAT = 'PARQUET', EXTERNAL_LOCATION = '{location}')

--- a/presto/testing/common/schemas/tpcds/warehouse.sql
+++ b/presto/testing/common/schemas/tpcds/warehouse.sql
@@ -13,4 +13,4 @@ CREATE TABLE hive.{schema}.warehouse (
     w_zip VARCHAR,
     w_country VARCHAR,
     w_gmt_offset DOUBLE
-) WITH (FORMAT = 'PARQUET', EXTERNAL_LOCATION = 'file:{file_path}')
+) WITH (FORMAT = 'PARQUET', EXTERNAL_LOCATION = '{location}')

--- a/presto/testing/common/schemas/tpcds/web_page.sql
+++ b/presto/testing/common/schemas/tpcds/web_page.sql
@@ -13,4 +13,4 @@ CREATE TABLE hive.{schema}.web_page (
     wp_link_count INTEGER,
     wp_image_count INTEGER,
     wp_max_ad_count INTEGER
-) WITH (FORMAT = 'PARQUET', EXTERNAL_LOCATION = 'file:{file_path}')
+) WITH (FORMAT = 'PARQUET', EXTERNAL_LOCATION = '{location}')

--- a/presto/testing/common/schemas/tpcds/web_returns.sql
+++ b/presto/testing/common/schemas/tpcds/web_returns.sql
@@ -23,4 +23,4 @@ CREATE TABLE hive.{schema}.web_returns (
     wr_reversed_charge DOUBLE,
     wr_account_credit DOUBLE,
     wr_net_loss DOUBLE
-) WITH (FORMAT = 'PARQUET', EXTERNAL_LOCATION = 'file:{file_path}')
+) WITH (FORMAT = 'PARQUET', EXTERNAL_LOCATION = '{location}')

--- a/presto/testing/common/schemas/tpcds/web_sales.sql
+++ b/presto/testing/common/schemas/tpcds/web_sales.sql
@@ -33,4 +33,4 @@ CREATE TABLE hive.{schema}.web_sales (
     ws_net_paid_inc_ship DOUBLE,
     ws_net_paid_inc_ship_tax DOUBLE,
     ws_net_profit DOUBLE
-) WITH (FORMAT = 'PARQUET', EXTERNAL_LOCATION = 'file:{file_path}')
+) WITH (FORMAT = 'PARQUET', EXTERNAL_LOCATION = '{location}')

--- a/presto/testing/common/schemas/tpcds/web_site.sql
+++ b/presto/testing/common/schemas/tpcds/web_site.sql
@@ -25,4 +25,4 @@ CREATE TABLE hive.{schema}.web_site (
     web_country VARCHAR,
     web_gmt_offset DOUBLE,
     web_tax_percentage DOUBLE
-) WITH (FORMAT = 'PARQUET', EXTERNAL_LOCATION = 'file:{file_path}')
+) WITH (FORMAT = 'PARQUET', EXTERNAL_LOCATION = '{location}')

--- a/presto/testing/common/schemas/tpch/customer.sql
+++ b/presto/testing/common/schemas/tpch/customer.sql
@@ -7,4 +7,4 @@ CREATE TABLE hive.{schema}.customer (
     c_acctbal DECIMAL(15,2) NOT NULL,
     c_mktsegment VARCHAR NOT NULL,
     c_comment VARCHAR NOT NULL
-) WITH (FORMAT = 'PARQUET', EXTERNAL_LOCATION = 'file:{file_path}')
+) WITH (FORMAT = 'PARQUET', EXTERNAL_LOCATION = '{location}')

--- a/presto/testing/common/schemas/tpch/lineitem.sql
+++ b/presto/testing/common/schemas/tpch/lineitem.sql
@@ -15,4 +15,4 @@ CREATE TABLE hive.{schema}.lineitem (
     l_shipinstruct VARCHAR NOT NULL,
     l_shipmode VARCHAR NOT NULL,
     l_comment VARCHAR NOT NULL
-) WITH (FORMAT = 'PARQUET', EXTERNAL_LOCATION = 'file:{file_path}')
+) WITH (FORMAT = 'PARQUET', EXTERNAL_LOCATION = '{location}')

--- a/presto/testing/common/schemas/tpch/nation.sql
+++ b/presto/testing/common/schemas/tpch/nation.sql
@@ -3,4 +3,4 @@ CREATE TABLE hive.{schema}.nation (
     n_name VARCHAR NOT NULL,
     n_regionkey BIGINT NOT NULL,
     n_comment VARCHAR NOT NULL
-) WITH (FORMAT = 'PARQUET', EXTERNAL_LOCATION = 'file:{file_path}')
+) WITH (FORMAT = 'PARQUET', EXTERNAL_LOCATION = '{location}')

--- a/presto/testing/common/schemas/tpch/orders.sql
+++ b/presto/testing/common/schemas/tpch/orders.sql
@@ -8,4 +8,4 @@ CREATE TABLE hive.{schema}.orders (
     o_clerk VARCHAR NOT NULL,
     o_shippriority INTEGER NOT NULL,
     o_comment VARCHAR NOT NULL
-) WITH (FORMAT = 'PARQUET', EXTERNAL_LOCATION = 'file:{file_path}')
+) WITH (FORMAT = 'PARQUET', EXTERNAL_LOCATION = '{location}')

--- a/presto/testing/common/schemas/tpch/part.sql
+++ b/presto/testing/common/schemas/tpch/part.sql
@@ -8,4 +8,4 @@ CREATE TABLE hive.{schema}.part (
     p_container VARCHAR NOT NULL,
     p_retailprice DECIMAL(15,2) NOT NULL,
     p_comment VARCHAR NOT NULL
-) WITH (FORMAT = 'PARQUET', EXTERNAL_LOCATION = 'file:{file_path}')
+) WITH (FORMAT = 'PARQUET', EXTERNAL_LOCATION = '{location}')

--- a/presto/testing/common/schemas/tpch/partsupp.sql
+++ b/presto/testing/common/schemas/tpch/partsupp.sql
@@ -4,4 +4,4 @@ CREATE TABLE hive.{schema}.partsupp (
     ps_availqty INTEGER NOT NULL,
     ps_supplycost DECIMAL(15,2) NOT NULL,
     ps_comment VARCHAR NOT NULL
-) WITH (FORMAT = 'PARQUET', EXTERNAL_LOCATION = 'file:{file_path}')
+) WITH (FORMAT = 'PARQUET', EXTERNAL_LOCATION = '{location}')

--- a/presto/testing/common/schemas/tpch/region.sql
+++ b/presto/testing/common/schemas/tpch/region.sql
@@ -2,4 +2,4 @@ CREATE TABLE hive.{schema}.region (
     r_regionkey BIGINT NOT NULL,
     r_name VARCHAR NOT NULL,
     r_comment VARCHAR NOT NULL
-) WITH (FORMAT = 'PARQUET', EXTERNAL_LOCATION = 'file:{file_path}')
+) WITH (FORMAT = 'PARQUET', EXTERNAL_LOCATION = '{location}')

--- a/presto/testing/common/schemas/tpch/supplier.sql
+++ b/presto/testing/common/schemas/tpch/supplier.sql
@@ -6,4 +6,4 @@ CREATE TABLE hive.{schema}.supplier (
     s_phone VARCHAR NOT NULL,
     s_acctbal DECIMAL(15,2) NOT NULL,
     s_comment VARCHAR NOT NULL
-) WITH (FORMAT = 'PARQUET', EXTERNAL_LOCATION = 'file:{file_path}')
+) WITH (FORMAT = 'PARQUET', EXTERNAL_LOCATION = '{location}')

--- a/presto/testing/common/test_utils.py
+++ b/presto/testing/common/test_utils.py
@@ -3,37 +3,48 @@
 
 import os
 import re
+import sys
 
 import pytest
 
 from common.testing.test_utils import (
     get_abs_file_path,
     get_queries,  # noqa: F401
-    get_scale_factor_from_file,
 )
+
+sys.path.append(get_abs_file_path(__file__, "../../../benchmark_data_tools"))
 
 
 def get_table_external_location(schema_name, table, presto_cursor):
     create_table_text = presto_cursor.execute(f"SHOW CREATE TABLE hive.{schema_name}.{table}").fetchone()
-    test_pattern = r"external_location = 'file:/var/lib/presto/data/hive/data/integration_test/(.*)'"
-    user_pattern = r"external_location = 'file:/var/lib/presto/data/hive/data/user_data/(.*)'"
     assert len(create_table_text) == 1
-    test_match = re.search(test_pattern, create_table_text[0])
-    external_dir = ""
+    # Capture everything between two single quotes
+    location_match = re.search(r"external_location = '([^']*)'", create_table_text[0])
+    location = location_match.group(1) if location_match else ""
+    # For remote path
+    if location and not location.startswith("file:"):
+        return location
+    # For local path
+    test_match = re.search(r"^file:/var/lib/presto/data/hive/data/integration_test/(.*)$", location)
     if test_match:
         external_dir = get_abs_file_path(
             __file__, f"../../../common/testing/integration_tests/data/{test_match.group(1)}"
         )
     else:
-        user_match = re.search(user_pattern, create_table_text[0])
-        if user_match:
-            external_dir = f"{os.environ['PRESTO_DATA_DIR']}/{user_match.group(1)}"
+        user_match = re.search(r"^file:/var/lib/presto/data/hive/data/user_data/(.*)$", location)
+        external_dir = f"{os.environ['PRESTO_DATA_DIR']}/{user_match.group(1)}" if user_match else ""
     if not os.path.isdir(external_dir):
         raise Exception(
-            f"External location '{external_dir}' referenced by table hive.{schema_name}.{table} \
-does not exist"
+            f"External location '{external_dir}' referenced by table hive.{schema_name}.{table} does not exist"
         )
     return external_dir
+
+
+def read_scale_factor(metadata_uri):
+    """Read the scale factor from a metadata.json at metadata_uri (local path or s3://)."""
+    import duckdb_utils
+
+    return duckdb_utils.read_scale_factor(metadata_uri)
 
 
 def get_scale_factor(request, presto_cursor):
@@ -45,17 +56,18 @@ def get_scale_factor(request, presto_cursor):
     repository_path = ""
     if bool(schema_name):
         # If a schema name is specified, get the scale factor from the metadata file located
-        # where the table are fetching data from.
+        # where the table are fetching data from (can be local or remote).
         table = presto_cursor.execute(f"SHOW TABLES in {schema_name}").fetchone()[0]
         location = get_table_external_location(schema_name, table, presto_cursor)
         repository_path = os.path.dirname(location)
     else:
-        # default assumed location for metadata file.
         repository_path = get_abs_file_path(
             __file__, f"../../../common/testing/integration_tests/data/{benchmark_type}"
         )
     meta_file = f"{repository_path}/metadata.json"
-    if not os.path.exists(meta_file):
+    try:
+        return read_scale_factor(meta_file)
+    except Exception as error:
         raise pytest.UsageError(
             f"Could not find metadata file in data repository '{repository_path}'.\n"
             "Metadata file must be called 'metadata.json' and have the following format:\n"
@@ -63,5 +75,4 @@ def get_scale_factor(request, presto_cursor):
             '  "scale_factor": <scale_factor>\n'
             "}\n"
             "where <scale_factor> is a floating point number."
-        )
-    return get_scale_factor_from_file(meta_file)
+        ) from error

--- a/presto/testing/integration_tests/create_hive_tables.py
+++ b/presto/testing/integration_tests/create_hive_tables.py
@@ -7,17 +7,19 @@ import os
 import prestodb
 
 
-def create_tables(presto_cursor, schema_name, schemas_dir_path, data_sub_directory):
+def create_tables(presto_cursor, schema_name, schemas_dir_path, data_sub_directory, external_location_base=None):
     drop_schema(presto_cursor, schema_name)
     presto_cursor.execute(f"CREATE SCHEMA hive.{schema_name}")
 
     schemas = get_table_schemas(schemas_dir_path)
     for table_name, schema in schemas:
-        presto_cursor.execute(
-            schema.format(
-                file_path=f"/var/lib/presto/data/hive/data/{data_sub_directory}/{table_name}", schema=schema_name
-            )
-        )
+        # When external_location_base is set (e.g. s3://bucket/prefix/sf100), point the
+        # table at that base. Otherwise fall back to the local bind-mounted file path.
+        if external_location_base:
+            location = f"{external_location_base}/{table_name}"
+        else:
+            location = f"file:/var/lib/presto/data/hive/data/{data_sub_directory}/{table_name}"
+        presto_cursor.execute(schema.format(location=location, schema=schema_name))
 
 
 def get_table_schemas(schemas_dir):
@@ -51,7 +53,20 @@ if __name__ == "__main__":
         help="The path to the directory that will contain the schema files.",
     )
     parser.add_argument(
-        "--data-dir-name", type=str, required=True, help="The name of the directory that contains the benchmark data."
+        "--data-dir-name",
+        type=str,
+        required=False,
+        default="",
+        help="The name of the directory that contains the benchmark data. Only used to build the local "
+        "file: location. Not needed when --external-location-base is set.",
+    )
+    parser.add_argument(
+        "--external-location-base",
+        type=str,
+        required=False,
+        default=None,
+        help="Full URI base for the table EXTERNAL_LOCATION (e.g. s3://bucket/prefix/sf100). For each table "
+        "'/<table_name>' is appended. If omitted, the default local file: path is used.",
     )
     args = parser.parse_args()
 
@@ -63,4 +78,4 @@ if __name__ == "__main__":
     )
     cursor = conn.cursor()
     data_sub_directory = f"user_data/{args.data_dir_name}"
-    create_tables(cursor, args.schema_name, args.schemas_dir_path, data_sub_directory)
+    create_tables(cursor, args.schema_name, args.schemas_dir_path, data_sub_directory, args.external_location_base)

--- a/presto/testing/performance_benchmarks/run_context.py
+++ b/presto/testing/performance_benchmarks/run_context.py
@@ -8,7 +8,6 @@ read from worker log files (LOGS_DIR env var). Scale factor and n_workers come f
 schema and Presto /v1/node respectively.
 """
 
-import json
 import os
 import re
 from pathlib import Path
@@ -62,15 +61,12 @@ def _get_schema_info(hostname: str, port: int, user: str, schema_name: str) -> d
             return result
         table = tables[0][0]
         location = test_utils.get_table_external_location(schema_name, table, cursor)
-        meta_path = (Path(location).parent / "metadata.json").resolve()
-        if not meta_path.is_file():
-            return result
-        with open(meta_path) as f:
-            data = json.load(f)
-        sf = data.get("scale_factor") or data.get("options", {}).get("scale_factor")
+        # Use os.path instead of pathlib.Path to avoid messing up the remote path URI
+        parent = os.path.dirname(location)
+        sf = test_utils.read_scale_factor(f"{parent}/metadata.json")
         if sf is not None:
             result["scale_factor"] = sf
-        result["data_dir"] = str(Path(location).parent)
+        result["data_dir"] = parent
         return result
     except Exception as e:
         _debug(f"schema info lookup failed: {e}")


### PR DESCRIPTION
This PR lets Presto GPU TPC-H/TPC-DS benchmarks and integration tests run against data in a remote object store (AWS S3) with no local copy of the dataset. Only the Hive metastore stays local.