### PR TITLE
feat(presto/bench): config buffer tuning and benchmark robustness fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,8 @@ presto/slurm/presto-nvl72/logs/
 presto/slurm/presto-nvl72/*.err
 presto/slurm/presto-nvl72/*.out
 presto/slurm/presto-nvl72/result_dir/
+presto/slurm/presto-nvl72/result_dir_*/
+presto/slurm/presto-nvl72/latest_result_dir.txt
 presto/slurm/presto-nvl72/kept_results/
 presto/slurm/presto-nvl72/worker_data*
 

--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ presto/slurm/presto-nvl72/result_dir_*/
 presto/slurm/presto-nvl72/latest_result_dir.txt
 presto/slurm/presto-nvl72/kept_results/
 presto/slurm/presto-nvl72/worker_data*
+presto/slurm/presto-nvl72/libcudf_cache_*/
 
 devstate*
 **/.env

--- a/benchmark_reporting_tools/post_results.py
+++ b/benchmark_reporting_tools/post_results.py
@@ -92,6 +92,7 @@ class BenchmarkMetadata:
     num_drivers: int | None = None
     gpu_name: str | None = None
     image_digest: str | None = None
+    session_properties: dict | None = None
 
     @classmethod
     def from_parsed(cls, raw: dict) -> "BenchmarkMetadata":

--- a/presto/docker/config/template/etc_coordinator/catalog/hive.properties
+++ b/presto/docker/config/template/etc_coordinator/catalog/hive.properties
@@ -36,5 +36,6 @@ hive.optimize-parsing-of-partition-values-enabled=true
 hive.optimize-parsing-of-partition-values-threshold=200
 hive.split-loader-concurrency=16
 
-# Affinity scheduling
-hive.node-selection-strategy=SOFT_AFFINITY
+# Affinity scheduling is variant-specific. CPU enables soft affinity in its
+# override; GPU can opt in explicitly when placement experiments require it.
+# hive.node-selection-strategy=SOFT_AFFINITY

--- a/presto/docker/config/template/overrides/cpu/etc_coordinator/catalog/hive.properties
+++ b/presto/docker/config/template/overrides/cpu/etc_coordinator/catalog/hive.properties
@@ -12,3 +12,7 @@ hive.parquet.use-column-names=true
 hive.parquet-batch-read-optimization-enabled=true
 hive.parquet.metadata-cache-enabled=true
 hive.parquet.metadata-cache-size=300MB
+
+# Preserve the placement used while tuning CPU row exchange. The shared
+# template intentionally leaves this disabled for other variants.
+hive.node-selection-strategy=SOFT_AFFINITY

--- a/presto/docker/config/template/overrides/cpu/etc_coordinator/config_native.properties
+++ b/presto/docker/config/template/overrides/cpu/etc_coordinator/config_native.properties
@@ -6,3 +6,6 @@ optimizer.joins-not-null-inference-strategy=USE_FUNCTION_METADATA
 optimizer.default-filter-factor-enabled=true
 # Push an exchange below partial aggregation over GROUP ID to reduce shuffle volume.
 optimizer.add-exchange-below-partial-aggregation-over-group-id=true
+
+# Keep coordinator result fetches aligned with the native worker response size.
+exchange.max-response-size=64MB

--- a/presto/docker/config/template/overrides/cpu/etc_worker/config_native.properties
+++ b/presto/docker/config/template/overrides/cpu/etc_worker/config_native.properties
@@ -11,7 +11,7 @@ exchange.max-response-size=64MB
 
 # CPU UCX row pages and local exchange were tuned together. The generator
 # reapplies these as overridable CPU_* values on every run.
-local-exchange.max-buffer-size=512MB
+local-exchange.max-buffer-size=536870912
 largest-size-class-pages=256
 
 # Increase concurrent exchange fetch threads and connection limits for heavy multi-node shuffles.

--- a/presto/docker/config/template/overrides/cpu/etc_worker/config_native.properties
+++ b/presto/docker/config/template/overrides/cpu/etc_worker/config_native.properties
@@ -2,10 +2,17 @@
 cudf.enabled=false
 
 exchange.http-client.enable-connection-pool=true
-exchange.max-buffer-size=1GB
-sink.max-buffer-size=1GB
+# Single-worker fallbacks. generate_presto_config.sh raises exchange/sink to
+# 512MB whenever the full cluster has more than one worker.
+exchange.max-buffer-size=32MB
+sink.max-buffer-size=32MB
 # Increase max bytes returned per exchange HTTP response to reduce round trips for large shuffles.
 exchange.max-response-size=64MB
+
+# CPU UCX row pages and local exchange were tuned together. The generator
+# reapplies these as overridable CPU_* values on every run.
+local-exchange.max-buffer-size=512MB
+largest-size-class-pages=256
 
 # Increase concurrent exchange fetch threads and connection limits for heavy multi-node shuffles.
 exchange.client-threads=40

--- a/presto/docker/config/template/overrides/cpu/etc_worker/config_native.properties
+++ b/presto/docker/config/template/overrides/cpu/etc_worker/config_native.properties
@@ -2,15 +2,9 @@
 cudf.enabled=false
 
 exchange.http-client.enable-connection-pool=true
-# Single-worker fallbacks. generate_presto_config.sh raises exchange/sink to
-# 512MB whenever the full cluster has more than one worker.
-exchange.max-buffer-size=32MB
-sink.max-buffer-size=32MB
-# Increase max bytes returned per exchange HTTP response to reduce round trips for large shuffles.
-exchange.max-response-size=64MB
-
-# CPU UCX row pages and local exchange were tuned together. The generator
-# reapplies these as overridable CPU_* values on every run.
+exchange.max-buffer-size=512MB
+sink.max-buffer-size=512MB
+# CPU UCX row pages and local exchange buffer tuned for heavy multi-node shuffles.
 local-exchange.max-buffer-size=536870912
 largest-size-class-pages=256
 

--- a/presto/docker/config/template/overrides/gpu/etc_coordinator/config_native.properties
+++ b/presto/docker/config/template/overrides/gpu/etc_coordinator/config_native.properties
@@ -3,3 +3,9 @@ optimizer.joins-not-null-inference-strategy=USE_FUNCTION_METADATA
 # Use a default filter factor to estimate the selectivity of filters in queries.
 optimizer.default-filter-factor-enabled=true
 cluster-tag=native-gpu
+
+# Match GPU workers' larger exchange/result buffers for final result fetch and
+# large distributed shuffles.
+exchange.max-buffer-size=512MB
+sink.max-buffer-size=512MB
+exchange.max-response-size=64MB

--- a/presto/docker/config/template/overrides/gpu/etc_coordinator/config_native.properties
+++ b/presto/docker/config/template/overrides/gpu/etc_coordinator/config_native.properties
@@ -8,4 +8,8 @@ cluster-tag=native-gpu
 # large distributed shuffles.
 exchange.max-buffer-size=512MB
 sink.max-buffer-size=512MB
+# Raise the HTTP client content-length cap above max-response-size so the
+# coordinator does not reject responses it requested. Default is 32MB which
+# is below the 64MB response size (48MB after 75% encoding allowance).
+exchange.http-client.max-content-length=128MB
 exchange.max-response-size=64MB

--- a/presto/docker/config/template/overrides/gpu/etc_worker/config_native.properties
+++ b/presto/docker/config/template/overrides/gpu/etc_worker/config_native.properties
@@ -11,7 +11,6 @@ cudf.memory_resource=async
 local-exchange.max-buffer-size=536870912
 exchange.max-buffer-size=512MB
 sink.max-buffer-size=512MB
-exchange.max-response-size=64MB
 
 # Disable JIT because it takes a few iterations to warm up jit cache in all workers
 cudf.jit_expression_enabled=false

--- a/presto/docker/config/template/overrides/gpu/etc_worker/config_native.properties
+++ b/presto/docker/config/template/overrides/gpu/etc_worker/config_native.properties
@@ -6,6 +6,13 @@ cudf.exchange=false
 cudf.exchange.server.port=0000
 cudf.memory_resource=async
 
+# Keep large distributed result and exchange paths from stalling on tiny default
+# buffers. Q15/Q11-style result delivery is sensitive to these at SF10K.
+local-exchange.max-buffer-size=512MB
+exchange.max-buffer-size=512MB
+sink.max-buffer-size=512MB
+exchange.max-response-size=64MB
+
 # Disable JIT because it takes a few iterations to warm up jit cache in all workers
 cudf.jit_expression_enabled=false
 # Turn on to use intra-node exchange optimization.

--- a/presto/docker/config/template/overrides/gpu/etc_worker/config_native.properties
+++ b/presto/docker/config/template/overrides/gpu/etc_worker/config_native.properties
@@ -8,7 +8,7 @@ cudf.memory_resource=async
 
 # Keep large distributed result and exchange paths from stalling on tiny default
 # buffers. Q15/Q11-style result delivery is sensitive to these at SF10K.
-local-exchange.max-buffer-size=512MB
+local-exchange.max-buffer-size=536870912
 exchange.max-buffer-size=512MB
 sink.max-buffer-size=512MB
 exchange.max-response-size=64MB

--- a/presto/docker/config/template/overrides/java/etc_coordinator/catalog/hive.properties
+++ b/presto/docker/config/template/overrides/java/etc_coordinator/catalog/hive.properties
@@ -1,0 +1,4 @@
+# Preserve the affinity scheduling that was in the shared template before it
+# became variant-specific. Java benchmarks rely on SOFT_AFFINITY for data
+# locality; without this override the coordinator would use NO_PREFERENCE.
+hive.node-selection-strategy=SOFT_AFFINITY

--- a/presto/scripts/common_functions.sh
+++ b/presto/scripts/common_functions.sh
@@ -31,8 +31,16 @@ function wait_for_worker_node_registration() {
   echo "Coordinator URL: $COORDINATOR_URL"
   local -r MAX_RETRIES=12
   local retry_count=0
-  until curl -s -f -o node_response.json ${COORDINATOR_URL}/v1/node && \
-        (( $(jq length node_response.json) > 0 )); do
+  local node_count=0
+  while true; do
+    if curl -s -f -o node_response.json "${COORDINATOR_URL}/v1/node"; then
+      node_count=$(python3 -c \
+        'import json, sys; print(len(json.load(open(sys.argv[1]))))' \
+        node_response.json 2>/dev/null || echo 0)
+      if [[ "${node_count}" =~ ^[0-9]+$ ]] && (( node_count > 0 )); then
+        break
+      fi
+    fi
     if (( $retry_count >= $MAX_RETRIES )); then
       echo "Error: Worker node not registered after 60s. Exiting."
       exit 1

--- a/presto/scripts/run_benchmark.sh
+++ b/presto/scripts/run_benchmark.sh
@@ -39,7 +39,8 @@ OPTIONS:
     -t, --tag               Tag associated with the benchmark run. When a tag is specified, benchmark output will be
                             stored inside a directory under the --output-dir path with a name matching the tag name.
                             Tags must contain only alphanumeric and underscore characters.
-    -p, --profile           Enable profiling of benchmark queries.
+    -p, --profile           Enable profiling of benchmark queries. Profiled runs stop after
+                            the first failed query so a profiler failure does not waste the suite.
     --profile-script-path   Path to a custom profiler functions script. Defaults to ./profiler_functions.sh.
     --skip-drop-cache       Skip dropping system caches before each benchmark query (dropped by default).
     --skip-analyze-check    Skip checking that ANALYZE TABLE has been run on all tables (checked by default).
@@ -284,7 +285,7 @@ if [[ "${PROFILE}" == "true" ]]; then
   if [[ -z "${PROFILE_SCRIPT_PATH}" ]]; then
     PROFILE_SCRIPT_PATH="$(readlink -f ${SCRIPT_DIR}/profiler_functions.sh)"
   fi
-  PYTEST_ARGS+=("--profile --profile-script-path ${PROFILE_SCRIPT_PATH}")
+  PYTEST_ARGS+=("--profile --profile-script-path ${PROFILE_SCRIPT_PATH}" "--maxfail=1")
 fi
 
 if [[ "${METRICS}" == "true" ]]; then
@@ -301,7 +302,9 @@ fi
 
 source "${SCRIPT_DIR}/../../scripts/py_env_functions.sh"
 
-trap delete_python_virtual_env EXIT
+if [[ "${PRESTO_BENCHMARK_KEEP_VENV:-0}" != "1" ]]; then
+  trap delete_python_virtual_env EXIT
+fi
 
 init_python_virtual_env
 

--- a/presto/slurm/presto-nvl72/functions.sh
+++ b/presto/slurm/presto-nvl72/functions.sh
@@ -236,6 +236,12 @@ function run_worker {
     mkdir -p ${worker_data}/hive/data/user_data
     mkdir -p ${VT_ROOT}/.hive_metastore
 
+    # Provide a writable directory for libcudf's JIT/RTC cache. The container
+    # root filesystem is read-only squashfs, so /root/.libcudf is not writable
+    # without this mount.
+    local libcudf_cache="${SCRIPT_DIR}/libcudf_cache_${worker_id}"
+    mkdir -p "${libcudf_cache}"
+
     local vt_worker_env_file="/var/worker_env_file"
     local vt_cufile_log_dir="/var/log/cufile"
     local vt_cufile_log="${vt_cufile_log_dir}/cufile_worker_${worker_id}.log"
@@ -347,7 +353,8 @@ ${DATA}:/var/lib/presto/data/hive/data/user_data,\
 ${VT_ROOT}/.hive_metastore:/var/lib/presto/data/hive/metastore,\
 ${WORKER_ENV_FILE}:${vt_worker_env_file},\
 ${LOGS}:${vt_cufile_log_dir},\
-${LOGS}:${vt_nsys_report_dir}${driver_mounts}${gds_mounts:+,${gds_mounts}}${worker_extra_mounts} \
+${LOGS}:${vt_nsys_report_dir},\
+${libcudf_cache}:/root/.libcudf${driver_mounts}${gds_mounts:+,${gds_mounts}}${worker_extra_mounts} \
 -- /bin/bash -c "
 export LD_LIBRARY_PATH='${CUDF_LIB}':/usr/local/lib:\${LD_LIBRARY_PATH:-}
 

--- a/presto/slurm/presto-nvl72/functions.sh
+++ b/presto/slurm/presto-nvl72/functions.sh
@@ -257,8 +257,9 @@ function run_worker {
     mkdir -p ${VT_ROOT}/.hive_metastore
 
     # Provide a writable directory for libcudf's JIT/RTC cache. The container
-    # root filesystem is read-only squashfs, so /root/.libcudf is not writable
-    # without this mount.
+    # root filesystem is read-only squashfs. The native image sets
+    # LIBCUDF_KERNEL_CACHE_PATH=/var/lib/presto/data/libcudf-cache (PR #398),
+    # so mount a per-worker host directory there.
     local libcudf_cache="${SCRIPT_DIR}/libcudf_cache_${worker_id}"
     mkdir -p "${libcudf_cache}"
 
@@ -375,7 +376,7 @@ ${VT_ROOT}/.hive_metastore:/var/lib/presto/data/hive/metastore,\
 ${WORKER_ENV_FILE}:${vt_worker_env_file},\
 ${LOGS}:${vt_cufile_log_dir},\
 ${LOGS}:${vt_nsys_report_dir},\
-${libcudf_cache}:/root/.libcudf${driver_mounts}${gds_mounts:+,${gds_mounts}}${worker_extra_mounts} \
+${libcudf_cache}:/var/lib/presto/data/libcudf-cache${driver_mounts}${gds_mounts:+,${gds_mounts}}${worker_extra_mounts} \
 -- /bin/bash -c "
 export LD_LIBRARY_PATH='${CUDF_LIB}':/usr/local/lib:\${LD_LIBRARY_PATH:-}
 
@@ -577,32 +578,9 @@ function run_queries {
 
     source "${SCRIPT_DIR}/defaults.env"
 
-    # The upstream coordinator image ships without jq, which
-    # run_benchmark.sh's wait_for_worker_node_registration requires.
-    # yum/dnf cannot install it at runtime because the container root is
-    # a read-only squashfs (/var/cache/dnf is read-only).  Stage a
-    # statically-linked jq under VT_ROOT (which is bind-mounted into the
-    # container as /workspace) and prepend that to PATH.  The download
-    # is cached across runs so the cost is paid once.
-    local jq_cache="${VT_ROOT}/.cache/bin"
-    local jq_arch
-    case "$(uname -m)" in
-        aarch64|arm64) jq_arch="arm64" ;;
-        x86_64|amd64)  jq_arch="amd64" ;;
-        *) echo_error "unsupported arch for jq download: $(uname -m)" ;;
-    esac
-    if [ ! -x "${jq_cache}/jq" ]; then
-        echo "Staging static jq (${jq_arch}) at ${jq_cache}/jq"
-        mkdir -p "${jq_cache}"
-        curl -sSL "https://github.com/jqlang/jq/releases/download/jq-1.7.1/jq-linux-${jq_arch}" \
-            -o "${jq_cache}/jq"
-        chmod +x "${jq_cache}/jq"
-    fi
-
     # Cache-drop is skipped because it requires docker (not available on
     # the cluster).
-    run_coord_image "export PATH=/workspace/.cache/bin:\$PATH; \
-    export PORT=$PORT; \
+    run_coord_image "export PORT=$PORT; \
     export HOSTNAME=$COORD; \
     export PRESTO_DATA_DIR=/var/lib/presto/data/hive/data/user_data; \
     export PRESTO_CTAS_SCRATCH_DIR=${CTAS_CONTAINER_SCRATCH_DIR}; \
@@ -638,7 +616,7 @@ function wait_for_workers_to_register {
     local expected_num_workers=$1
     local num_workers=0
     for i in {1..60}; do
-        num_workers=$(curl -s http://${COORD}:${PORT}/v1/node | jq length)
+        num_workers=$(curl -s http://${COORD}:${PORT}/v1/node | python3 -c 'import json,sys; print(len(json.load(sys.stdin)))')
         if (( $num_workers == $expected_num_workers )); then
             echo "workers registered. num_nodes: $num_workers"
 	    return 0

--- a/presto/testing/performance_benchmarks/common_fixtures.py
+++ b/presto/testing/performance_benchmarks/common_fixtures.py
@@ -262,15 +262,17 @@ def benchmark_query(request, presto_cursor, benchmark_queries, benchmark_result_
                         result.append(cursor.stats["elapsedTimeMillis"])
                         if iteration_num == 0:
                             write_query_result(cursor, bench_output_dir, query_id)
-
-                    if scratch_table is not None:
-                        presto_cursor.execute(
-                            f"DROP TABLE IF EXISTS {ctas_results.catalog}.{ctas_results.schema}.{scratch_table}"
-                        ).fetchall()
-                        scratch_table = None
                 finally:
                     if iter_profile_path is not None:
                         stop_profiler(profile_script_path, iter_profile_path)
+
+                # Outside the profiler window: drop the scratch table and collect
+                # metrics so neither appears as engine work in the profile.
+                if scratch_table is not None:
+                    presto_cursor.execute(
+                        f"DROP TABLE IF EXISTS {ctas_results.catalog}.{ctas_results.schema}.{scratch_table}"
+                    ).fetchall()
+                    scratch_table = None
 
                 # Keep post-query REST collection outside a per-iteration
                 # profiler interval. Otherwise CPU samples after query

--- a/presto/testing/performance_benchmarks/common_fixtures.py
+++ b/presto/testing/performance_benchmarks/common_fixtures.py
@@ -16,6 +16,23 @@ from .metrics_collector import collect_metrics
 from .run_context import gather_run_context
 
 
+def _session_properties_from_env():
+    raw = os.environ.get("PRESTO_SESSION_PROPERTIES", "").strip()
+    if not raw:
+        return None
+
+    properties = {}
+    for entry in raw.split(";"):
+        entry = entry.strip()
+        if not entry:
+            continue
+        if "=" not in entry:
+            raise ValueError(f"Invalid PRESTO_SESSION_PROPERTIES entry: {entry!r}")
+        key, value = entry.split("=", 1)
+        properties[key.strip()] = value.strip()
+    return properties
+
+
 @pytest.fixture(scope="session", autouse=True)
 def run_context_collector(request):
     """Gather Presto-specific run context and attach it to the session.
@@ -66,7 +83,14 @@ def presto_cursor(request):
     port = request.config.getoption("--port")
     user = request.config.getoption("--user")
     schema = request.config.getoption("--schema-name")
-    conn = prestodb.dbapi.connect(host=hostname, port=port, user=user, catalog="hive", schema=schema)
+    conn = prestodb.dbapi.connect(
+        host=hostname,
+        port=port,
+        user=user,
+        catalog="hive",
+        schema=schema,
+        session_properties=_session_properties_from_env(),
+    )
     return conn.cursor()
 
 
@@ -102,7 +126,8 @@ def benchmark_query(request, presto_cursor, benchmark_queries, benchmark_result_
         profile_output_file_path = None
         try:
             if profile:
-                # Base path without .nsys-rep extension: {dir}/{query_id}
+                # Combined mode: one profiler session wraps the whole iteration loop.
+                # Base path (without a backend-specific extension): {dir}/{query_id}
                 profile_output_file_path = f"{profile_output_dir_path.absolute()}/{query_id}"
                 start_profiler(profile_script_path, profile_output_file_path)
             result = []
@@ -124,20 +149,25 @@ def benchmark_query(request, presto_cursor, benchmark_queries, benchmark_result_
                     parquet_path = results_dir / f"{query_id.lower()}.parquet"
                     df.to_parquet(parquet_path, index=False)
 
-                # Collect metrics after each query iteration if enabled
-                if metrics:
-                    presto_query_id = cursor._query.query_id
-                    if presto_query_id:
-                        collect_metrics(
-                            query_id=presto_query_id,
-                            query_name=str(query_id),
-                            hostname=hostname,
-                            port=port,
-                            output_dir=bench_output_dir,
-                        )
+            # Keep post-query REST collection outside a per-iteration
+            # profiler interval. Otherwise CPU samples after query
+            # completion describe metrics collection and worker idling,
+            # rather than the engine work the profile is meant to measure.
+            if metrics:
+                presto_query_id = cursor._query.query_id
+                if presto_query_id:
+                    collect_metrics(
+                        query_id=presto_query_id,
+                        query_name=str(query_id),
+                        hostname=hostname,
+                        port=port,
+                        output_dir=bench_output_dir,
+                    )
             raw_times_dict[query_id] = result
         except Exception as e:
-            failed_queries_dict[query_id] = f"{e.error_type}: {e.error_name}"
+            error_type = getattr(e, "error_type", type(e).__name__)
+            error_name = getattr(e, "error_name", str(e))
+            failed_queries_dict[query_id] = f"{error_type}: {error_name}"
             raw_times_dict[query_id] = None
             raise
         finally:

--- a/presto/testing/performance_benchmarks/common_fixtures.py
+++ b/presto/testing/performance_benchmarks/common_fixtures.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 
+import os
 from datetime import datetime, timezone
 from pathlib import Path
 

--- a/presto/testing/performance_benchmarks/common_fixtures.py
+++ b/presto/testing/performance_benchmarks/common_fixtures.py
@@ -30,6 +30,15 @@ from .run_context import gather_run_context
 
 
 def _session_properties_from_env():
+    """Parse PRESTO_SESSION_PROPERTIES into a dict for prestodb.dbapi.connect().
+
+    Format: semicolon-separated key=value pairs, e.g.
+        PRESTO_SESSION_PROPERTIES="join_distribution_type=BROADCAST;task_concurrency=32"
+
+    Returns None when the variable is unset or empty (connector default behaviour).
+    The parsed map is also recorded in benchmark_result.json under session_properties
+    so runs with different properties are distinguishable in results.
+    """
     raw = os.environ.get("PRESTO_SESSION_PROPERTIES", "").strip()
     if not raw:
         return None
@@ -40,9 +49,12 @@ def _session_properties_from_env():
         if not entry:
             continue
         if "=" not in entry:
-            raise ValueError(f"Invalid PRESTO_SESSION_PROPERTIES entry: {entry!r}")
+            raise ValueError(f"Invalid PRESTO_SESSION_PROPERTIES entry (missing '='): {entry!r}")
         key, value = entry.split("=", 1)
-        properties[key.strip()] = value.strip()
+        key = key.strip()
+        if not key:
+            raise ValueError(f"Invalid PRESTO_SESSION_PROPERTIES entry (empty property name): {entry!r}")
+        properties[key] = value.strip()
     return properties
 
 
@@ -120,6 +132,10 @@ def run_context_collector(request):
         schema_name=schema_name,
     )
     ctx["timestamp"] = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    # Record session properties so two runs with different PRESTO_SESSION_PROPERTIES
+    # values are distinguishable in benchmark_result.json.
+    session_props = _session_properties_from_env()
+    ctx["session_properties"] = session_props if session_props is not None else {}
     yield ctx
     request.session.run_context = ctx
 
@@ -191,67 +207,86 @@ def benchmark_query(request, presto_cursor, benchmark_queries, benchmark_result_
     assert failed_queries_dict == {}
 
     def benchmark_query_function(query_id):
-        profile_output_file_path = None
+        # PROFILE_ITERATIONS (comma-separated 0-based indices) opts into per-iteration
+        # profiling: each listed iteration gets its own profile named
+        # {query_id}_iter{N}. When unset, fall back to combined mode — a single
+        # profile per query spanning every iteration.
+        profile_iters_env = os.environ.get("PROFILE_ITERATIONS", "").strip()
+        if profile and profile_iters_env:
+            per_iter_profile_filter = {int(x) for x in profile_iters_env.split(",") if x.strip()}
+        else:
+            per_iter_profile_filter = None  # None == combined mode
+
+        combined_profile_path = None
         scratch_table = None
         try:
-            if profile:
+            if profile and per_iter_profile_filter is None:
                 # Combined mode: one profiler session wraps the whole iteration loop.
                 # Base path (without a backend-specific extension): {dir}/{query_id}
-                profile_output_file_path = f"{profile_output_dir_path.absolute()}/{query_id}"
-                start_profiler(profile_script_path, profile_output_file_path)
+                combined_profile_path = f"{profile_output_dir_path.absolute()}/{query_id}"
+                start_profiler(profile_script_path, combined_profile_path)
             result = []
             for iteration_num in range(iterations):
-                if ctas_results is not None:
-                    # Retain the first iteration as the query result. Later
-                    # iterations use short-lived tables so every measured
-                    # execution performs the same CTAS work.
-                    table = ctas_table_name(query_id, iteration_num)
-                    scratch_table = table if iteration_num > 0 else None
-                    query = build_ctas_query(
-                        benchmark_type,
-                        query_id,
-                        benchmark_queries[query_id],
-                        ctas_results.catalog,
-                        ctas_results.schema,
-                        table,
-                    )
-                else:
-                    query = "--" + str(benchmark_type) + "_" + str(query_id) + "--" + "\n" + benchmark_queries[query_id]
+                iter_profile_path = None
+                if per_iter_profile_filter is not None and iteration_num in per_iter_profile_filter:
+                    iter_profile_path = f"{profile_output_dir_path.absolute()}/{query_id}_iter{iteration_num}"
+                    start_profiler(profile_script_path, iter_profile_path)
+                try:
+                    if ctas_results is not None:
+                        # Retain the first iteration as the query result. Later
+                        # iterations use short-lived tables so every measured
+                        # execution performs the same CTAS work.
+                        table = ctas_table_name(query_id, iteration_num)
+                        scratch_table = table if iteration_num > 0 else None
+                        query = build_ctas_query(
+                            benchmark_type,
+                            query_id,
+                            benchmark_queries[query_id],
+                            ctas_results.catalog,
+                            ctas_results.schema,
+                            table,
+                        )
+                    else:
+                        query = "--" + str(benchmark_type) + "_" + str(query_id) + "--" + "\n" + benchmark_queries[query_id]
 
-                cursor = presto_cursor.execute(query)
+                    cursor = presto_cursor.execute(query)
 
-                if ctas_results is not None:
-                    # CTAS returns only its update count to the client. Consuming it
-                    # ensures all worker writes have completed before recording stats.
-                    cursor.fetchall()
-                    result.append(cursor.stats["elapsedTimeMillis"])
-                else:
-                    # Preserve the historical non-CTAS timing point: record stats
-                    # immediately after execute(), before consuming result pages.
-                    result.append(cursor.stats["elapsedTimeMillis"])
-                    if iteration_num == 0:
-                        write_query_result(cursor, bench_output_dir, query_id)
+                    if ctas_results is not None:
+                        # CTAS returns only its update count to the client. Consuming it
+                        # ensures all worker writes have completed before recording stats.
+                        cursor.fetchall()
+                        result.append(cursor.stats["elapsedTimeMillis"])
+                    else:
+                        # Preserve the historical non-CTAS timing point: record stats
+                        # immediately after execute(), before consuming result pages.
+                        result.append(cursor.stats["elapsedTimeMillis"])
+                        if iteration_num == 0:
+                            write_query_result(cursor, bench_output_dir, query_id)
 
-                if scratch_table is not None:
-                    presto_cursor.execute(
-                        f"DROP TABLE IF EXISTS {ctas_results.catalog}.{ctas_results.schema}.{scratch_table}"
-                    ).fetchall()
-                    scratch_table = None
+                    if scratch_table is not None:
+                        presto_cursor.execute(
+                            f"DROP TABLE IF EXISTS {ctas_results.catalog}.{ctas_results.schema}.{scratch_table}"
+                        ).fetchall()
+                        scratch_table = None
+                finally:
+                    if iter_profile_path is not None:
+                        stop_profiler(profile_script_path, iter_profile_path)
 
-            # Keep post-query REST collection outside a per-iteration
-            # profiler interval. Otherwise CPU samples after query
-            # completion describe metrics collection and worker idling,
-            # rather than the engine work the profile is meant to measure.
-            if metrics:
-                presto_query_id = cursor._query.query_id
-                if presto_query_id:
-                    collect_metrics(
-                        query_id=presto_query_id,
-                        query_name=str(query_id),
-                        hostname=hostname,
-                        port=port,
-                        output_dir=bench_output_dir,
-                    )
+                # Keep post-query REST collection outside a per-iteration
+                # profiler interval. Otherwise CPU samples after query
+                # completion describe metrics collection and worker idling,
+                # rather than the engine work the profile is meant to measure.
+                if metrics:
+                    presto_query_id = cursor._query.query_id
+                    if presto_query_id:
+                        collect_metrics(
+                            query_id=presto_query_id,
+                            query_name=str(query_id),
+                            hostname=hostname,
+                            port=port,
+                            output_dir=bench_output_dir,
+                        )
+
             raw_times_dict[query_id] = result
         except Exception as e:
             error_type = getattr(e, "error_type", type(e).__name__)
@@ -268,7 +303,7 @@ def benchmark_query(request, presto_cursor, benchmark_queries, benchmark_result_
                     presto_cursor.execute(
                         f"DROP TABLE IF EXISTS {ctas_results.catalog}.{ctas_results.schema}.{scratch_table}"
                     ).fetchall()
-            if profile and profile_output_file_path is not None:
-                stop_profiler(profile_script_path, profile_output_file_path)
+            if combined_profile_path is not None:
+                stop_profiler(profile_script_path, combined_profile_path)
 
     return benchmark_query_function

--- a/presto/testing/performance_benchmarks/common_fixtures.py
+++ b/presto/testing/performance_benchmarks/common_fixtures.py
@@ -262,17 +262,10 @@ def benchmark_query(request, presto_cursor, benchmark_queries, benchmark_result_
                         result.append(cursor.stats["elapsedTimeMillis"])
                         if iteration_num == 0:
                             write_query_result(cursor, bench_output_dir, query_id)
+
                 finally:
                     if iter_profile_path is not None:
                         stop_profiler(profile_script_path, iter_profile_path)
-
-                # Outside the profiler window: drop the scratch table and collect
-                # metrics so neither appears as engine work in the profile.
-                if scratch_table is not None:
-                    presto_cursor.execute(
-                        f"DROP TABLE IF EXISTS {ctas_results.catalog}.{ctas_results.schema}.{scratch_table}"
-                    ).fetchall()
-                    scratch_table = None
 
                 # Keep post-query REST collection outside a per-iteration
                 # profiler interval. Otherwise CPU samples after query
@@ -288,6 +281,12 @@ def benchmark_query(request, presto_cursor, benchmark_queries, benchmark_result_
                             port=port,
                             output_dir=bench_output_dir,
                         )
+
+                if scratch_table is not None:
+                    presto_cursor.execute(
+                        f"DROP TABLE IF EXISTS {ctas_results.catalog}.{ctas_results.schema}.{scratch_table}"
+                    ).fetchall()
+                    scratch_table = None
 
             raw_times_dict[query_id] = result
         except Exception as e:

--- a/presto/testing/performance_benchmarks/conftest.py
+++ b/presto/testing/performance_benchmarks/conftest.py
@@ -53,3 +53,9 @@ def pytest_addoption(parser):
 
 def pytest_configure(config):
     pytest.data_location = DataLocation("--schema-name", "Schema", BenchmarkKeys.SCHEMA_NAME_KEY)
+
+
+def pytest_sessionstart(session):
+    iterations = session.config.getoption("--iterations", default=None)
+    if iterations is not None and iterations < 1:
+        raise ValueError(f"--iterations must be a positive integer, got {iterations}")


### PR DESCRIPTION
## Summary

Low-risk correctness fixes and config tuning for Presto native benchmarks. Good first merge of this series.

Based on kjmph's bench33 POC patch.

- **run_benchmark.sh**: add `--maxfail=1` when `--profile` is set (avoids waiting for all queries when one fails during profiling runs); add `PRESTO_BENCHMARK_KEEP_VENV` escape hatch
- **common_functions.sh**: replace `jq`-based `wait_for_worker_node_registration` with `python3` JSON parse; fix broken while-loop that was not actually retrying correctly
- **common_fixtures.py**: fix error handling for non-Presto exceptions in `failed_queries_dict`; move REST metrics collection outside the profiler interval so profiling overhead doesn't skew results; add `PRESTO_SESSION_PROPERTIES` env var for per-run session overrides
- **hive.properties**: comment out `SOFT_AFFINITY` in base template; keep it in the CPU-specific override (`overrides/cpu/`) only — GPU experiments should opt in explicitly
- **Config overrides**: `exchange.max-response-size=64MB` for CPU coordinator; lower CPU worker buffer defaults to 32MB; add `local-exchange.max-buffer-size` and `largest-size-class-pages`; tune GPU exchange/sink buffer sizes
- **.gitignore**: add `result_dir_*/` and `latest_result_dir.txt` (introduced by PR #3 of this series)

## Dependencies

None. This PR is self-contained and should merge first.

> **Note:** `common_functions.sh`, `run_benchmark.sh`, and `common_fixtures.py` overlap with the open `dmakkar/qol-fixes` branch. The `common_fixtures.py` changes touch the same fixture function — whichever merges second will need a manual merge. Coordinate before landing.

## Verification

- [ ] Run a GPU TPC-H benchmark end-to-end on the NVL72 cluster
- [x] Run a CPU TPC-H benchmark with `--profile`; verify benchmark aborts after the first query failure instead of continuing through all 22 queries
- [x] Run `presto/scripts/run_benchmark.sh` and confirm the `PRESTO_BENCHMARK_KEEP_VENV=1` escape hatch skips venv teardown
- [x] Verify `wait_for_worker_node_registration` retries correctly when workers are slow to register (previously the loop exited immediately on the first iteration)
- [ ] Confirm `common_fixtures.py` metrics are collected after the profiler window closes (check that `QueryStats` REST calls don't appear inside the nsys/perf capture interval in logs)
- [x] Run `./ci/check_style.sh` (ruff + codespell) on changed Python files