### PR TITLE
feat(presto/bench): NUMA-aware Presto worker config generation

### DIFF
--- a/presto/scripts/common_functions.sh
+++ b/presto/scripts/common_functions.sh
@@ -15,6 +15,126 @@ function capture_build_provenance() {
   VELOX_REPO=$(git -C "${repo_root}/../velox" remote get-url origin 2>/dev/null || echo "")
 }
 
+# Count CPUs represented by a Linux cpulist such as "0-3,8,10-11".
+function count_linux_cpu_list() {
+  local cpulist="${1:-}"
+  [[ -n "${cpulist}" ]] || {
+    printf '0\n'
+    return 0
+  }
+  awk -F, '
+    {
+      count = 0
+      for (i = 1; i <= NF; ++i) {
+        if ($i ~ /^[0-9]+$/) {
+          count += 1
+        } else if ($i ~ /^[0-9]+-[0-9]+$/) {
+          split($i, bounds, "-")
+          count += bounds[2] - bounds[1] + 1
+        } else {
+          exit 2
+        }
+      }
+      print count
+    }
+  ' <<< "${cpulist}"
+}
+
+# Discover CPU-bearing and memory-bearing NUMA nodes from sysfs.
+#
+# Results are returned in globals so callers can use the same topology for
+# resource sizing and worker placement:
+#   CPU_NUMA_NODE_IDS              indexed CPU-bearing node IDs
+#   CPU_NUMA_NODE_CPU_COUNTS       matching logical CPU counts
+#   CPU_NUMA_NODE_MEMORY_GB        matching memory sizes, rounded down
+#   CPU_NUMA_NODE_COUNT
+#   CPU_NUMA_MIN_CPUS
+#   CPU_NUMA_MIN_MEMORY_GB
+#   CPU_NUMA_TOTAL_MEMORY_GB
+#   MEMORY_NUMA_NODE_IDS           all non-empty memory nodes (CPU DRAM + HBM)
+#   VISIBLE_NUMA_NODE_COUNT        every node* directory, including zero-memory
+#                                  accelerator proximity domains
+#
+# CPU_NUMA_SYSFS_ROOT can point at a synthetic tree for tests.
+function discover_cpu_numa_topology() {
+  local sysfs_root="${1:-${CPU_NUMA_SYSFS_ROOT:-/sys/devices/system/node}}"
+  local nullglob_was_set=0
+  shopt -q nullglob && nullglob_was_set=1
+  shopt -s nullglob
+
+  CPU_NUMA_NODE_IDS=()
+  CPU_NUMA_NODE_CPU_COUNTS=()
+  CPU_NUMA_NODE_MEMORY_GB=()
+  MEMORY_NUMA_NODE_IDS=()
+  VISIBLE_NUMA_NODE_COUNT=0
+  CPU_NUMA_NODE_COUNT=0
+  CPU_NUMA_MIN_CPUS=0
+  CPU_NUMA_MIN_MEMORY_GB=0
+  CPU_NUMA_TOTAL_MEMORY_GB=0
+
+  local -a node_dirs=("${sysfs_root}"/node[0-9]*)
+  if ((${#node_dirs[@]} > 1)); then
+    mapfile -t node_dirs < <(printf '%s\n' "${node_dirs[@]}" | sort -V)
+  fi
+
+  local node_dir node_id cpulist cpu_count memory_kb memory_gb
+  for node_dir in "${node_dirs[@]}"; do
+    [[ -d "${node_dir}" ]] || continue
+    VISIBLE_NUMA_NODE_COUNT=$((VISIBLE_NUMA_NODE_COUNT + 1))
+    node_id="${node_dir##*/node}"
+    cpulist=""
+    [[ -r "${node_dir}/cpulist" ]] && cpulist="$(tr -d '[:space:]' < "${node_dir}/cpulist")"
+    memory_kb=0
+    if [[ -r "${node_dir}/meminfo" ]]; then
+      memory_kb="$(awk '/MemTotal:/ { print $(NF - 1); exit }' "${node_dir}/meminfo")"
+    fi
+    [[ "${memory_kb}" =~ ^[0-9]+$ ]] || memory_kb=0
+    if (( memory_kb > 0 )); then
+      MEMORY_NUMA_NODE_IDS+=("${node_id}")
+    fi
+
+    [[ -n "${cpulist}" ]] || continue
+    cpu_count="$(count_linux_cpu_list "${cpulist}")" || {
+      (( nullglob_was_set )) || shopt -u nullglob
+      return 1
+    }
+    [[ "${cpu_count}" =~ ^[1-9][0-9]*$ ]] || continue
+    memory_gb=$((memory_kb / 1024 / 1024))
+    (( memory_gb > 0 )) || continue
+
+    CPU_NUMA_NODE_IDS+=("${node_id}")
+    CPU_NUMA_NODE_CPU_COUNTS+=("${cpu_count}")
+    CPU_NUMA_NODE_MEMORY_GB+=("${memory_gb}")
+    CPU_NUMA_TOTAL_MEMORY_GB=$((CPU_NUMA_TOTAL_MEMORY_GB + memory_gb))
+    if (( CPU_NUMA_MIN_CPUS == 0 || cpu_count < CPU_NUMA_MIN_CPUS )); then
+      CPU_NUMA_MIN_CPUS="${cpu_count}"
+    fi
+    if (( CPU_NUMA_MIN_MEMORY_GB == 0 || memory_gb < CPU_NUMA_MIN_MEMORY_GB )); then
+      CPU_NUMA_MIN_MEMORY_GB="${memory_gb}"
+    fi
+  done
+
+  (( nullglob_was_set )) || shopt -u nullglob
+  CPU_NUMA_NODE_COUNT="${#CPU_NUMA_NODE_IDS[@]}"
+  (( CPU_NUMA_NODE_COUNT > 0 ))
+}
+
+# Map a local worker slot to CPU-bearing NUMA nodes in contiguous balanced
+# groups. For two CPU nodes this produces:
+#   1 worker:  0
+#   2 workers: 0,1
+#   4 workers: 0,0,1,1
+function cpu_numa_node_for_worker() {
+  local local_worker_id="${1:-}" workers_per_host="${2:-}"
+  [[ "${local_worker_id}" =~ ^[0-9]+$ ]] || return 1
+  [[ "${workers_per_host}" =~ ^[1-9][0-9]*$ ]] || return 1
+  (( local_worker_id < workers_per_host )) || return 1
+  (( ${CPU_NUMA_NODE_COUNT:-0} > 0 )) || return 1
+
+  local node_index=$((local_worker_id * CPU_NUMA_NODE_COUNT / workers_per_host))
+  printf '%s\n' "${CPU_NUMA_NODE_IDS[${node_index}]}"
+}
+
 function wait_for_worker_node_registration() {
   local host="$1"
   local port="$2"
@@ -31,8 +151,16 @@ function wait_for_worker_node_registration() {
   echo "Coordinator URL: $COORDINATOR_URL"
   local -r MAX_RETRIES=12
   local retry_count=0
-  until curl -s -f -o node_response.json ${COORDINATOR_URL}/v1/node && \
-        (( $(jq length node_response.json) > 0 )); do
+  local node_count=0
+  while true; do
+    if curl -s -f -o node_response.json "${COORDINATOR_URL}/v1/node"; then
+      node_count=$(python3 -c \
+        'import json, sys; print(len(json.load(open(sys.argv[1]))))' \
+        node_response.json 2>/dev/null || echo 0)
+      if [[ "${node_count}" =~ ^[0-9]+$ ]] && (( node_count > 0 )); then
+        break
+      fi
+    fi
     if (( $retry_count >= $MAX_RETRIES )); then
       echo "Error: Worker node not registered after 60s. Exiting."
       exit 1

--- a/presto/scripts/generate_presto_config.sh
+++ b/presto/scripts/generate_presto_config.sh
@@ -47,9 +47,6 @@ function duplicate_worker_configs() {
   rm -rf ${worker_config}
   cp -r ${CONFIG_DIR}/etc_worker ${worker_config}
 
-  # single-node-execution-enabled and cudf.exchange are reconciled for all
-  # workers by the block below duplicate_worker_configs; no need to set them here.
-
   # Each worker node needs to have it's own http-server port.  This isn't used, but
   # the cudf.exchange server port is currently hard-coded to be the server port +3
   # and that needs to be unique for each worker.

--- a/presto/scripts/generate_presto_config.sh
+++ b/presto/scripts/generate_presto_config.sh
@@ -70,6 +70,9 @@ function duplicate_worker_configs() {
 # Variant override files append properties after the common templates. Keep
 # subsequent topology tuning idempotent whether a key came from either source
 # or is being introduced here for the first time.
+# Values must not contain sed metacharacters (& or \). All callers in this
+# script pass integers, booleans, or simple strings (e.g. 512MB, 10m) so this
+# is safe without escaping.
 function set_or_append_property() {
   local key=$1 value=$2 cfg=$3
   if grep -q "^${key}=" "${cfg}"; then
@@ -106,6 +109,9 @@ fi
 NUMA_NODES="${VISIBLE_NUMA_NODE_COUNT:-0}"
 (( NUMA_NODES > 0 )) || NUMA_NODES=1
 
+# Diagnostic only — logged in the auto-tune summary below for SMT context.
+# Neither variable is applied to any Presto property; CPU_DRIVERS defaults to
+# logical threads per worker and can be overridden explicitly via CPU_DRIVERS=N.
 PHYSICAL_CORES=0
 if command -v lscpu >/dev/null 2>&1; then
   PHYSICAL_CORES=$(lscpu -p 2>/dev/null \

--- a/presto/scripts/generate_presto_config.sh
+++ b/presto/scripts/generate_presto_config.sh
@@ -47,23 +47,16 @@ function duplicate_worker_configs() {
   rm -rf ${worker_config}
   cp -r ${CONFIG_DIR}/etc_worker ${worker_config}
 
-  # Some configs should only be applied if we are in a multi-worker environment.
-  if [[ ${NUM_WORKERS} -gt 1 ]]; then
-    sed -i "s+single-node-execution-enabled.*+single-node-execution-enabled=false+g" ${coord_native_config} ${worker_native_config}
-    # cuDF exchange is GPU-only. CPU distributed exchange is selected by the
-    # plan transport plus VELOX_UCX_CPU_EXCHANGE, not this worker property.
-    if [[ "${VARIANT_TYPE}" == "gpu" ]]; then
-      sed -i "s+cudf.exchange=false+cudf.exchange=true+g" ${worker_native_config}
-    fi
-  fi
+  # single-node-execution-enabled and cudf.exchange are reconciled for all
+  # workers by the block below duplicate_worker_configs; no need to set them here.
 
   # Each worker node needs to have it's own http-server port.  This isn't used, but
   # the cudf.exchange server port is currently hard-coded to be the server port +3
   # and that needs to be unique for each worker.
-  sed -i "s+http-server\.http\.port.*+http-server\.http\.port=${http_port}+g" ${worker_native_config}
-  sed -i "s+cudf.exchange.server.port=.*+cudf.exchange.server.port=${exch_port}+g" ${worker_native_config}
+  set_or_append_property "http-server.http.port" "${http_port}" "${worker_native_config}"
+  set_or_append_property "cudf.exchange.server.port" "${exch_port}" "${worker_native_config}"
   # Give each worker a unique id.
-  sed -i "s+node\.id.*+node\.id=worker_${worker_id}+g" ${worker_config}/node.properties
+  set_or_append_property "node.id" "worker_${worker_id}" "${worker_config}/node.properties"
 }
 
 # set_or_append_property <key> <value> <file>

--- a/presto/scripts/generate_presto_config.sh
+++ b/presto/scripts/generate_presto_config.sh
@@ -25,6 +25,7 @@ function echo_success {
 
 # Compute the directory where this script resides
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/common_functions.sh"
 
 if [ ! -x "${SCRIPT_DIR}/../pbench/pbench" ]; then
   echo_error "ERROR: generate_presto_config.sh script cannot find pbench at ${SCRIPT_DIR}/../pbench/pbench"
@@ -34,7 +35,7 @@ fi
 # It also adds certain config options to the workers if those options apply only to multi-worker environments.
 function duplicate_worker_configs() {
   local worker_id=$1
-  echo "Duplicating worker configs for GPU ID $worker_id"
+  echo "Duplicating worker configs for worker ID $worker_id"
   local worker_config="${CONFIG_DIR}/etc_worker_${worker_id}"
   local coord_config="${CONFIG_DIR}/etc_coordinator"
   local worker_native_config="${worker_config}/config_native.properties"
@@ -49,8 +50,11 @@ function duplicate_worker_configs() {
   # Some configs should only be applied if we are in a multi-worker environment.
   if [[ ${NUM_WORKERS} -gt 1 ]]; then
     sed -i "s+single-node-execution-enabled.*+single-node-execution-enabled=false+g" ${coord_native_config} ${worker_native_config}
-    # make cudf.exchange=true if we are running multiple workers
-    sed -i "s+cudf.exchange=false+cudf.exchange=true+g" ${worker_native_config}
+    # cuDF exchange is GPU-only. CPU distributed exchange is selected by the
+    # plan transport plus VELOX_UCX_CPU_EXCHANGE, not this worker property.
+    if [[ "${VARIANT_TYPE}" == "gpu" ]]; then
+      sed -i "s+cudf.exchange=false+cudf.exchange=true+g" ${worker_native_config}
+    fi
   fi
 
   # Each worker node needs to have it's own http-server port.  This isn't used, but
@@ -62,19 +66,139 @@ function duplicate_worker_configs() {
   sed -i "s+node\.id.*+node\.id=worker_${worker_id}+g" ${worker_config}/node.properties
 }
 
-# get host values
-NPROC=$(nproc)
-# lsmem will report in SI.  Make sure we get values in GB.
-RAM_GB=$(lsmem -b | grep "Total online memory" | awk '{print int($4 / (1024*1024*1024)); }')
+# set_or_append_property <key> <value> <file>
+# Variant override files append properties after the common templates. Keep
+# subsequent topology tuning idempotent whether a key came from either source
+# or is being introduced here for the first time.
+function set_or_append_property() {
+  local key=$1 value=$2 cfg=$3
+  if grep -q "^${key}=" "${cfg}"; then
+    sed -i "s|^${key}=.*|${key}=${value}|" "${cfg}"
+  else
+    echo "${key}=${value}" >> "${cfg}"
+  fi
+}
+
+# Get host values. lsmem can be installed but unusable when memory sysfs is
+# hidden from a container, so fall back to /proc/meminfo. NPROC/RAM_GB may be
+# supplied explicitly to make topology tests reproducible.
+NPROC="${NPROC:-$(nproc)}"
+RAM_GB="${RAM_GB:-}"
+if [[ -z "${RAM_GB}" ]] && command -v lsmem >/dev/null 2>&1; then
+  RAM_GB="$(lsmem -b 2>/dev/null \
+    | awk '/Total online memory/ { print int($4 / (1024*1024*1024)); exit }' \
+    || true)"
+fi
+if [[ -z "${RAM_GB}" && -r /proc/meminfo ]]; then
+  RAM_GB="$(awk '/^MemTotal:/ { print int($2 / (1024*1024)); exit }' /proc/meminfo)"
+fi
+if [[ ! "${NPROC}" =~ ^[1-9][0-9]*$ || ! "${RAM_GB}" =~ ^[1-9][0-9]*$ ]]; then
+  echo_error "ERROR: could not determine positive NPROC/RAM_GB host values. Set them explicitly."
+fi
+
+# Linux exposes Grace CPU/DRAM nodes and accelerator/HBM proximity domains in
+# the same NUMA namespace. Count them separately: only nodes with both CPUs and
+# memory are valid targets for CPU workers.
+NUMA_TOPOLOGY_AVAILABLE=0
+if discover_cpu_numa_topology; then
+  NUMA_TOPOLOGY_AVAILABLE=1
+fi
+NUMA_NODES="${VISIBLE_NUMA_NODE_COUNT:-0}"
+(( NUMA_NODES > 0 )) || NUMA_NODES=1
+
+PHYSICAL_CORES=0
+if command -v lscpu >/dev/null 2>&1; then
+  PHYSICAL_CORES=$(lscpu -p 2>/dev/null \
+    | awk -F, '!/^#/ { cores[$3 "," $2] = 1 } END { print length(cores) }')
+fi
+[[ "${PHYSICAL_CORES}" =~ ^[0-9]+$ ]] || PHYSICAL_CORES=0
+(( PHYSICAL_CORES > 0 )) || PHYSICAL_CORES=${NPROC}
+SMT_RATIO=$((NPROC / PHYSICAL_CORES))
+(( SMT_RATIO > 0 )) || SMT_RATIO=1
 
 # variant-specific behavior
 # for GPU you must set vcpu_per_worker to a small number, not the CPU count
-if [[ -z ${VARIANT_TYPE} || ! ${VARIANT_TYPE} =~ ^(cpu|gpu|java)$ ]]; then
+if [[ -z ${VARIANT_TYPE:-} || ! ${VARIANT_TYPE} =~ ^(cpu|gpu|java)$ ]]; then
   echo_error "ERROR: VARIANT_TYPE must be set to a valid variant type (cpu, gpu, java)."
 fi
+if [[ ! "${NUM_WORKERS:-}" =~ ^[1-9][0-9]*$ ]]; then
+  echo_error "ERROR: NUM_WORKERS must be a positive integer."
+fi
+
+# NUM_WORKERS describes the whole Presto cluster. CPU resources, however, are
+# divided only among workers sharing this host. Slurm supplies
+# CPU_WORKERS_PER_HOST=NUM_GPUS_PER_NODE; local Docker runs fall back to the
+# total because every worker is local there.
+if [[ "${VARIANT_TYPE}" == "cpu" ]]; then
+  CPU_WORKERS_PER_HOST="${CPU_WORKERS_PER_HOST:-${NUM_WORKERS}}"
+  if [[ ! "${CPU_WORKERS_PER_HOST}" =~ ^[1-9][0-9]*$ ]]; then
+    echo_error "ERROR: CPU_WORKERS_PER_HOST must be a positive integer."
+  fi
+  if (( CPU_WORKERS_PER_HOST > NUM_WORKERS )); then
+    echo_error "ERROR: CPU_WORKERS_PER_HOST (${CPU_WORKERS_PER_HOST}) cannot exceed NUM_WORKERS (${NUM_WORKERS})."
+  fi
+  if (( CPU_WORKERS_PER_HOST > NPROC )); then
+    echo_error "ERROR: CPU_WORKERS_PER_HOST (${CPU_WORKERS_PER_HOST}) exceeds the ${NPROC} available logical CPUs."
+  fi
+
+  if [[ ! "${USE_NUMA:-0}" =~ ^[01]$ ]]; then
+    echo_error "ERROR: USE_NUMA must be 0 or 1; got '${USE_NUMA:-}'."
+  fi
+  CPU_RESOURCE_POLICY="host-wide"
+  CPU_THREADS_PER_WORKER=$((NPROC / CPU_WORKERS_PER_HOST))
+  CPU_RAM_PER_WORKER_GB=$((RAM_GB / CPU_WORKERS_PER_HOST))
+  CPU_NUMA_WORKER_LAYOUT="unbound"
+
+  if [[ "${USE_NUMA:-0}" == "1" ]]; then
+    if (( NUMA_TOPOLOGY_AVAILABLE == 0 )); then
+      echo_error "ERROR: CPU NUMA binding was requested, but no NUMA node with both CPUs and memory was discovered."
+    fi
+
+    # Match the launcher's balanced contiguous placement. Workers are sized
+    # to the smallest share assigned anywhere on the host. Placement yields
+    # 0; 0,1; and 0,0,1,1 for one, two, and four workers on a two-socket
+    # Grace host without treating HBM nodes as CPU sockets.
+    declare -a cpu_numa_worker_counts=()
+    local_worker_id=0
+    while (( local_worker_id < CPU_WORKERS_PER_HOST )); do
+      node_index=$((local_worker_id * CPU_NUMA_NODE_COUNT / CPU_WORKERS_PER_HOST))
+      cpu_numa_worker_counts[${node_index}]=$(( ${cpu_numa_worker_counts[${node_index}]:-0} + 1 ))
+      local_worker_id=$((local_worker_id + 1))
+    done
+
+    CPU_NUMA_WORKER_LAYOUT=""
+    CPU_THREADS_PER_WORKER=0
+    CPU_RAM_PER_WORKER_GB=0
+    node_index=0
+    while (( node_index < CPU_NUMA_NODE_COUNT )); do
+      workers_on_node="${cpu_numa_worker_counts[${node_index}]:-0}"
+      if (( workers_on_node > 0 )); then
+        candidate_threads=$((CPU_NUMA_NODE_CPU_COUNTS[${node_index}] / workers_on_node))
+        candidate_memory_gb=$((CPU_NUMA_NODE_MEMORY_GB[${node_index}] / workers_on_node))
+        if (( CPU_THREADS_PER_WORKER == 0 || candidate_threads < CPU_THREADS_PER_WORKER )); then
+          CPU_THREADS_PER_WORKER="${candidate_threads}"
+        fi
+        if (( CPU_RAM_PER_WORKER_GB == 0 || candidate_memory_gb < CPU_RAM_PER_WORKER_GB )); then
+          CPU_RAM_PER_WORKER_GB="${candidate_memory_gb}"
+        fi
+        CPU_NUMA_WORKER_LAYOUT+="${CPU_NUMA_WORKER_LAYOUT:+,}${CPU_NUMA_NODE_IDS[${node_index}]}:${workers_on_node}"
+      fi
+      node_index=$((node_index + 1))
+    done
+
+    if (( CPU_THREADS_PER_WORKER < 1 || CPU_RAM_PER_WORKER_GB < 1 )); then
+      echo_error "ERROR: CPU NUMA placement left fewer than one CPU or 1GB of DRAM per worker."
+    fi
+    CPU_RESOURCE_POLICY="cpu-numa-bound"
+  fi
+fi
+
 if [[ -z ${VCPU_PER_WORKER:-} ]]; then
   if [[ "${VARIANT_TYPE}" == "gpu" ]]; then
     VCPU_PER_WORKER=2
+  elif [[ "${VARIANT_TYPE}" == "cpu" ]]; then
+    VCPU_PER_WORKER="${CPU_THREADS_PER_WORKER}"
+    (( VCPU_PER_WORKER > 0 )) || VCPU_PER_WORKER=1
   else
     VCPU_PER_WORKER=${NPROC}
   fi
@@ -89,7 +213,7 @@ trap "popd > /dev/null" EXIT
 CONFIG_DIR=generated/${VARIANT_TYPE}
 
 # generate only if no existing config or overwrite flag is set
-if [[ ! -d ${CONFIG_DIR} || "${OVERWRITE_CONFIG}" == "true" ]]; then
+if [[ ! -d ${CONFIG_DIR} || "${OVERWRITE_CONFIG:-false}" == "true" ]]; then
   echo "Generating Presto Config files for '${VARIANT_TYPE}' for host with ${NPROC} CPU cores and ${RAM_GB}GB RAM"
 
   # (re-)generate the config.json file
@@ -151,5 +275,135 @@ if [[ -n "$NUM_WORKERS" ]]; then
   fi
   for i in "${WORKER_IDS[@]}"; do
     duplicate_worker_configs $i
+  done
+fi
+
+# Reconcile settings that depend on the total cluster size on every run. This
+# prevents a reused generated directory from retaining distributed settings
+# after switching back to one worker (or vice versa).
+if [[ "${VARIANT_TYPE}" == "gpu" || "${VARIANT_TYPE}" == "cpu" ]]; then
+  if (( NUM_WORKERS > 1 )); then
+    SINGLE_NODE_EXECUTION=false
+  else
+    SINGLE_NODE_EXECUTION=true
+  fi
+  CUDF_EXCHANGE=false
+  if [[ "${VARIANT_TYPE}" == "gpu" && "${SINGLE_NODE_EXECUTION}" == "false" ]]; then
+    CUDF_EXCHANGE=true
+  fi
+  for cfg in \
+    "${CONFIG_DIR}/etc_coordinator/config_native.properties" \
+    "${CONFIG_DIR}"/etc_worker*/config_native.properties; do
+    [[ -f "${cfg}" ]] || continue
+    set_or_append_property "single-node-execution-enabled" "${SINGLE_NODE_EXECUTION}" "${cfg}"
+  done
+  for cfg in "${CONFIG_DIR}"/etc_worker*/config_native.properties; do
+    [[ -f "${cfg}" ]] || continue
+    set_or_append_property "cudf.exchange" "${CUDF_EXCHANGE}" "${cfg}"
+  done
+fi
+
+# CPU defaults measured for the row-based UCX exchange path. Resource
+# partitioning uses workers on this host, while exchange-buffer sizing uses the
+# total cluster size because one worker on each of two hosts still shuffles.
+# Every CPU_* value remains explicitly overridable for controlled sweeps.
+if [[ "${VARIANT_TYPE}" == "cpu" ]]; then
+  : "${CPU_ASYNC_DATA_CACHE:=true}"
+  : "${CPU_SYSTEM_MEM_HEADROOM_GB:=35}"
+  : "${CPU_SYSTEM_MEM_LIMIT_HEADROOM_GB:=5}"
+  for headroom_var in CPU_SYSTEM_MEM_HEADROOM_GB CPU_SYSTEM_MEM_LIMIT_HEADROOM_GB; do
+    if [[ ! "${!headroom_var}" =~ ^[1-9][0-9]*$ ]]; then
+      echo_error "ERROR: ${headroom_var} must be a positive integer; got '${!headroom_var}'."
+    fi
+  done
+
+  # MmapAllocator reserves virtual address space for every size class during
+  # startup. Giving even a single worker all of MemTotal can therefore fail
+  # before it registers, and system-mem-limit-gb must never exceed the memory
+  # available to that worker. Apply the same per-worker headroom for one or
+  # many local workers; the previous single-worker special case used all RAM.
+  THREADS_PER_WORKER="${CPU_THREADS_PER_WORKER}"
+  RAM_PER_WORKER_GB="${CPU_RAM_PER_WORKER_GB}"
+  if [[ -z "${CPU_SYSTEM_MEM_GB:-}" ]]; then
+    if (( RAM_PER_WORKER_GB <= CPU_SYSTEM_MEM_HEADROOM_GB )); then
+      echo_error "ERROR: only ${RAM_PER_WORKER_GB}GB is available per CPU worker, which does not leave the requested ${CPU_SYSTEM_MEM_HEADROOM_GB}GB headroom; use fewer workers per host or override the CPU memory settings."
+    fi
+    CPU_SYSTEM_MEM_GB=$((RAM_PER_WORKER_GB - CPU_SYSTEM_MEM_HEADROOM_GB))
+  fi
+  if [[ ! "${CPU_SYSTEM_MEM_GB}" =~ ^[1-9][0-9]*$ ]]; then
+    echo_error "ERROR: CPU_SYSTEM_MEM_GB must be a positive integer; got '${CPU_SYSTEM_MEM_GB}'."
+  fi
+  : "${CPU_DRIVERS:=$((THREADS_PER_WORKER < 255 ? THREADS_PER_WORKER : 255))}"
+
+  if (( NUM_WORKERS > 1 )); then
+    : "${CPU_EXCHANGE_BUFFER:=512MB}"
+    : "${CPU_SINK_BUFFER:=512MB}"
+  else
+    : "${CPU_EXCHANGE_BUFFER:=32MB}"
+    : "${CPU_SINK_BUFFER:=32MB}"
+  fi
+
+  : "${CPU_QUERY_MEM_GB:=$((CPU_SYSTEM_MEM_GB * 70 / 100))}"
+  : "${CPU_SYSTEM_MEM_LIMIT_GB:=$((RAM_PER_WORKER_GB - CPU_SYSTEM_MEM_LIMIT_HEADROOM_GB))}"
+  : "${CPU_LOCAL_EXCHANGE_BUFFER:=512MB}"
+  : "${CPU_EXCHANGE_MAX_RESPONSE_SIZE:=64MB}"
+  : "${CPU_LARGEST_SIZE_CLASS_PAGES:=256}"
+  : "${CPU_TABLE_SCAN_SHUFFLE_STRATEGY:=DISABLED}"
+  : "${CPU_SCHEDULE_SPLITS_BASED_ON_TASK_LOAD:=true}"
+  : "${CPU_MAX_SPLITS_PER_TASK:=512}"
+  : "${CPU_QUERY_MAX_EXECUTION_TIME:=10m}"
+
+  for numeric_var in CPU_QUERY_MEM_GB CPU_SYSTEM_MEM_LIMIT_GB CPU_DRIVERS CPU_LARGEST_SIZE_CLASS_PAGES CPU_MAX_SPLITS_PER_TASK; do
+    if [[ ! "${!numeric_var}" =~ ^[1-9][0-9]*$ ]]; then
+      echo_error "ERROR: ${numeric_var} must be a positive integer; got '${!numeric_var}'."
+    fi
+  done
+  if (( CPU_SYSTEM_MEM_GB >= RAM_PER_WORKER_GB )); then
+    echo_error "ERROR: CPU_SYSTEM_MEM_GB (${CPU_SYSTEM_MEM_GB}) must be smaller than the ${RAM_PER_WORKER_GB}GB available per CPU worker."
+  fi
+  if (( CPU_SYSTEM_MEM_LIMIT_GB < CPU_SYSTEM_MEM_GB || CPU_SYSTEM_MEM_LIMIT_GB > RAM_PER_WORKER_GB )); then
+    echo_error "ERROR: CPU_SYSTEM_MEM_LIMIT_GB (${CPU_SYSTEM_MEM_LIMIT_GB}) must be at least CPU_SYSTEM_MEM_GB (${CPU_SYSTEM_MEM_GB}) and no greater than the ${RAM_PER_WORKER_GB}GB available per CPU worker."
+  fi
+  if (( CPU_QUERY_MEM_GB >= CPU_SYSTEM_MEM_GB )); then
+    echo_error "ERROR: CPU_QUERY_MEM_GB (${CPU_QUERY_MEM_GB}) must be smaller than CPU_SYSTEM_MEM_GB (${CPU_SYSTEM_MEM_GB})."
+  fi
+  if (( CPU_LARGEST_SIZE_CLASS_PAGES < 256 || (CPU_LARGEST_SIZE_CLASS_PAGES & (CPU_LARGEST_SIZE_CLASS_PAGES - 1)) != 0 )); then
+    echo_error "ERROR: CPU_LARGEST_SIZE_CLASS_PAGES must be a power of two of at least 256."
+  fi
+
+  echo "CPU topology: visible-nodes=${NUMA_NODES} cpu-nodes=${CPU_NUMA_NODE_COUNT:-0} cpu-node-ids=${CPU_NUMA_NODE_IDS[*]:-none} memory-node-ids=${MEMORY_NUMA_NODE_IDS[*]:-none}"
+  echo "CPU auto-tune: policy=${CPU_RESOURCE_POLICY} layout=${CPU_NUMA_WORKER_LAYOUT} total-workers=${NUM_WORKERS} workers-per-host=${CPU_WORKERS_PER_HOST} NPROC=${NPROC} PHYSICAL_CORES=${PHYSICAL_CORES} SMT_RATIO=${SMT_RATIO}"
+  echo "               memory-per-worker-gb=${RAM_PER_WORKER_GB} system-memory-gb=${CPU_SYSTEM_MEM_GB} query-memory-gb=${CPU_QUERY_MEM_GB} system-mem-limit-gb=${CPU_SYSTEM_MEM_LIMIT_GB}"
+  echo "               task.max-drivers-per-task=${CPU_DRIVERS} async-data-cache-enabled=${CPU_ASYNC_DATA_CACHE} largest-size-class-pages=${CPU_LARGEST_SIZE_CLASS_PAGES}"
+  echo "               local-exchange.max-buffer-size=${CPU_LOCAL_EXCHANGE_BUFFER} exchange.max-buffer-size=${CPU_EXCHANGE_BUFFER} sink.max-buffer-size=${CPU_SINK_BUFFER} exchange.max-response-size=${CPU_EXCHANGE_MAX_RESPONSE_SIZE}"
+  echo "               optimizer.table-scan-shuffle-strategy=${CPU_TABLE_SCAN_SHUFFLE_STRATEGY} node-scheduler.schedule-splits-based-on-task-load=${CPU_SCHEDULE_SPLITS_BASED_ON_TASK_LOAD} node-scheduler.max-splits-per-task=${CPU_MAX_SPLITS_PER_TASK}"
+  echo "               query.max-execution-time=${CPU_QUERY_MAX_EXECUTION_TIME}"
+
+  coordinator_cfg="${CONFIG_DIR}/etc_coordinator/config_native.properties"
+  set_or_append_property "optimizer.table-scan-shuffle-strategy" "${CPU_TABLE_SCAN_SHUFFLE_STRATEGY}" "${coordinator_cfg}"
+  set_or_append_property "node-scheduler.schedule-splits-based-on-task-load" "${CPU_SCHEDULE_SPLITS_BASED_ON_TASK_LOAD}" "${coordinator_cfg}"
+  set_or_append_property "node-scheduler.max-splits-per-task" "${CPU_MAX_SPLITS_PER_TASK}" "${coordinator_cfg}"
+  set_or_append_property "exchange.max-buffer-size" "${CPU_EXCHANGE_BUFFER}" "${coordinator_cfg}"
+  set_or_append_property "sink.max-buffer-size" "${CPU_SINK_BUFFER}" "${coordinator_cfg}"
+  set_or_append_property "exchange.max-response-size" "${CPU_EXCHANGE_MAX_RESPONSE_SIZE}" "${coordinator_cfg}"
+  set_or_append_property "query.max-execution-time" "${CPU_QUERY_MAX_EXECUTION_TIME}" "${coordinator_cfg}"
+
+  for worker_dir in "${CONFIG_DIR}"/etc_worker*/; do
+    cfg="${worker_dir}config_native.properties"
+    [[ -f "${cfg}" ]] || continue
+    set_or_append_property "system-memory-gb" "${CPU_SYSTEM_MEM_GB}" "${cfg}"
+    set_or_append_property "system-mem-limit-gb" "${CPU_SYSTEM_MEM_LIMIT_GB}" "${cfg}"
+    set_or_append_property "query-memory-gb" "${CPU_QUERY_MEM_GB}" "${cfg}"
+    set_or_append_property "query.max-memory-per-node" "${CPU_QUERY_MEM_GB}GB" "${cfg}"
+    set_or_append_property "task.max-drivers-per-task" "${CPU_DRIVERS}" "${cfg}"
+    set_or_append_property "async-data-cache-enabled" "${CPU_ASYNC_DATA_CACHE}" "${cfg}"
+    set_or_append_property "local-exchange.max-buffer-size" "${CPU_LOCAL_EXCHANGE_BUFFER}" "${cfg}"
+    set_or_append_property "exchange.max-buffer-size" "${CPU_EXCHANGE_BUFFER}" "${cfg}"
+    set_or_append_property "sink.max-buffer-size" "${CPU_SINK_BUFFER}" "${cfg}"
+    set_or_append_property "exchange.max-response-size" "${CPU_EXCHANGE_MAX_RESPONSE_SIZE}" "${cfg}"
+    set_or_append_property "largest-size-class-pages" "${CPU_LARGEST_SIZE_CLASS_PAGES}" "${cfg}"
+    # query.execution-policy is coordinator-only and causes native worker
+    # bootstrap failures when retained in reused configs from older branches.
+    sed -i '/^query\.execution-policy=/d' "${cfg}"
   done
 fi

--- a/presto/scripts/start_presto_helper_parse_args.sh
+++ b/presto/scripts/start_presto_helper_parse_args.sh
@@ -43,7 +43,17 @@ OPTIONS:
                          differences that could lead to build failures).
 
 ENVIRONMENT VARIABLES:
-    SCCACHE_AUTH_DIR     Directory containing sccache auth files (default: ~/.sccache-auth/).
+    SCCACHE_AUTH_DIR          Directory containing sccache auth files (default: ~/.sccache-auth/).
+    USE_NUMA                  Set to 1 to bind CPU workers to NUMA nodes (cpu variant only).
+                              Workers are distributed across CPU-bearing nodes in contiguous
+                              balanced groups; nodes with only HBM/GPU memory are excluded.
+                              Requires a host with discoverable NUMA topology (default: 0).
+    CPU_WORKERS_PER_HOST      Number of CPU workers sharing this host's resources. Defaults to
+                              NUM_WORKERS for local Docker runs. Set explicitly in multi-host
+                              Slurm deployments where workers are spread across nodes (cpu only).
+    NPROC                     Override logical CPU count (default: nproc). Useful for testing.
+    RAM_GB                    Override total host memory in GB (default: auto-detected). Useful
+                              for testing.
 
 EXAMPLES:
     $SCRIPT_NAME --no-cache

--- a/presto/scripts/test_common_functions.sh
+++ b/presto/scripts/test_common_functions.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+# SPDX-License-Identifier: Apache-2.0
+
+# Unit tests for the NUMA topology functions in common_functions.sh.
+# No external dependencies; synthetic sysfs trees are built in $TMPDIR.
+# Usage: presto/scripts/test_common_functions.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/common_functions.sh"
+
+# ---------- test harness ----------
+PASS=0
+FAIL=0
+
+pass() { echo "PASS: $*"; PASS=$((PASS + 1)); }
+fail() { echo "FAIL: $*"; FAIL=$((FAIL + 1)); }
+
+assert_eq() {
+  local label="$1" expected="$2" actual="$3"
+  if [[ "${actual}" == "${expected}" ]]; then
+    pass "${label}"
+  else
+    fail "${label}: expected '${expected}', got '${actual}'"
+  fi
+}
+
+assert_success() {
+  local label="$1"; shift
+  if "$@"; then
+    pass "${label}"
+  else
+    fail "${label}: expected exit 0"
+  fi
+}
+
+assert_failure() {
+  local label="$1"; shift
+  if "$@"; then
+    fail "${label}: expected non-zero exit"
+  else
+    pass "${label}"
+  fi
+}
+
+# make_node <root> <id> <cpulist-or-empty> <memtotal_kb>
+make_node() {
+  local root="$1" id="$2" cpulist="$3" memtotal_kb="$4"
+  mkdir -p "${root}/node${id}"
+  [[ -z "${cpulist}" ]] || printf '%s\n' "${cpulist}" > "${root}/node${id}/cpulist"
+  (( memtotal_kb > 0 )) && printf 'MemTotal: %s kB\n' "${memtotal_kb}" \
+    > "${root}/node${id}/meminfo" || true
+}
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "${TMP}"' EXIT
+
+# ---------- count_linux_cpu_list ----------
+assert_eq "count: empty string"       "0"  "$(count_linux_cpu_list '')"
+assert_eq "count: single cpu"         "1"  "$(count_linux_cpu_list '5')"
+assert_eq "count: range 0-3"          "4"  "$(count_linux_cpu_list '0-3')"
+assert_eq "count: range 0-71"         "72" "$(count_linux_cpu_list '0-71')"
+assert_eq "count: mixed 0-3,8,10-11" "7"  "$(count_linux_cpu_list '0-3,8,10-11')"
+assert_failure "count: invalid input exits non-zero" count_linux_cpu_list "abc"
+
+# ---------- discover_cpu_numa_topology: no nodes ----------
+assert_failure "no-nodes: returns non-zero" discover_cpu_numa_topology "${TMP}/empty"
+assert_eq "no-nodes: CPU_NUMA_NODE_COUNT"     "0" "${CPU_NUMA_NODE_COUNT}"
+assert_eq "no-nodes: VISIBLE_NUMA_NODE_COUNT" "0" "${VISIBLE_NUMA_NODE_COUNT}"
+
+# ---------- discover_cpu_numa_topology: single node ----------
+sysfs="${TMP}/single"
+make_node "${sysfs}" 0 "0-71" $((480 * 1024 * 1024))
+assert_success "single-node: returns zero" discover_cpu_numa_topology "${sysfs}"
+assert_eq "single-node: CPU_NUMA_NODE_COUNT"      "1"   "${CPU_NUMA_NODE_COUNT}"
+assert_eq "single-node: VISIBLE_NUMA_NODE_COUNT"  "1"   "${VISIBLE_NUMA_NODE_COUNT}"
+assert_eq "single-node: node id"                  "0"   "${CPU_NUMA_NODE_IDS[0]}"
+assert_eq "single-node: cpu count"                "72"  "${CPU_NUMA_NODE_CPU_COUNTS[0]}"
+assert_eq "single-node: memory gb"                "480" "${CPU_NUMA_NODE_MEMORY_GB[0]}"
+assert_eq "single-node: CPU_NUMA_MIN_CPUS"        "72"  "${CPU_NUMA_MIN_CPUS}"
+assert_eq "single-node: CPU_NUMA_TOTAL_MEMORY_GB" "480" "${CPU_NUMA_TOTAL_MEMORY_GB}"
+
+# ---------- discover_cpu_numa_topology: HBM node excluded from CPU nodes ----------
+# Simulates a Grace-Hopper-style topology: one CPU+DRAM node, one GPU HBM proximity
+# domain (memory only, no cpulist). The HBM node must appear in MEMORY_NUMA_NODE_IDS
+# and VISIBLE_NUMA_NODE_COUNT but not in CPU_NUMA_NODE_IDS.
+sysfs="${TMP}/with-hbm"
+make_node "${sysfs}" 0 "0-71" $((480 * 1024 * 1024))  # CPU + DRAM
+make_node "${sysfs}" 1 ""     $((80  * 1024 * 1024))  # HBM only
+assert_success "hbm-node: returns zero" discover_cpu_numa_topology "${sysfs}"
+assert_eq "hbm-node: CPU_NUMA_NODE_COUNT"     "1" "${CPU_NUMA_NODE_COUNT}"
+assert_eq "hbm-node: VISIBLE_NUMA_NODE_COUNT" "2" "${VISIBLE_NUMA_NODE_COUNT}"
+assert_eq "hbm-node: MEMORY_NUMA_NODE_IDS count" "2" "${#MEMORY_NUMA_NODE_IDS[@]}"
+
+# ---------- discover_cpu_numa_topology: symmetric 2-node ----------
+sysfs="${TMP}/two-node"
+make_node "${sysfs}" 0 "0-71"   $((480 * 1024 * 1024))
+make_node "${sysfs}" 1 "72-143" $((480 * 1024 * 1024))
+assert_success "two-node: returns zero" discover_cpu_numa_topology "${sysfs}"
+assert_eq "two-node: CPU_NUMA_NODE_COUNT"      "2"   "${CPU_NUMA_NODE_COUNT}"
+assert_eq "two-node: node 0 id"                "0"   "${CPU_NUMA_NODE_IDS[0]}"
+assert_eq "two-node: node 1 id"                "1"   "${CPU_NUMA_NODE_IDS[1]}"
+assert_eq "two-node: cpu count node 0"         "72"  "${CPU_NUMA_NODE_CPU_COUNTS[0]}"
+assert_eq "two-node: cpu count node 1"         "72"  "${CPU_NUMA_NODE_CPU_COUNTS[1]}"
+assert_eq "two-node: CPU_NUMA_MIN_CPUS"        "72"  "${CPU_NUMA_MIN_CPUS}"
+assert_eq "two-node: CPU_NUMA_MIN_MEMORY_GB"   "480" "${CPU_NUMA_MIN_MEMORY_GB}"
+assert_eq "two-node: CPU_NUMA_TOTAL_MEMORY_GB" "960" "${CPU_NUMA_TOTAL_MEMORY_GB}"
+
+# ---------- cpu_numa_node_for_worker (uses two-node topology from above) ----------
+# 1 worker → all on node 0
+assert_eq "worker-map: 1 worker,  slot 0 → node 0" "0" "$(cpu_numa_node_for_worker 0 1)"
+# 2 workers → one per node
+assert_eq "worker-map: 2 workers, slot 0 → node 0" "0" "$(cpu_numa_node_for_worker 0 2)"
+assert_eq "worker-map: 2 workers, slot 1 → node 1" "1" "$(cpu_numa_node_for_worker 1 2)"
+# 4 workers → balanced 2 per node (0,0,1,1)
+assert_eq "worker-map: 4 workers, slot 0 → node 0" "0" "$(cpu_numa_node_for_worker 0 4)"
+assert_eq "worker-map: 4 workers, slot 1 → node 0" "0" "$(cpu_numa_node_for_worker 1 4)"
+assert_eq "worker-map: 4 workers, slot 2 → node 1" "1" "$(cpu_numa_node_for_worker 2 4)"
+assert_eq "worker-map: 4 workers, slot 3 → node 1" "1" "$(cpu_numa_node_for_worker 3 4)"
+assert_failure "worker-map: out-of-range slot exits non-zero" cpu_numa_node_for_worker 4 4
+assert_failure "worker-map: zero workers_per_host exits non-zero" cpu_numa_node_for_worker 0 0
+
+# ---------- summary ----------
+printf '\n%d passed, %d failed\n' "${PASS}" "${FAIL}"
+(( FAIL == 0 ))


### PR DESCRIPTION
## Summary

Rewrites `generate_presto_config.sh` to discover host NUMA topology at config-generation time and size each worker to its proportional share of the NUMA node(s) it will be bound to. Previously all workers on a host received identical configs sized to the full host, which over-allocated CPU and memory for multi-worker-per-host CPU runs.

Based on kjmph's bench33 POC patch.

- **`discover_cpu_numa_topology`** (new helper in `common_functions.sh`): uses `lscpu`, `lsmem`, and `/proc/meminfo` fallbacks to enumerate CPU NUMA nodes, their logical CPU counts, and their memory in GB; distinguishes CPU-hosting nodes from HBM-only memory nodes (relevant for Grace-Hopper hosts)
- **`cpu_numa_node_for_worker`** (new helper): maps a worker slot index to its NUMA node using balanced contiguous placement (yields 0; 0,1; 0,0,1,1 for 1/2/4 workers on a 2-socket host)
- **`count_linux_cpu_list`** (new helper): parses Linux `Cpus_allowed_list`-style range strings (e.g. `0-47,96-143`) to a count
- **`generate_presto_config.sh`**: NUMA topology discovery runs when `USE_NUMA=1`; per-worker CPU thread and RAM limits derived from the smallest NUMA node share; `CPU_NUMA_WORKER_LAYOUT` exported as `<node>:<count>` map for downstream consumers; `set_or_append_property` helper for idempotent property file mutations; cuDF exchange guard restricted to GPU-only (was incorrectly gating CPU runs)

## Dependencies

Depends on PR #390 (`bench-fixes-tuning`) for the `common_functions.sh` jq→python3 fix in `wait_for_worker_node_registration`. Rebase after PR #390 merges.

## Verification

- [ ] On a 2-socket Grace host with `CPU_WORKERS_PER_HOST=2` and `USE_NUMA=1`, verify `generate_presto_config.sh` produces two configs with CPU count = (total logical CPUs on one socket / 2) and RAM = (HBM on that socket / 2)
- [ ] On a host with `USE_NUMA=0`, verify the generated config is unchanged from the pre-patch behavior (full-host sizing, single worker)
- [ ] Verify `CPU_NUMA_WORKER_LAYOUT` is set correctly (e.g. `0:1,1:1` for 2 workers on a 2-socket host)
- [ ] Check that `discover_cpu_numa_topology` correctly ignores HBM-only NUMA nodes as CPU-hosting nodes on Grace-Hopper (nodes with `CPU_NUMA_NODE_CPU_COUNTS[i] == 0` should not contribute CPU slots)
- [ ] Verify `set_or_append_property` is idempotent: running `generate_presto_config.sh` twice does not duplicate property entries
- [ ] Run `./ci/check_style.sh` on changed files