### PR TITLE
(CI)fix-style/workflow status stacktrace code fence

### DIFF
--- a/scripts/workflow_status/lib/ai.py
+++ b/scripts/workflow_status/lib/ai.py
@@ -13,6 +13,7 @@ import threading
 from pathlib import Path
 
 from .config import Config
+from .logs import strip_code_fences
 
 _PROMPT_DIR = Path(__file__).resolve().parent.parent / "prompts"
 
@@ -171,7 +172,8 @@ def analyze_block(
         re.DOTALL | re.IGNORECASE,
     )
     if st_match:
-        st_lines = [ln for ln in st_match.group(1).strip().splitlines() if ln.strip()]
+        cleaned = strip_code_fences(st_match.group(1).strip())
+        st_lines = [ln for ln in cleaned.splitlines() if ln.strip()]
         stacktrace = "\n".join(st_lines[:5])
 
     for line in resp.splitlines():

--- a/scripts/workflow_status/lib/formatting.py
+++ b/scripts/workflow_status/lib/formatting.py
@@ -20,6 +20,11 @@ EMOJI_HOURGLASS = "\u23f3"  # ⏳ hourglass
 EMOJI_CHECK = "\u2705"  # ✅ check mark
 EMOJI_CROSS = "\u274c"  # ❌ cross mark
 
+# Rule drawn between consecutive failures inside one job.  A visible character
+# (not a blank line) is required: Slack strips leading/trailing whitespace when
+# the report is split into blocks, so a blank separator would disappear.
+GROUP_RULE = "\u2508" * 30  # ┈┈┈…
+
 
 def status_emoji(conclusion: str, status: str = "completed") -> str:
     """Map a job conclusion / status to an emoji."""
@@ -203,7 +208,7 @@ def format_failure_detail(
     out.print(f"\u2022 *Conclusion:* {conclusion}")
 
     for s in failed_steps:
-        out.print(f"  \u25aa\ufe0e Step: {s.get('name', '?')} ({s.get('conclusion', 'unknown')})")
+        out.print(f"\u25aa\ufe0e Step: {s.get('name', '?')} ({s.get('conclusion', 'unknown')})")
 
     n_groups = len(stacktraces)
     for gidx, (st, cause, fix) in enumerate(stacktraces):
@@ -215,32 +220,35 @@ def format_failure_detail(
         if not body:
             body = ["(no stacktrace available)"]
 
-        out.print(f"    *Stacktrace{suffix}:*")
+        out.print(f"*Stacktrace{suffix}:*")
         out.print("```")
         for line in body:
             out.print(line)
         out.print("```")
 
         if analyze_cause:
-            out.print(f"    *Cause:* _{cause or 'Unable to determine cause'}_")
+            out.print(f"*Cause:* _{cause or 'Unable to determine cause'}_")
             if analyze_fix:
-                out.print(f"    *Fix:* _{fix or 'Pending investigation'}_")
+                out.print(f"*Fix:* _{fix or 'Pending investigation'}_")
+
+        if gidx < n_groups - 1:
+            out.print(GROUP_RULE)
 
     if related_items:
         out.print()
-        out.print("    *Related issues/PRs (last 7 days):*")
+        out.print("*Related issues/PRs (last 7 days):*")
         out.print(related_items)
 
     if duplicates:
         out.print()
-        out.print("  _Same error also appears in:_")
+        out.print("_Same error also appears in:_")
         for dup in duplicates:
             dup_name = dup.get("name", "unknown")
             dup_job_id = dup.get("databaseId", "")
             if dup_job_id and run_url:
                 dup_url = f"{run_url}/job/{dup_job_id}"
-                out.print(f"  \u2022 `{dup_name}` \u2192 {dup_url}")
+                out.print(f"\u2022 `{dup_name}` \u2192 {dup_url}")
             else:
-                out.print(f"  \u2022 `{dup_name}`")
+                out.print(f"\u2022 `{dup_name}`")
 
     return out.text()

--- a/scripts/workflow_status/lib/formatting.py
+++ b/scripts/workflow_status/lib/formatting.py
@@ -11,6 +11,7 @@ import json
 import sys
 
 from . import slack as slack_mod
+from .logs import strip_code_fences
 
 # ---- Emoji constants -------------------------------------------------------
 
@@ -207,13 +208,17 @@ def format_failure_detail(
     n_groups = len(stacktraces)
     for gidx, (st, cause, fix) in enumerate(stacktraces):
         suffix = f" {gidx + 1}/{n_groups}" if n_groups > 1 else ""
-        display_st = st or "(no stacktrace available)"
+        # Strip any fences around the stacktrace; nesting them
+        # inside our own fence renders an empty code block and pushes the real
+        # stacktrace outside it.
+        body = [ln for ln in strip_code_fences(st).splitlines()[:5] if ln.strip()]
+        if not body:
+            body = ["(no stacktrace available)"]
 
         out.print(f"    *Stacktrace{suffix}:*")
         out.print("```")
-        for line in display_st.splitlines()[:5]:
-            if line.strip():
-                out.print(line)
+        for line in body:
+            out.print(line)
         out.print("```")
 
         if analyze_cause:

--- a/scripts/workflow_status/lib/logs.py
+++ b/scripts/workflow_status/lib/logs.py
@@ -30,6 +30,28 @@ def strip_log_prefixes(raw: str) -> str:
     return "\n".join(_strip_gh_log_prefix(line) for line in raw.splitlines())
 
 
+# ---- Markdown fence stripping ---------------------------------------------
+
+_CODE_FENCE_LINE = re.compile(r"^\s*(?:```|~~~)\s*\w*\s*$")
+
+
+def strip_code_fences(text: str) -> str:
+    """Remove markdown code-fence markers from *text*.
+
+    AI responses sometimes wrap an extracted stacktrace in their own ``` fence.
+    Nesting that inside the report's own fence renders as an empty code block
+    with the real stacktrace spilling out below it, so fence-only lines are
+    dropped and any leftover inline ``` is neutralised to keep the enclosing
+    fence balanced.
+    """
+    lines = []
+    for line in text.splitlines():
+        if _CODE_FENCE_LINE.match(line):
+            continue
+        lines.append(line.replace("```", ""))
+    return "\n".join(lines)
+
+
 # ---- GTest patterns -------------------------------------------------------
 
 _GTEST_RUN = re.compile(r"^\[ RUN\s+\]")

--- a/scripts/workflow_status/lib/slack.py
+++ b/scripts/workflow_status/lib/slack.py
@@ -32,6 +32,11 @@ def split_mrkdwn_sections(content: str) -> list[str]:
     return sections
 
 
+def _has_content(fragment: str) -> bool:
+    """True if *fragment* holds anything besides code-fence markers."""
+    return any(ln.strip() and not ln.strip().startswith("```") for ln in fragment.splitlines())
+
+
 def split_code_blocks(section: str) -> list[str]:
     """Split a section into alternating text and code-fenced fragments."""
     fragments: list[str] = []
@@ -58,7 +63,7 @@ def split_code_blocks(section: str) -> list[str]:
         if in_code:
             trailing += "\n```"
         fragments.append(trailing)
-    return [f for f in fragments if f]
+    return [f for f in fragments if f and _has_content(f)]
 
 
 def chunk_text(text: str, max_len: int = SLACK_BLOCK_TEXT_LIMIT) -> list[str]:

--- a/scripts/workflow_status/lib/upstream.py
+++ b/scripts/workflow_status/lib/upstream.py
@@ -214,7 +214,7 @@ def find_related_github_items(
     stacktrace: str,
     since_date: str,
     config: Config,
-    prefix: str = "    - ",
+    prefix: str = "- ",
 ) -> str:
     """Search for related issues / PRs based on a stacktrace.
 

--- a/scripts/workflow_status/prompts/analyze_failure.txt
+++ b/scripts/workflow_status/prompts/analyze_failure.txt
@@ -22,7 +22,8 @@ Based on your analysis, provide:
 2. CAUSE: The specific root cause (mention file/class/function names, exact error like type mismatch, missing symbol, failed test names, etc.)
 3. FIX: A concrete suggested fix or investigation step{fix_extra}
 
-Respond in exactly this format (no markdown except for STACKTRACE which can be multiline):
+Respond in exactly this format. Use NO markdown formatting: STACKTRACE may span
+multiple lines, but do NOT wrap it (or anything else) in ``` code fences.
 STACKTRACE:<3-5 most relevant root-cause error lines only, end with END_STACKTRACE on its own line>
 END_STACKTRACE
 CAUSE:<your specific root cause description - single line>

--- a/scripts/workflow_status/workflow_status.py
+++ b/scripts/workflow_status/workflow_status.py
@@ -128,7 +128,7 @@ def _process_failed_job(
             job_log_content,
             since_date,
             config,
-            prefix="    \u2022 ",
+            prefix="\u2022 ",
         )
 
     stacktraces: list[tuple[str, str, str]] = []
@@ -334,16 +334,16 @@ def main() -> None:
                     tracker.record_dedup_skip(len(dup_indices))
                     dup_buf = OutputBuffer()
                     dup_buf.print()
-                    dup_buf.print("  _Same error also appears in:_")
+                    dup_buf.print("_Same error also appears in:_")
                     for di in dup_indices:
                         dup_job = failed_jobs[di]
                         dup_name = dup_job.get("name", "unknown")
                         dup_job_id = dup_job.get("databaseId", "")
                         if dup_job_id and run_url:
                             dup_url = f"{run_url}/job/{dup_job_id}"
-                            dup_buf.print(f"  \u2022 `{dup_name}` \u2192 {dup_url}")
+                            dup_buf.print(f"\u2022 `{dup_name}` \u2192 {dup_url}")
                         else:
-                            dup_buf.print(f"  \u2022 `{dup_name}`")
+                            dup_buf.print(f"\u2022 `{dup_name}`")
                     detail_text += dup_buf.text()
 
                 results_map[didx] = detail_text


### PR DESCRIPTION
**Overview**

Fixes Slack rendering of the nightly status report. Code blocks and stack-traces are properly identified and included inside code blocks.

Sample Run:

https://nvidia.slack.com/archives/C09KKD896EQ/p1785428085724929