### PR TITLE
build(presto): Install nsight-systems-cli 2026.3.1 for NVTX counters

### DIFF
--- a/presto/docker/native_build.dockerfile
+++ b/presto/docker/native_build.dockerfile
@@ -4,7 +4,7 @@ FROM ${BASE_IMAGE}
 
 RUN rpm --import https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/7fa2af80.pub && \
     dnf config-manager --add-repo "https://developer.download.nvidia.com/devtools/repos/rhel$(source /etc/os-release; echo ${VERSION_ID%%.*})/$(rpm --eval '%{_arch}' | sed s/aarch/arm/)/" && \
-    dnf install -y nsight-systems-cli-2025.5.1 numactl
+    dnf install -y nsight-systems-cli-2026.3.1 numactl
 
 ARG GPU=ON
 ARG BUILD_TYPE=release


### PR DESCRIPTION
## What

Bump the Nsight Systems CLI installed into the Presto native image from
`2025.5.1` to `2026.3.1`.

## Why

Velox-cuDF can attribute GPU memory to operator instances and publish it as NVTX
counters, so an Nsight capture shows a per-operator memory timeline nested by plan node
(facebookincubator/velox#18344). Nsight Systems draws counter rows only from **2026.3**
onward — the release where NVTX counters stopped being a preview feature.

**Capture is not the problem.** `2025.5.1` records counters correctly, including through
the `nsys launch` + `nsys start`/`stop` path `run_benchmark.sh -p` uses:

| nsys used to capture | Counter samples recorded |
|---|---|
| 2025.3.2 | correct |
| 2025.5.1 (what this image installs today) | correct |
| 2025.6.1 | correct |
| 2026.4.1 | correct |

The gap is on the **viewing** side, and it is silent. Nsight 2025.6.1 opens a capture
containing counters, shows the scope tree, and draws no counter rows at all. The same
report in 2026.4.1 renders correctly. Someone on an older Nsight therefore sees a
well-formed report with nothing in it and concludes the feature produced nothing.

Pinning the capture side to 2026.3.1 converts that into a loud failure. An Nsight older
than the report refuses to open it:

```
Report was created in Nsight Systems version (2026.x), newer than your current
version (2025.5.1). Please update your Nsight Systems to the latest version to
view this report.
```

A stale viewer gets reported rather than mistaken for missing data. That is the whole
benefit — this does not make any capture record more than it already does.

## Changes

One line in `presto/docker/native_build.dockerfile`. The package is published for both
`x86_64` and `aarch64`, so the arch-templated repo URL on the preceding line resolves on
either.

## Notes

Nothing else in this repo needs to change to capture these profiles. Enabling the
feature is a worker config key that a user sets at run time:

```properties
cudf.memory_tracking_enabled=true
```

If it would help discoverability, that key could be added to
`presto/docker/config/template/overrides/gpu/etc_worker/config_native.properties` with a
`false` default in a follow-up; it is left out here to keep this reviewable as a version
bump.
