### PR TITLE
Set libcudf kernel cache path

### DIFF
--- a/presto/docker/native_build.dockerfile
+++ b/presto/docker/native_build.dockerfile
@@ -112,6 +112,8 @@ RUN mkdir /usr/lib64/presto-native-libs && \
 
 COPY velox-testing/presto/docker/launch_presto_servers.sh velox-testing/presto/docker/presto_profiling_wrapper.sh /opt
 
+ENV LIBCUDF_KERNEL_CACHE_PATH=/var/lib/presto/data/libcudf-cache
+
 ARG PRESTO_SHA
 ARG PRESTO_BRANCH
 ARG PRESTO_REPOSITORY


### PR DESCRIPTION
## Description

Set `LIBCUDF_KERNEL_CACHE_PATH=/var/lib/presto/data/libcudf-cache` in the native Presto image.

Without an explicit path, cuDF uses the root user cache directory (`/root/.cache/libcudf`). The Presto container filesystem is read-only, so that directory cannot be created. Older cuDF versions silently continued without a file cache. [rapidsai/cudf#22975](https://github.com/rapidsai/cudf/pull/22975) makes failure to select or create a writable kernel-cache directory an error, which turns this into a startup failure.

The Presto data directory is writable, so configure it as the kernel-cache location.