### PR TITLE
Fix validation of decimal benchmark results

### DIFF
--- a/common/testing/result_comparison.py
+++ b/common/testing/result_comparison.py
@@ -12,6 +12,7 @@ parquet files). See compare_result_frames for full comparison semantics.
 import datetime
 import re
 import warnings
+from decimal import Decimal
 from typing import Literal
 
 import numpy as np
@@ -160,6 +161,23 @@ def _normalize_to_expected(actual: pd.DataFrame, expected: pd.DataFrame) -> pd.D
             # parse the strings and yield datetime.date to match.
             out.isetitem(i, pd.to_datetime(a_col).dt.date)
     return out
+
+
+def normalize_decimal_columns(frame: pd.DataFrame, column_types: list[str] | None) -> pd.DataFrame:
+    """Restore DECIMAL values using engine types rather than value inference."""
+    if not column_types:
+        return frame
+
+    frame = frame.copy()
+    for i, type_name in enumerate(column_types):
+        if i >= frame.shape[1] or _decimal_abs_tolerance(type_name) is None:
+            continue
+        column = frame.iloc[:, i]
+        frame.isetitem(
+            i,
+            column.map(lambda value: value if pd.isna(value) else Decimal(str(value))),
+        )
+    return frame
 
 
 # ---------------------------------------------------------------------------
@@ -418,7 +436,7 @@ def compare_result_frames(
 
     Steps:
       1. Validate column count and capture expected column names.
-      2. Normalize dtypes / value types.
+      2. Restore declared DECIMAL columns and normalize dtypes / value types.
       3. Validate row count.
       4. Parse ORDER BY / LIMIT from SQL.
       5. Validate each engine respected ORDER BY (per-frame, strict equality).
@@ -436,7 +454,10 @@ def compare_result_frames(
     expected_col_names = list(expected.columns)
     abs_tolerances = [_decimal_abs_tolerance(type_name) or ABS_TOL for type_name in actual_column_types or []]
 
-    # 2. Coerce actual's dtypes/value types to match expected's
+    # 2. Restore typed decimal values before generic dtype alignment. Presto's
+    # Python client and benchmark Parquet files represent DECIMAL as strings.
+    actual = normalize_decimal_columns(actual, actual_column_types)
+    expected = normalize_decimal_columns(expected, actual_column_types)
     actual = _normalize_to_expected(actual, expected)
 
     # 3. Row count
@@ -492,6 +513,7 @@ def validate_query_result(
     actual: pd.DataFrame,
     expected: pd.DataFrame,
     query_sql: str,
+    actual_column_types: list[str] | None = None,
 ) -> tuple[ValidationStatus, str | None]:
     """
     Compare actual vs expected for one query. Returns (status, message).
@@ -509,7 +531,7 @@ def validate_query_result(
         )
 
     try:
-        compare_result_frames(actual, expected, query_sql)
+        compare_result_frames(actual, expected, query_sql, actual_column_types)
         return "passed", None
     except Exception as e:
         return "failed", f"{type(e).__name__}: {e}"[:500]

--- a/common/testing/result_comparison_test.py
+++ b/common/testing/result_comparison_test.py
@@ -4,6 +4,7 @@
 """Unit tests for result_comparison.py."""
 
 import datetime
+from decimal import Decimal
 
 import numpy as np
 import pandas as pd
@@ -14,6 +15,8 @@ from common.testing.result_comparison import (
     _find_last_tie_start,
     _normalize_to_expected,
     _validate_orderby,
+    compare_result_frames,
+    normalize_decimal_columns,
 )
 
 # ---------------------------------------------------------------------------
@@ -52,6 +55,31 @@ def test_normalize_to_expected_handles_str_to_date_in_object_dtype():
     assert result[0].dtype == object
     assert isinstance(result[0].iloc[0], datetime.date)
     assert (result[0] == expected[0]).all()
+
+
+def test_normalize_decimal_columns_uses_declared_types():
+    actual = pd.DataFrame({"amount": ["9.99", "10.00"], "identifier": ["9", "10"]})
+    expected = actual.copy()
+
+    actual = normalize_decimal_columns(actual, ["decimal(7,2)", "varchar"])
+    expected = normalize_decimal_columns(expected, ["decimal(7,2)", "varchar"])
+
+    assert isinstance(actual["amount"].iloc[0], Decimal)
+    assert actual["amount"].iloc[0] < actual["amount"].iloc[1]
+    assert actual["identifier"].iloc[0] > actual["identifier"].iloc[1]
+    assert expected.equals(actual)
+
+
+def test_compare_result_frames_validates_decimal_order_numerically():
+    actual = pd.DataFrame({"amount": ["1135171.38", "971187.80"]})
+    expected = actual.copy()
+
+    compare_result_frames(
+        actual,
+        expected,
+        "SELECT amount FROM t ORDER BY amount DESC",
+        ["decimal(14,2)"],
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/common/testing/validate_results.py
+++ b/common/testing/validate_results.py
@@ -15,6 +15,8 @@ import sys
 from pathlib import Path
 
 import pandas as pd
+import pyarrow.parquet as pq
+import pyarrow.types as pat
 
 # Allow importing from the repo root (common/testing/result_comparison)
 sys.path.insert(0, str(Path(__file__).parent.parent.parent))
@@ -25,6 +27,22 @@ from common.testing.test_utils import get_queries
 # ---------------------------------------------------------------------------
 # Main validation loop
 # ---------------------------------------------------------------------------
+
+
+def _get_column_types(result_file: Path) -> list[str] | None:
+    types_file = result_file.with_suffix(".types.json")
+    if types_file.exists():
+        return json.loads(types_file.read_text())
+
+    inferred_types = []
+    has_decimal = False
+    for field in pq.ParquetFile(result_file).schema_arrow:
+        if pat.is_decimal(field.type):
+            inferred_types.append(f"decimal({field.type.precision},{field.type.scale})")
+            has_decimal = True
+        else:
+            inferred_types.append(str(field.type))
+    return inferred_types if has_decimal else None
 
 
 def validate(
@@ -86,6 +104,7 @@ def validate(
 
         actual = pd.read_parquet(result_file)
         expected = pd.read_parquet(expected_file)
+        actual_column_types = _get_column_types(result_file)
 
         if expected.empty and all(t is object for t in expected.dtypes):
             msg = f"expected file is empty (no schema): {expected_file.name}"
@@ -101,7 +120,7 @@ def validate(
             not_validated += 1
             continue
 
-        status, msg = validate_query_result(query_id, actual, expected, query_sql)
+        status, msg = validate_query_result(query_id, actual, expected, query_sql, actual_column_types)
 
         if status == "not-validated":
             query_results[query_id] = {"status": "not-validated", "message": msg}

--- a/presto/testing/performance_benchmarks/common_fixtures.py
+++ b/presto/testing/performance_benchmarks/common_fixtures.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 
+import json
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -10,6 +11,7 @@ import pytest
 
 from common.testing.performance_benchmarks.benchmark_keys import BenchmarkKeys
 from common.testing.performance_benchmarks.profiler_utils import start_profiler, stop_profiler
+from common.testing.result_comparison import normalize_decimal_columns
 
 from ..integration_tests.analyze_tables import check_tables_analyzed
 from .metrics_collector import collect_metrics
@@ -116,13 +118,17 @@ def benchmark_query(request, presto_cursor, benchmark_queries, benchmark_result_
                 if iteration_num == 0:
                     rows = cursor.fetchall()
                     columns = [desc[0] for desc in cursor.description]
+                    column_types = [desc[1] for desc in cursor.description]
                     df = pd.DataFrame(rows, columns=columns)
+                    df = normalize_decimal_columns(df, column_types)
 
                     # Save to Parquet format to match expected results
                     results_dir = Path(f"{bench_output_dir}/query_results")
                     results_dir.mkdir(parents=True, exist_ok=True)
                     parquet_path = results_dir / f"{query_id.lower()}.parquet"
                     df.to_parquet(parquet_path, index=False)
+                    types_path = results_dir / f"{query_id.lower()}.types.json"
+                    types_path.write_text(json.dumps(column_types))
 
                 # Collect metrics after each query iteration if enabled
                 if metrics:


### PR DESCRIPTION
## Summary

Fix benchmark validation for Presto DECIMAL result columns.                                                                                                       
                                                                                                                                                                       
The Presto Python client returns DECIMAL values as strings. Benchmark results were therefore written as Parquet string columns, causing the validator to compare DECIMAL values lexicographically during `ORDER BY` validation.

## Changes:
                                                                                                                                                 
- Capture Presto result types from cursor.description.                                                                                                            
- Convert declared DECIMAL columns to Python Decimal values before writing benchmark Parquet results.                                                             
- Store the complete Presto result types in per-query qN.types.json sidecar files.                                                                                
- Load the sidecar during benchmark validation.                                                                                                                   
- Fall back to Parquet decimal logical types when sidecar metadata is unavailable.                                                                                
- Normalize only columns explicitly declared as decimal(p,s).                                                                                                     
- Preserve numeric-looking VARCHAR columns as strings.                                                                                                            
- Pass result types through the shared comparison path so DECIMAL ordering and comparison use numeric values.                                                     
- Add regression coverage for numeric DECIMAL ordering and VARCHAR preservation.                                                                                  
