### PR TITLE
feat(workflow-status): route nightly job log analysis through NVIDIA Inference Hub

### DIFF
--- a/.github/workflows/nightly-status-report.yml
+++ b/.github/workflows/nightly-status-report.yml
@@ -63,7 +63,9 @@ jobs:
       - name: Analyse velox nightly run
         if: ${{ steps.runs.outputs.velox_run != '' }}
         env:
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          ANTHROPIC_AUTH_TOKEN: ${{ secrets.ANTHROPIC_API_KEY }}
+          ANTHROPIC_BASE_URL: ${{ vars.ANTHROPIC_BASE_URL }}
+          CLAUDE_MODEL: ${{ vars.CLAUDE_MODEL }}
         run: | # zizmor: ignore[template-injection]
           python3 scripts/workflow_status/workflow_status.py \
             --run-id ${{ steps.runs.outputs.velox_run }} \
@@ -73,7 +75,9 @@ jobs:
       - name: Analyse presto nightly run
         if: ${{ steps.runs.outputs.presto_run != '' }}
         env:
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          ANTHROPIC_AUTH_TOKEN: ${{ secrets.ANTHROPIC_API_KEY }}
+          ANTHROPIC_BASE_URL: ${{ vars.ANTHROPIC_BASE_URL }}
+          CLAUDE_MODEL: ${{ vars.CLAUDE_MODEL }}
         run: | # zizmor: ignore[template-injection]
           python3 scripts/workflow_status/workflow_status.py \
             --run-id ${{ steps.runs.outputs.presto_run }} \

--- a/.github/workflows/nightly-status-report.yml
+++ b/.github/workflows/nightly-status-report.yml
@@ -100,6 +100,7 @@ jobs:
           payload-file-path: velox-status-payload.json
           webhook: ${{ secrets.SLACK_WEBHOOK_NIGHTLY_STATUS_URL }}
           webhook-type: incoming-webhook
+          errors: true
 
       - name: Send presto status to Slack
         if: ${{ always() && hashFiles('presto-status-payload.json') != '' }}
@@ -108,3 +109,4 @@ jobs:
           payload-file-path: presto-status-payload.json
           webhook: ${{ secrets.SLACK_WEBHOOK_NIGHTLY_STATUS_URL }}
           webhook-type: incoming-webhook
+          errors: true

--- a/.github/workflows/nightly-status-report.yml
+++ b/.github/workflows/nightly-status-report.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Analyse velox nightly run
         if: ${{ steps.runs.outputs.velox_run != '' }}
         env:
-          ANTHROPIC_AUTH_TOKEN: ${{ secrets.ANTHROPIC_API_KEY }}
+          ANTHROPIC_AUTH_TOKEN: ${{ secrets.ANTHROPIC_AUTH_TOKEN }}
           ANTHROPIC_BASE_URL: ${{ vars.ANTHROPIC_BASE_URL }}
           CLAUDE_MODEL: ${{ vars.CLAUDE_MODEL }}
         run: | # zizmor: ignore[template-injection]
@@ -75,7 +75,7 @@ jobs:
       - name: Analyse presto nightly run
         if: ${{ steps.runs.outputs.presto_run != '' }}
         env:
-          ANTHROPIC_AUTH_TOKEN: ${{ secrets.ANTHROPIC_API_KEY }}
+          ANTHROPIC_AUTH_TOKEN: ${{ secrets.ANTHROPIC_AUTH_TOKEN }}
           ANTHROPIC_BASE_URL: ${{ vars.ANTHROPIC_BASE_URL }}
           CLAUDE_MODEL: ${{ vars.CLAUDE_MODEL }}
         run: | # zizmor: ignore[template-injection]

--- a/scripts/workflow_status/lib/ai.py
+++ b/scripts/workflow_status/lib/ai.py
@@ -6,9 +6,11 @@
 
 from __future__ import annotations
 
+import os
 import re
 import shutil
 import subprocess
+import sys
 import threading
 from pathlib import Path
 
@@ -66,6 +68,24 @@ class TokenTracker:
 # ---- Internal dispatchers --------------------------------------------------
 
 
+def _claude_subprocess_env(config: Config) -> dict[str, str]:
+    """Env for Claude Code, including NVIDIA Inference Hub gateway settings.
+
+    Inference Hub is an Anthropic-compatible LLM gateway. Claude Code sends
+    ``Authorization: Bearer`` from ``ANTHROPIC_AUTH_TOKEN`` and posts to
+    ``{ANTHROPIC_BASE_URL}/v1/messages``. See:
+    https://nvidia.atlassian.net/wiki/spaces/NOVA/pages/3505648978/Using+Claude+Code+and+SDK+with+Inference+Hub
+    """
+    env = os.environ.copy()
+    env["ANTHROPIC_BASE_URL"] = config.anthropic_base_url
+    if config.anthropic_auth_token:
+        env["ANTHROPIC_AUTH_TOKEN"] = config.anthropic_auth_token
+        # Gateway auth is bearer; an empty API key still occupies Claude Code's
+        # credential slot, so only set a placeholder when none is present.
+        env.setdefault("ANTHROPIC_API_KEY", config.anthropic_auth_token)
+    return env
+
+
 def _truncate_log(content: str, max_chars: int = 30000) -> str:
     if len(content) <= max_chars:
         return content
@@ -115,35 +135,67 @@ def _analyze_with_claude(
         fix_format_extra=(", include relevant PR links if applicable" if prefetched_items else ""),
     )
 
+    cmd = [
+        config.claude_bin,
+        "--print",
+        "--model",
+        config.claude_model,
+        "--no-session-persistence",
+        "--max-turns",
+        "1",
+        "--allowedTools",
+        "",
+    ]
+    # Skip claude.ai OAuth when talking to Inference Hub / a custom gateway.
+    if config.anthropic_base_url:
+        cmd.insert(2, "--bare")
+
     try:
         proc = subprocess.run(
-            [
-                config.claude_bin,
-                "--print",
-                "--model",
-                config.claude_model,
-                "--no-session-persistence",
-                "--allowedTools",
-                "",
-            ],
+            cmd,
             input=prompt,
             capture_output=True,
             text=True,
             timeout=120,
+            env=_claude_subprocess_env(config),
         )
         content = proc.stdout.strip()
-        if content:
+        if content and proc.returncode == 0:
             tracker.record_estimate(prompt, content)
             return content
-    except Exception:
-        pass
+        err = (proc.stderr or "").strip()
+        if err:
+            print(err[:2000], file=sys.stderr)
+        if not content and "--bare" in cmd:
+            cmd = [c for c in cmd if c != "--bare"]
+            proc = subprocess.run(
+                cmd,
+                input=prompt,
+                capture_output=True,
+                text=True,
+                timeout=120,
+                env=_claude_subprocess_env(config),
+            )
+            content = proc.stdout.strip()
+            if content and proc.returncode == 0:
+                tracker.record_estimate(prompt, content)
+                return content
+            err = (proc.stderr or "").strip()
+            if err:
+                print(err[:2000], file=sys.stderr)
+    except Exception as exc:
+        print(f"WARN: Claude CLI failed: {exc}", file=sys.stderr)
 
+    auth_hint = (
+        "set ANTHROPIC_AUTH_TOKEN or NVIDIA_API_KEY as a bearer token for "
+        f"Inference Hub ({config.anthropic_base_url})"
+    )
     return (
         "STACKTRACE:Unable to extract - Claude CLI returned no output\nEND_STACKTRACE\n"
-        "CAUSE:Unable to analyze - Claude CLI failed "
-        "(check authentication with 'claude --print \"hello\"')\n"
-        "FIX:Run 'claude' interactively once to authenticate, "
-        "or check ANTHROPIC_API_KEY"
+        f"CAUSE:Unable to analyze - Claude CLI failed ({auth_hint})\n"
+        "FIX:Configure Inference Hub per "
+        "https://nvidia.atlassian.net/wiki/spaces/NOVA/pages/3505648978/"
+        "Using+Claude+Code+and+SDK+with+Inference+Hub"
     )
 
 

--- a/scripts/workflow_status/lib/ai.py
+++ b/scripts/workflow_status/lib/ai.py
@@ -73,8 +73,7 @@ def _claude_subprocess_env(config: Config) -> dict[str, str]:
 
     Inference Hub is an Anthropic-compatible LLM gateway. Claude Code sends
     ``Authorization: Bearer`` from ``ANTHROPIC_AUTH_TOKEN`` and posts to
-    ``{ANTHROPIC_BASE_URL}/v1/messages``. See:
-    https://nvidia.atlassian.net/wiki/spaces/NOVA/pages/3505648978/Using+Claude+Code+and+SDK+with+Inference+Hub
+    ``{ANTHROPIC_BASE_URL}/v1/messages``.
     """
     env = os.environ.copy()
     env["ANTHROPIC_BASE_URL"] = config.anthropic_base_url
@@ -192,9 +191,7 @@ def _analyze_with_claude(
     return (
         "STACKTRACE:Unable to extract - Claude CLI returned no output\nEND_STACKTRACE\n"
         f"CAUSE:Unable to analyze - Claude CLI failed ({auth_hint})\n"
-        "FIX:Configure Inference Hub per "
-        "https://nvidia.atlassian.net/wiki/spaces/NOVA/pages/3505648978/"
-        "Using+Claude+Code+and+SDK+with+Inference+Hub"
+        "FIX:"
     )
 
 

--- a/scripts/workflow_status/lib/ai.py
+++ b/scripts/workflow_status/lib/ai.py
@@ -187,8 +187,7 @@ def _analyze_with_claude(
         print(f"WARN: Claude CLI failed: {exc}", file=sys.stderr)
 
     auth_hint = (
-        "set ANTHROPIC_AUTH_TOKEN or NVIDIA_API_KEY as a bearer token for "
-        f"Inference Hub ({config.anthropic_base_url})"
+        f"set ANTHROPIC_AUTH_TOKEN or NVIDIA_API_KEY as a bearer token for Inference Hub ({config.anthropic_base_url})"
     )
     return (
         "STACKTRACE:Unable to extract - Claude CLI returned no output\nEND_STACKTRACE\n"

--- a/scripts/workflow_status/lib/ai.py
+++ b/scripts/workflow_status/lib/ai.py
@@ -79,9 +79,6 @@ def _claude_subprocess_env(config: Config) -> dict[str, str]:
     env["ANTHROPIC_BASE_URL"] = config.anthropic_base_url
     if config.anthropic_auth_token:
         env["ANTHROPIC_AUTH_TOKEN"] = config.anthropic_auth_token
-        # Gateway auth is bearer; an empty API key still occupies Claude Code's
-        # credential slot, so only set a placeholder when none is present.
-        env.setdefault("ANTHROPIC_API_KEY", config.anthropic_auth_token)
     return env
 
 

--- a/scripts/workflow_status/lib/ai.py
+++ b/scripts/workflow_status/lib/ai.py
@@ -7,16 +7,21 @@
 from __future__ import annotations
 
 import os
+import random
 import re
 import shutil
 import subprocess
 import sys
 import threading
+import time
 from pathlib import Path
 
 from .config import Config
 
 _PROMPT_DIR = Path(__file__).resolve().parent.parent / "prompts"
+
+_CLAUDE_ATTEMPTS = 3
+_CLAUDE_RETRY_SLEEP = 3
 
 
 def _load_prompt_template() -> str:
@@ -146,48 +151,48 @@ def _analyze_with_claude(
     if config.anthropic_base_url:
         cmd.insert(2, "--bare")
 
-    try:
-        proc = subprocess.run(
-            cmd,
-            input=prompt,
-            capture_output=True,
-            text=True,
-            timeout=120,
-            env=_claude_subprocess_env(config),
-        )
-        content = proc.stdout.strip()
-        if content and proc.returncode == 0:
-            tracker.record_estimate(prompt, content)
-            return content
-        err = (proc.stderr or "").strip()
-        if err:
-            print(err[:2000], file=sys.stderr)
-        if not content and "--bare" in cmd:
-            cmd = [c for c in cmd if c != "--bare"]
-            proc = subprocess.run(
-                cmd,
-                input=prompt,
-                capture_output=True,
-                text=True,
-                timeout=120,
-                env=_claude_subprocess_env(config),
-            )
-            content = proc.stdout.strip()
-            if content and proc.returncode == 0:
-                tracker.record_estimate(prompt, content)
-                return content
-            err = (proc.stderr or "").strip()
-            if err:
-                print(err[:2000], file=sys.stderr)
-    except Exception as exc:
-        print(f"WARN: Claude CLI failed: {exc}", file=sys.stderr)
+    # Without --bare the CLI needs claude.ai OAuth, so it is only a fallback for
+    # a build that does not know the flag.
+    variants = [cmd]
+    if "--bare" in cmd:
+        variants.append([c for c in cmd if c != "--bare"])
 
-    auth_hint = (
-        f"set ANTHROPIC_AUTH_TOKEN or NVIDIA_API_KEY as a bearer token for Inference Hub ({config.anthropic_base_url})"
-    )
+    env = _claude_subprocess_env(config)
+    detail = "no attempt made"
+
+    for attempt in range(1, _CLAUDE_ATTEMPTS + 1):
+        for variant in variants:
+            try:
+                proc = subprocess.run(
+                    variant,
+                    input=prompt,
+                    capture_output=True,
+                    text=True,
+                    timeout=180,
+                    env=env,
+                )
+            except Exception as exc:
+                detail = f"{type(exc).__name__}: {exc}"
+            else:
+                content = proc.stdout.strip()
+                if content and proc.returncode == 0:
+                    tracker.record_estimate(prompt, content)
+                    return content
+                # Claude Code reports in-run failures such as bad credentials on
+                # stdout, so keep both streams for the diagnostic.
+                err = (proc.stderr or "").strip()
+                detail = err or content or f"empty output, exit {proc.returncode}"
+            print(
+                f"WARN: claude attempt {attempt}/{_CLAUDE_ATTEMPTS} failed: {detail[:1000]}",
+                file=sys.stderr,
+            )
+        if attempt < _CLAUDE_ATTEMPTS:
+            # Jitter so parallel workers retry at different times.
+            time.sleep(_CLAUDE_RETRY_SLEEP * attempt + random.uniform(0, 1))
+
     return (
         "STACKTRACE:Unable to extract - Claude CLI returned no output\nEND_STACKTRACE\n"
-        f"CAUSE:Unable to analyze - Claude CLI failed ({auth_hint})\n"
+        f"CAUSE:Unable to analyze - Claude CLI failed after {_CLAUDE_ATTEMPTS} attempts: {detail[:300]}\n"
         "FIX:"
     )
 

--- a/scripts/workflow_status/lib/config.py
+++ b/scripts/workflow_status/lib/config.py
@@ -12,7 +12,6 @@ from dataclasses import dataclass
 # NVIDIA Inference Hub (Claude Code / Anthropic-compatible gateway).
 # Claude Code appends /v1/messages — do not include /v1 on this URL.
 # Override with --anthropic-base-url or ANTHROPIC_BASE_URL.
-# https://nvidia.atlassian.net/wiki/spaces/NOVA/pages/3505648978/Using+Claude+Code+and+SDK+with+Inference+Hub
 INFERENCE_HUB_BASE_URL = "https://inference-api.nvidia.com"
 
 

--- a/scripts/workflow_status/lib/config.py
+++ b/scripts/workflow_status/lib/config.py
@@ -89,6 +89,5 @@ def load_from_args(args) -> Config:
     os.environ["CLAUDE_MODEL"] = cfg.claude_model
     if cfg.anthropic_auth_token:
         os.environ["ANTHROPIC_AUTH_TOKEN"] = cfg.anthropic_auth_token
-        os.environ.setdefault("ANTHROPIC_API_KEY", cfg.anthropic_auth_token)
 
     return cfg

--- a/scripts/workflow_status/lib/config.py
+++ b/scripts/workflow_status/lib/config.py
@@ -9,6 +9,12 @@ from __future__ import annotations
 import os
 from dataclasses import dataclass
 
+# NVIDIA Inference Hub (Claude Code / Anthropic-compatible gateway).
+# Claude Code appends /v1/messages — do not include /v1 on this URL.
+# Override with --anthropic-base-url or ANTHROPIC_BASE_URL.
+# https://nvidia.atlassian.net/wiki/spaces/NOVA/pages/3505648978/Using+Claude+Code+and+SDK+with+Inference+Hub
+INFERENCE_HUB_BASE_URL = "https://inference-api.nvidia.com"
+
 
 @dataclass
 class Config:
@@ -33,7 +39,9 @@ class Config:
     gh_http_timeout: int = 60
 
     claude_bin: str = "claude"
-    claude_model: str = "opus"
+    claude_model: str = "azure/anthropic/claude-opus-5"
+    anthropic_base_url: str = INFERENCE_HUB_BASE_URL
+    anthropic_auth_token: str = ""
 
     slack_webhook_url: str = ""
 
@@ -62,9 +70,30 @@ def load_from_args(args) -> Config:
     cfg.gh_retry_sleep = int(os.environ.get("GH_RETRY_SLEEP_SECONDS", "2"))
     cfg.gh_http_timeout = int(os.environ.get("GH_HTTP_TIMEOUT", "60"))
 
-    cfg.claude_bin = os.environ.get("CLAUDE_BIN", "claude")
-    cfg.claude_model = os.environ.get("CLAUDE_MODEL", "opus")
+    cfg.claude_bin = getattr(args, "claude_bin", "") or os.environ.get("CLAUDE_BIN", "claude")
+    cfg.claude_model = (
+        getattr(args, "claude_model", "")
+        or os.environ.get("CLAUDE_MODEL")
+        or "azure/anthropic/claude-opus-5"
+    )
+    cfg.anthropic_base_url = (
+        getattr(args, "anthropic_base_url", "")
+        or os.environ.get("ANTHROPIC_BASE_URL")
+        or INFERENCE_HUB_BASE_URL
+    ).rstrip("/")
+    cfg.anthropic_auth_token = (
+        os.environ.get("ANTHROPIC_AUTH_TOKEN")
+        or os.environ.get("NVIDIA_API_KEY")
+        or os.environ.get("NGC_API_KEY")
+        or ""
+    )
 
     cfg.slack_webhook_url = os.environ.get("SLACK_WEBHOOK_URL", "")
+
+    os.environ["ANTHROPIC_BASE_URL"] = cfg.anthropic_base_url
+    os.environ["CLAUDE_MODEL"] = cfg.claude_model
+    if cfg.anthropic_auth_token:
+        os.environ["ANTHROPIC_AUTH_TOKEN"] = cfg.anthropic_auth_token
+        os.environ.setdefault("ANTHROPIC_API_KEY", cfg.anthropic_auth_token)
 
     return cfg

--- a/scripts/workflow_status/lib/config.py
+++ b/scripts/workflow_status/lib/config.py
@@ -72,14 +72,10 @@ def load_from_args(args) -> Config:
 
     cfg.claude_bin = getattr(args, "claude_bin", "") or os.environ.get("CLAUDE_BIN", "claude")
     cfg.claude_model = (
-        getattr(args, "claude_model", "")
-        or os.environ.get("CLAUDE_MODEL")
-        or "azure/anthropic/claude-opus-5"
+        getattr(args, "claude_model", "") or os.environ.get("CLAUDE_MODEL") or "azure/anthropic/claude-opus-5"
     )
     cfg.anthropic_base_url = (
-        getattr(args, "anthropic_base_url", "")
-        or os.environ.get("ANTHROPIC_BASE_URL")
-        or INFERENCE_HUB_BASE_URL
+        getattr(args, "anthropic_base_url", "") or os.environ.get("ANTHROPIC_BASE_URL") or INFERENCE_HUB_BASE_URL
     ).rstrip("/")
     cfg.anthropic_auth_token = (
         os.environ.get("ANTHROPIC_AUTH_TOKEN")

--- a/scripts/workflow_status/lib/formatting.py
+++ b/scripts/workflow_status/lib/formatting.py
@@ -217,9 +217,9 @@ def format_failure_detail(
         out.print("```")
 
         if analyze_cause:
-            out.print(f"    *Cause:* _{cause or 'Unable to determine cause'}_")
+            out.print(f"    *Cause:* {cause or 'Unable to determine cause'}")
             if analyze_fix:
-                out.print(f"    *Fix:* _{fix or 'Pending investigation'}_")
+                out.print(f"    *Fix:* {fix or 'Pending investigation'}")
 
     if related_items:
         out.print()

--- a/scripts/workflow_status/lib/logs.py
+++ b/scripts/workflow_status/lib/logs.py
@@ -79,6 +79,7 @@ def extract_relevant_failures(raw_log: str) -> str:
 
 def _extract_gtest_blocks(lines: list[str]) -> str:
     result_parts: list[str] = []
+    ctest_parts: list[str] = []
     in_block = False
     block_lines: list[str] = []
     seen_tests: set[str] = set()
@@ -121,15 +122,20 @@ def _extract_gtest_blocks(lines: list[str]) -> str:
             continue
 
         if _CTEST_SUMMARY.match(line):
-            result_parts.append(line)
+            ctest_parts.append(line)
             continue
         if _CTEST_FAILED_LIST.match(line):
             in_ctest = True
         if in_ctest:
-            result_parts.append(line)
+            ctest_parts.append(line)
             continue
 
-    return "\n".join(result_parts) if result_parts else ""
+    # The CTest footer only names the failing target. When a GTest block was
+    # captured it restates that same failure without adding a cause, so keeping
+    # it would spend a second AI call to describe one failure twice.
+    if result_parts:
+        return "\n".join(result_parts)
+    return "\n".join(ctest_parts)
 
 
 def _extract_error_lines(

--- a/scripts/workflow_status/lib/slack.py
+++ b/scripts/workflow_status/lib/slack.py
@@ -62,29 +62,51 @@ def split_code_blocks(section: str) -> list[str]:
 
 
 def chunk_text(text: str, max_len: int = SLACK_BLOCK_TEXT_LIMIT) -> list[str]:
-    """Split text into chunks that fit within Slack's block text limit."""
+    """Split text into chunks that fit within Slack's block text limit.
+
+    When a fenced code block is split, each piece is re-wrapped with fences.
+    Those extra characters are reserved so no chunk exceeds *max_len* (Slack
+    rejects section text over 3000 characters).
+    """
     if len(text) <= max_len:
         return [text]
     is_code = text.lstrip().startswith("```")
+    # Room left for "\n```" when closing a split code chunk.
+    body_limit = max_len - 4 if is_code else max_len
     chunks: list[str] = []
-    lines = text.splitlines(keepends=True)
     current: list[str] = []
     current_len = 0
-    for line in lines:
-        if current_len + len(line) > max_len and current:
-            chunk = "".join(current).rstrip()
-            if is_code and not chunk.rstrip().endswith("```"):
-                chunk += "\n```"
-            chunks.append(chunk)
-            current = []
-            current_len = 0
-            if is_code:
-                current.append("```\n")
-                current_len = 4
+
+    def flush(*, final: bool) -> None:
+        nonlocal current, current_len
+        chunk = "".join(current).rstrip()
+        if not chunk.strip("`").strip():
+            # Nothing but fences so far; keep buffering instead of emitting.
+            if final:
+                current, current_len = [], 0
+            return
+        if is_code and chunk.count("```") % 2:
+            chunk += "\n```"
+        chunks.append(chunk)
+        current = []
+        current_len = 0
+        if is_code and not final:
+            current.append("```\n")
+            current_len = 4
+
+    for line in text.splitlines(keepends=True):
+        if current and current_len + len(line) > body_limit:
+            flush(final=False)
+        # A single line longer than the budget has to be broken mid-line.
+        while len(line) > body_limit - current_len:
+            room = body_limit - current_len
+            current.append(line[:room])
+            current_len += room
+            line = line[room:]
+            flush(final=False)
         current.append(line)
         current_len += len(line)
-    if current:
-        chunks.append("".join(current).rstrip())
+    flush(final=True)
     return chunks
 
 

--- a/scripts/workflow_status/workflow_status.py
+++ b/scripts/workflow_status/workflow_status.py
@@ -65,12 +65,14 @@ environment variables:
   GH_HTTP_TIMEOUT=N            gh HTTP timeout in seconds (default: 60)
 
   CLAUDE_BIN                   Claude CLI binary (default: claude)
-  CLAUDE_MODEL                 Claude model to use (default: opus)
-  ANTHROPIC_API_KEY            API key for Claude analysis
+  CLAUDE_MODEL                 Hub model id (default: azure/anthropic/claude-opus-5)
+  ANTHROPIC_BASE_URL           Inference Hub root (default: https://inference-api.nvidia.com)
+  ANTHROPIC_AUTH_TOKEN         Bearer token for Inference Hub (preferred)
+  NVIDIA_API_KEY / NGC_API_KEY Fallback if ANTHROPIC_AUTH_TOKEN is unset
 
 examples:
   python %(prog)s --run-id 23729840879
-  python %(prog)s --run-id 23729840879 --job-id 12345678
+  python %(prog)s --run-id 23729840879 --claude-model <hub-model-id>
   python %(prog)s --run-id 23729840879 --slack --output report.json
   python %(prog)s --run-id 23729840879 --no-cause --no-fix
 """,
@@ -83,6 +85,21 @@ examples:
     p.add_argument("--print-logs", action="store_true", default=False, help="print failed log tails for each failure")
     p.add_argument("--no-cause", action="store_true", default=False, help="disable AI cause analysis")
     p.add_argument("--no-fix", action="store_true", default=False, help="disable AI fix suggestions")
+    p.add_argument(
+        "--anthropic-base-url",
+        default="https://inference-api.nvidia.com",
+        help="Inference Hub root URL (default: https://inference-api.nvidia.com; do not include /v1)",
+    )
+    p.add_argument(
+        "--claude-model",
+        default="",
+        help="Model id passed to claude --model (overrides CLAUDE_MODEL)",
+    )
+    p.add_argument(
+        "--claude-bin",
+        default="",
+        help="Claude CLI binary (overrides CLAUDE_BIN; default: claude)",
+    )
     return p.parse_args()
 
 


### PR DESCRIPTION
## Summary
- Route `workflow_status.py` Claude failure analysis through NVIDIA Inference Hub (`https://inference-api.nvidia.com`) instead of a claude.ai login.
- Default model is `azure/anthropic/claude-opus-5`. Auth is `ANTHROPIC_AUTH_TOKEN` (nightly still uses `secrets.ANTHROPIC_API_KEY` as that bearer token), with `NVIDIA_API_KEY` / `NGC_API_KEY` as fallbacks.
- Nightly status workflow forwards hub env (`ANTHROPIC_AUTH_TOKEN`, `ANTHROPIC_BASE_URL`, `CLAUDE_MODEL`). `--bare` is used so GitHub runners skip OAuth.

## Test plan
- [x] `python3 scripts/workflow_status/workflow_status.py --help` shows hub defaults and `--anthropic-base-url` / `--claude-model`.
- [x] With `NVIDIA_API_KEY` or `ANTHROPIC_AUTH_TOKEN` set, run against a known failed nightly `--run-id` and confirm cause/fix text is produced (not the Claude CLI auth error).
- [x] Confirm Claude is called with `--model azure/anthropic/claude-opus-5` and `ANTHROPIC_BASE_URL=https://inference-api.nvidia.com`.
- [x] `workflow_dispatch` `nightly-status-report.yml` after repo vars/secrets are in place; check Slack payload / artifacts. 