### PR TITLE
fix(data-gen): build only the tpchgen-cli Rust stage

### DIFF
--- a/benchmark_data_tools/scripts/install_tpchgen_cli.sh
+++ b/benchmark_data_tools/scripts/install_tpchgen_cli.sh
@@ -18,8 +18,11 @@ trap 'rm -rf $TEMP_DIR' EXIT
 echo "Cloning tpchgen-rs ($REPO_BRANCH)..."
 git clone --depth 1 --single-branch --branch "$REPO_BRANCH" "$REPO_URL" "$TEMP_DIR/tpchgen-rs"
 
-echo "Building Docker image..."
-docker build -t "$IMAGE_NAME" "$TEMP_DIR/tpchgen-rs"
+# Only the Rust builder stage is required: this script copies tpchgen-cli out of
+# the image. The upstream Dockerfile also builds a python-deps stage that pip-
+# installs pyarrow (~48MiB) with UV_HTTP_TIMEOUT=30s, which flakes on CI.
+echo "Building Docker image (Rust builder stage)..."
+docker build --target builder -t "$IMAGE_NAME" "$TEMP_DIR/tpchgen-rs"
 
 echo "Extracting tpchgen-cli binary..."
 CONTAINER_ID=$(docker create "$IMAGE_NAME")


### PR DESCRIPTION
## Summary

`install_tpchgen_cli.sh` clones [TomAugspurger/tpchgen-rs](https://github.com/TomAugspurger/tpchgen-rs/blob/tom/sync-upstream-clean/Dockerfile) and `docker build`s the upstream Dockerfile, then copies only `/usr/local/bin/tpchgen-cli` out of the image.

That Dockerfile is multi-stage. The **builder** stage compiles the Rust CLI. A later **python-deps** stage runs `uv pip install pyarrow` (~48 MiB wheel) with **UV_HTTP_TIMEOUT=30s**. CI often cannot finish that download/extract, so the whole install fails even though we never use pyarrow or the Python entrypoint.

This change builds `--target builder` so Cargo still produces `tpchgen-cli` and the `pyarrow` install is skipped.

## Why?

Our CI runner job (https://github.com/rapidsai/velox-testing/actions/runs/32334525240/job/96331784081) sometimes faces network failures when building the unnecessary python-deps stage. This PR restricts Docker to build only the necessary stage (builder) instead of all stages such as builder, python-deps, etc., since we only need the binary built from the builder stage.