### PR TITLE
Add direct EC2 orchestration for distributed Presto benchmarks

### DIFF
--- a/benchmark_data_tools/duckdb_utils.py
+++ b/benchmark_data_tools/duckdb_utils.py
@@ -34,8 +34,7 @@ def ensure_remote_access(path) -> None:
 
 
 def read_scale_factor(metadata_uri: str):
-    """Read the scale_factor field from a metadata.json at ``metadata_uri``.
-    """
+    """Read the scale_factor field from a metadata.json at ``metadata_uri``."""
     # For local data
     if not str(metadata_uri).startswith("s3://"):
         with open(metadata_uri) as file:

--- a/benchmark_data_tools/duckdb_utils.py
+++ b/benchmark_data_tools/duckdb_utils.py
@@ -33,15 +33,22 @@ def ensure_remote_access(path) -> None:
     _s3_configured = True
 
 
+def _extract_scale_factor(metadata: dict):
+    """Return the scale factor from parsed metadata, whether it is a top-level field or
+    nested under 'options'."""
+    return metadata.get("scale_factor") or metadata.get("options", {}).get("scale_factor")
+
+
 def read_scale_factor(metadata_uri: str):
     """Read the scale_factor field from a metadata.json at ``metadata_uri``."""
     # For local data
     if not str(metadata_uri).startswith("s3://"):
         with open(metadata_uri) as file:
-            return json.load(file)["scale_factor"]
+            return _extract_scale_factor(json.load(file))
     # For remote data
     ensure_remote_access(metadata_uri)
-    return duckdb.sql(f"SELECT scale_factor FROM read_json_auto('{metadata_uri}')").fetchone()[0]
+    raw = duckdb.sql(f"SELECT content FROM read_text('{metadata_uri}')").fetchone()[0]
+    return _extract_scale_factor(json.loads(raw))
 
 
 def quote_ident(name: str) -> str:

--- a/benchmark_data_tools/duckdb_utils.py
+++ b/benchmark_data_tools/duckdb_utils.py
@@ -1,9 +1,48 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 
+import json
+import os
 import re
 
 import duckdb
+
+_s3_configured = False
+
+
+def ensure_remote_access(path) -> None:
+    """Configure DuckDB to read from a remote object store if ``path`` needs it.
+
+    The region must be provided via AWS_DEFAULT_REGION (or AWS_REGION). Do nothing for local
+    paths.
+    """
+    global _s3_configured
+    if _s3_configured or not str(path).startswith("s3://"):
+        return
+    region = os.environ.get("AWS_DEFAULT_REGION") or os.environ.get("AWS_REGION")
+    if not region:
+        raise RuntimeError(
+            "Reading s3:// data requires the AWS region: set AWS_DEFAULT_REGION "
+            "(or AWS_REGION), e.g. `export AWS_DEFAULT_REGION=us-east-2`."
+        )
+    # Enable DuckDB to access S3 storage
+    duckdb.sql("INSTALL httpfs; LOAD httpfs; INSTALL aws; LOAD aws;")
+    # Register an S3 access profile named s3_from_env that pulls credentials from the
+    # standard AWS chain and targets region <region>.
+    duckdb.sql(f"CREATE SECRET IF NOT EXISTS s3_from_env (TYPE s3, PROVIDER credential_chain, REGION '{region}')")
+    _s3_configured = True
+
+
+def read_scale_factor(metadata_uri: str):
+    """Read the scale_factor field from a metadata.json at ``metadata_uri``.
+    """
+    # For local data
+    if not str(metadata_uri).startswith("s3://"):
+        with open(metadata_uri) as file:
+            return json.load(file)["scale_factor"]
+    # For remote data
+    ensure_remote_access(metadata_uri)
+    return duckdb.sql(f"SELECT scale_factor FROM read_json_auto('{metadata_uri}')").fetchone()[0]
 
 
 def quote_ident(name: str) -> str:
@@ -30,6 +69,7 @@ def drop_benchmark_tables():
 
 
 def create_table(table_name, data_path):
+    ensure_remote_access(data_path)
     duckdb.sql(f"DROP TABLE IF EXISTS {quote_ident(table_name)}")
     duckdb.sql(f"CREATE TABLE {quote_ident(table_name)} AS SELECT * FROM '{data_path}/*.parquet';")
 
@@ -37,6 +77,7 @@ def create_table(table_name, data_path):
 # Generates a sample table with a small limit.
 # This is mainly used to extract the schema from the parquet files.
 def create_not_null_table_from_sample(table_name, data_path):
+    ensure_remote_access(data_path)
     duckdb.sql(f"DROP TABLE IF EXISTS {quote_ident(table_name)}")
     duckdb.sql(f"CREATE TABLE {quote_ident(table_name)} AS SELECT * FROM '{data_path}/*.parquet' LIMIT 10;")
     ret = duckdb.sql(f"DESCRIBE TABLE {quote_ident(table_name)}").fetchall()
@@ -45,6 +86,7 @@ def create_not_null_table_from_sample(table_name, data_path):
 
 
 def create_table_from_sample(table_name, data_path):
+    ensure_remote_access(data_path)
     duckdb.sql(f"DROP TABLE IF EXISTS {quote_ident(table_name)}")
     duckdb.sql(f"CREATE TABLE {quote_ident(table_name)} AS SELECT * FROM '{data_path}/*.parquet' LIMIT 10;")
 

--- a/benchmark_data_tools/generate_table_schemas.py
+++ b/benchmark_data_tools/generate_table_schemas.py
@@ -9,18 +9,40 @@ import duckdb
 import duckdb_utils as duck
 
 
-def generate_table_schemas(benchmark_type, schemas_dir_path, data_dir_name, verbose):
+def _sample_table(benchmark_type, table_name, data_path):
+    """Load a small sample of a table's Parquet into DuckDB so its schema can be read
+    back via DESCRIBE. ``data_path`` may be a local directory or a remote (e.g. s3://)
+    prefix."""
+    if benchmark_type == "tpch":
+        # For tpch we use the optional NOT NULL qualifier on all columns.
+        duck.create_not_null_table_from_sample(table_name, data_path)
+    else:
+        duck.create_table_from_sample(table_name, data_path)
+
+
+def generate_table_schemas(
+    benchmark_type,
+    schemas_dir_path,
+    data_dir_name=None,
+    verbose=False,
+    external_location_base=None,
+    table_names=None,
+):
     tables = duckdb.sql("SHOW TABLES").fetchall()
     assert len(tables) == 0
 
-    for file in os.listdir(data_dir_name):
-        sub_dir = os.path.join(data_dir_name, file)
-        if os.path.isdir(sub_dir):
-            if benchmark_type == "tpch":
-                # For tpch we use the optional NOT NULL qualifier on all columns.
-                duck.create_not_null_table_from_sample(os.path.basename(file), sub_dir)
-            else:
-                duck.create_table_from_sample(os.path.basename(file), sub_dir)
+    if external_location_base:
+        # Derive the schema from the Parquet that actually lives at the external
+        # location. A remote prefix cannot be listed, so the table names are supplied
+        # by the caller.
+        base = external_location_base.rstrip("/")
+        for table_name in table_names:
+            _sample_table(benchmark_type, table_name, f"{base}/{table_name}")
+    else:
+        for file in os.listdir(data_dir_name):
+            sub_dir = os.path.join(data_dir_name, file)
+            if os.path.isdir(sub_dir):
+                _sample_table(benchmark_type, os.path.basename(file), sub_dir)
 
     Path(schemas_dir_path).mkdir(parents=True, exist_ok=True)
 
@@ -74,12 +96,42 @@ if __name__ == "__main__":
         "-d",
         "--data-dir-name",
         type=str,
-        required=True,
-        help="The name of the directory that contains the benchmark data.",
+        required=False,
+        default=None,
+        help="Path to a local directory that contains the benchmark data (one subdirectory per "
+        "table). Mutually exclusive with --external-location-base.",
+    )
+    parser.add_argument(
+        "--external-location-base",
+        type=str,
+        required=False,
+        default=None,
+        help="URI base whose per-table subdirectories hold the Parquet data (e.g. "
+        "s3://bucket/prefix/scale-1000). The schema is derived from that data instead of a local "
+        "directory. Requires --table-names.",
+    )
+    parser.add_argument(
+        "--table-names",
+        nargs="+",
+        default=None,
+        help="Table names to generate schemas for. Required with --external-location-base since a "
+        "remote prefix cannot be listed.",
     )
     parser.add_argument(
         "-v", "--verbose", action="store_true", required=False, default=False, help="Extra verbose logging"
     )
     args = parser.parse_args()
 
-    generate_table_schemas(args.benchmark_type, args.schemas_dir_path, args.data_dir_name, args.verbose)
+    if bool(args.data_dir_name) == bool(args.external_location_base):
+        parser.error("Provide exactly one of --data-dir-name or --external-location-base")
+    if args.external_location_base and not args.table_names:
+        parser.error("--table-names is required when --external-location-base is set")
+
+    generate_table_schemas(
+        args.benchmark_type,
+        args.schemas_dir_path,
+        data_dir_name=args.data_dir_name,
+        verbose=args.verbose,
+        external_location_base=args.external_location_base,
+        table_names=args.table_names,
+    )

--- a/benchmark_data_tools/generate_table_schemas.py
+++ b/benchmark_data_tools/generate_table_schemas.py
@@ -40,7 +40,7 @@ def get_table_schema(benchmark_type, table_name):
     ]
     columns_text = ",\n".join(columns_ddl_list)
     schema = f"CREATE TABLE hive.{{schema}}.{table_name} (\n{columns_text}\n) \
-WITH (FORMAT = 'PARQUET', EXTERNAL_LOCATION = 'file:{{file_path}}')"
+WITH (FORMAT = 'PARQUET', EXTERNAL_LOCATION = '{{location}}')"
     return schema
 
 

--- a/common/testing/integration_tests/test_utils.py
+++ b/common/testing/integration_tests/test_utils.py
@@ -71,7 +71,10 @@ def write_query_engine_rows(output_dir, result_file_name, rows, columns, query_e
 
 
 def create_duckdb_table(table_name, data_path):
-    create_table(table_name, get_abs_file_path(__file__, data_path))
+    # Only resolve local path
+    if "://" not in data_path:
+        data_path = get_abs_file_path(__file__, data_path)
+    create_table(table_name, data_path)
 
 
 def initialize_output_dir(config, query_engine):

--- a/presto/README.md
+++ b/presto/README.md
@@ -167,6 +167,46 @@ There are two common approaches:
    ```
    This allows you to run benchmarks and tests without regenerating data for each scale factor—simply specify the schema name.
 
+## Remote Data Sources (AWS S3)
+
+Benchmarks and integration tests can run directly against Parquet data stored in S3. Only the Hive metastore needs to stay local.
+
+### Prerequisites
+
+Set up AWS S3 credentials. The AWS region is required.
+
+```bash
+export AWS_DEFAULT_REGION=us-east-2 # region of your bucket (required)
+eval "$(aws configure export-credentials --format env)" # AWS_ACCESS_KEY_ID / SECRET / SESSION_TOKEN
+```
+
+### Workflow
+
+1. Start Presto (GPU is shown. CPU works too):
+   ```bash
+   cd velox-testing/presto/scripts
+   ./start_native_gpu_presto.sh
+   ```
+
+2. Register the external tables at the S3 location:
+   ```bash
+   ./register_external_tables.sh --help  # See all options
+   ./register_external_tables.sh -b tpch -s tpch_sf100_s3 -l s3://my-bucket/velox/sf100
+   ```
+
+3. Run ANALYZE on CPU Presto:
+   ```bash
+   ./analyze_tables.sh -s tpch_sf100_s3
+   ```
+
+4. Run benchmarks or integration tests against the schema:
+   ```bash
+   ./run_benchmark.sh  -b tpch -s tpch_sf100_s3
+   ./run_integ_test.sh -b tpch -s tpch_sf100_s3
+   ```
+
+The scale factor is auto-detected from a `metadata.json` at the data location, regardless of local or remote. Any URI scheme accepted by the engine works with `register_external_tables.sh` (e.g. `file:`, `s3://`).
+
 ## Configuration
 
 Configuration files for Presto are managed through a template system in:

--- a/presto/README.md
+++ b/presto/README.md
@@ -123,6 +123,7 @@ pytest tpch_test.py
 ## Directory Structure
 
 - **`docker/`** - Docker Compose configurations and Dockerfiles for different Presto variants
+- **`aws/ec2/`** - Direct EC2 + SSM orchestration for distributed CPU benchmarks
 - **`pbench/`** - Performance benchmarking utilities and TPC-H query definitions
 - **`scripts/`** - Shell scripts for building, deploying, and testing Presto
 - **`testing/`** - Python-based test framework using pytest

--- a/presto/aws/ec2/README.md
+++ b/presto/aws/ec2/README.md
@@ -1,0 +1,283 @@
+# Presto CPU benchmarks on direct EC2
+
+This directory manages an ephemeral Presto cluster with one coordinator-only
+EC2 instance and one native CPU worker per worker EC2 instance. It uses AWS
+Systems Manager (SSM) instead of SSH and keeps all Presto traffic on private
+addresses.
+
+The initial implementation targets TPC-H SF1000 at 1, 2, 8, 16, or 32 workers.
+Worker counts exclude the coordinator.
+
+## Status and source dependency
+
+The S3 benchmark path depends on
+[velox-testing PR 376](https://github.com/rapidsai/velox-testing/pull/376).
+The first qualified source revision is expected to use PR head
+`7a2e66683fd7262d8ad2cb6614a6bac1a14e7afa`. Rebase this work onto `main` after
+that PR merges, then repeat local checks and fresh-fleet 8-worker qualification.
+
+Do not use the broader `pioneer` branch as an implicit configuration bundle.
+Apply experimental settings as explicit, archived overrides.
+
+## What the harness owns
+
+- EC2 launch, inventory, and RunId-scoped termination.
+- SSM bootstrap and command status.
+- Docker image pulls and immutable source checkout.
+- Per-role Presto config generation and a recorded config diff.
+- Coordinator-first startup and exact worker-count registration.
+- Benchmark execution and S3 artifact upload.
+- Host/container telemetry and node artifact collection.
+
+It does not create a VPC, subnet, security group, IAM role, S3 bucket, placement
+group, or benchmark dataset. Those account-level resources are inputs.
+
+## Prerequisites
+
+The control machine needs Python 3.10+ and AWS CLI v2. The EC2 subnet needs
+outbound access or VPC endpoints for SSM, S3, source checkout, and image pulls.
+
+The control identity needs permission to launch, describe, price, tag, and
+terminate EC2 resources; pass the configured instance profile; resolve the AMI
+SSM parameter; and send/read SSM commands. Resolve permissions and prices
+before EC2 launch so access failures do not leave a partial fleet.
+
+The instance profile needs:
+
+- SSM managed-instance permissions;
+- read access to the benchmark data and metastore;
+- write access to the configured results prefix;
+- ECR permissions only when private ECR images are selected.
+
+The security group needs no SSH ingress. Add a self-referencing TCP rule for
+port 8080 so workers can register and exchange data with the coordinator.
+Restrict all rules to the benchmark security group and required egress paths.
+
+Use a same-AZ subnet. A placement group is optional and must be recorded as a
+separate experiment dimension.
+
+## Configuration
+
+Copy the example outside the repository and fill in real values:
+
+```bash
+mkdir -p ~/.config/velox-testing
+cp aws_config.env.example ~/.config/velox-testing/aws-cpu.env
+$EDITOR ~/.config/velox-testing/aws-cpu.env
+```
+
+Do not commit the populated file. Pin coordinator and worker images by digest
+before qualification even if initial smoke tests use tags.
+
+Set `VELOX_TESTING_REPOSITORY` and `VELOX_TESTING_FETCH_REF` to the fork and
+branch containing this harness. Set `VELOX_TESTING_REF` to that branch's exact
+40-character commit SHA. Bootstrap verifies that the fetched ref resolves to
+the expected SHA before checkout.
+
+For a pre-commit smoke test only, `HARNESS_BUNDLE_S3_URI` and
+`HARNESS_BUNDLE_SHA256` may point to an immutable tar overlay containing
+`presto/aws/ec2/`. Bootstrap verifies and extracts it after checking out the
+pinned base commit. The run manifest records both values. Qualification runs
+must use a committed source revision instead.
+
+`m7a.4xlarge` has less memory than `r6i.4xlarge`; use a named worker-memory
+overlay for each family. Keep the coordinator type and coordinator settings
+fixed when comparing worker families.
+
+Leave `AMI_ID` empty to resolve the configured Canonical Ubuntu SSM parameter
+at launch. The resolved AMI and live on-demand Linux prices are written to the
+run manifest.
+
+Mixed-architecture fleets can instead set `COORDINATOR_AMI_SSM_PARAMETER` and
+`WORKER_AMI_SSM_PARAMETER` (or their `_ID` equivalents). Bootstrap selects the
+AWS CLI binary for each host architecture and pulls only the image used by that
+role.
+
+## Local validation and dry run
+
+Validation and dry-run launch do not contact AWS:
+
+```bash
+python3 aws_cluster.py \
+  --config ~/.config/velox-testing/aws-cpu.env \
+  --run-id aws102-dry-run \
+  validate
+
+python3 aws_cluster.py \
+  --config ~/.config/velox-testing/aws-cpu.env \
+  --run-id aws102-dry-run \
+  --workers 8 \
+  --dry-run \
+  launch
+
+python3 -m unittest -v test_aws_cluster.py
+```
+
+Review both generated `run-instances` commands, especially tags, count,
+metadata options, instance types, subnet, security group, role, and placement.
+
+## Fleet workflow
+
+Choose one unique RunId and use it for the full lifecycle:
+
+```bash
+CONFIG=~/.config/velox-testing/aws-cpu.env
+RUN_ID=aws102-m7a8-$(date -u +%Y%m%dT%H%M%SZ)
+
+python3 aws_cluster.py --config "$CONFIG" --run-id "$RUN_ID" --workers 8 launch
+python3 aws_cluster.py --config "$CONFIG" --run-id "$RUN_ID" --workers 8 status
+python3 aws_cluster.py --config "$CONFIG" --run-id "$RUN_ID" --workers 8 bootstrap
+python3 aws_cluster.py --config "$CONFIG" --run-id "$RUN_ID" --workers 8 start
+python3 aws_cluster.py --config "$CONFIG" --run-id "$RUN_ID" --workers 8 run
+python3 aws_cluster.py --config "$CONFIG" --run-id "$RUN_ID" --workers 8 collect
+python3 aws_cluster.py --config "$CONFIG" --run-id "$RUN_ID" --workers 8 stop
+python3 aws_cluster.py --config "$CONFIG" --run-id "$RUN_ID" --workers 8 terminate
+```
+
+`launch` waits for EC2 health and SSM registration. `bootstrap` installs Docker
+and AWS CLI v2, checks out the pinned source revision, pulls images, restores
+the metastore, and probes IMDSv2 credentials. `start` generates configs on each
+role, starts the coordinator first, then starts workers and waits for exactly N
+workers.
+
+All mutating commands select or tag resources with the exact RunId. `launch`
+uses separate idempotency tokens for coordinator and worker requests.
+Destructive inventory also includes the Owner tag to prevent a RunId collision
+from crossing users.
+
+`SSM_COMMAND_TIMEOUT_SECONDS` applies to both the remote document and the local
+poller. Its default is six hours, which avoids SSM's one-hour default while
+still bounding a hung benchmark.
+
+Always run `collect` before `terminate`, including after failed benchmarks.
+Collection accepts a partial fleet and gathers every still-running node.
+Instances carry an expiry tag and an OS shutdown behavior, but neither replaces
+explicit teardown and billing verification.
+
+List expired AWS 102 instances without mutating them:
+
+```bash
+python3 aws_cluster.py \
+  --config "$CONFIG" --run-id ignored-for-listing list-stale
+```
+
+## Correctness smoke
+
+The first cloud sequence is one coordinator plus one `m7a.4xlarge` worker:
+
+```bash
+python3 aws_cluster.py \
+  --config "$CONFIG" --run-id "$RUN_ID" --workers 1 \
+  run --queries 6,18 --iterations 1 --tag c1_q6_q18
+```
+
+Then use two workers for one full Q1-Q22 pass before allocating eight workers.
+
+The current benchmark runner collects query and task metrics. Provide expected
+result files through the normal `velox-testing` benchmark configuration when
+semantic validation artifacts are required for qualification.
+
+## Baseline timing
+
+For cache-off AWS 101-compatible timing, run five query-major iterations. Treat
+iteration 1 as warm-up. For every query, average iterations 2-5, then sum the 22
+means. Provisioning, startup, registration, and warm-up are excluded from that
+primary runtime and must be reported separately.
+
+The harness archives raw output; top-line reduction should happen in the
+experiment repository so rejected runs and the reduction rule remain visible.
+Use `summarize_results.py --baseline <benchmark_result.json>` to apply the
+one-warm-up/four-measured rule without relying on the runner's aggregate field.
+
+For repeated data-cold suites with cache off, drop host page caches before each
+single-iteration Q1-Q22 pass:
+
+```bash
+python3 aws_cluster.py \
+  --config "$CONFIG" --run-id "$RUN_ID" --workers 8 \
+  run-cold-series --repetitions 3 --tag-prefix sf1k
+```
+
+This preserves the Presto processes and worker membership while issuing
+`sync` and dropping Linux page cache on every coordinator and worker before
+each pass. Each repetition has a separate result tag.
+
+## Controlled CPU tuning
+
+The environment file exposes the generated CPU override as explicit controls:
+
+- `TASK_MAX_DRIVERS_PER_TASK`;
+- `HIVE_MAX_SPLIT_SIZE`;
+- `HIVE_SPLIT_LOADER_CONCURRENCY`;
+- `DYNAMIC_FILTERING_ENABLED`;
+- `CPU_EXCHANGE_TUNING_ENABLED`.
+
+The example values reproduce the normal generated CPU configuration. Change
+one value at a time, rerun `start` to generate and archive the candidate
+configuration, then use `run-cold-series` with a diagnostic query list. Setting
+`CPU_EXCHANGE_TUNING_ENABLED=false` removes the generated CPU exchange
+properties so the native worker uses its defaults.
+
+## Async data cache
+
+Do not compare cache-on and cache-off results as the same workload.
+
+For cache-on qualification, use a fresh fleet and an explicit cache capacity.
+Run one complete Q1-Q22 suite with one iteration per query as cold fill. Without
+clearing, restarting, or changing the worker session, run four more complete
+one-iteration suites. Average each query across those four warm suites and sum
+the query means.
+
+Do not use `--iterations 5` for this cache-on sequence because that produces
+query-major order rather than suite-major order. Give each pass a unique tag,
+and preserve one uninterrupted cluster session.
+
+The harness encodes that sequence:
+
+```bash
+python3 aws_cluster.py \
+  --config "$CONFIG" --run-id "$RUN_ID" --workers 8 \
+  run-cache-series --tag-prefix sf1k_cache
+```
+
+It requires `ASYNC_DATA_CACHE_ENABLED=true`, runs one cold-fill suite followed
+by four warm suites, and rejects a run if worker membership changes.
+Pass the five resulting `benchmark_result.json` files to
+`summarize_results.py --cache-series` in cold, warm-1, warm-2, warm-3, warm-4
+order.
+
+## Generated state and artifacts
+
+Local mutable state defaults to:
+
+```text
+~/.cache/velox-testing/aws-ec2/<RunId>/
+```
+
+It contains the launch manifest and SSM command IDs. It is intentionally
+outside the repository.
+
+Remote state is under `/opt/presto-aws`. Collection uploads:
+
+- generated base and final configs plus their diff and hashes;
+- Presto and container logs;
+- worker-registration response;
+- host and container telemetry;
+- CPU, memory, filesystem, network, Docker, kernel, and journal snapshots;
+- benchmark raw output and detailed Presto/Velox metrics.
+
+SSM command output also goes to the run-specific S3 prefix when
+`RESULTS_S3_ROOT` is configured.
+
+## Failure handling
+
+- A benchmark never starts unless exactly N workers register.
+- SSM failures identify the command and instance.
+- Config patching requires exactly one occurrence of each expected property.
+- A failed benchmark still attempts to sync partial results.
+- `terminate` describes resources by the exact Project, Experiment, and RunId
+  tags; it does not read a broad local instance list.
+
+If coordinator sizing must change during 16/32-worker work, restart the scaling
+series at eight workers. Only required-worker count and aggregate coordinator
+query limits should vary mechanically with N.

--- a/presto/aws/ec2/aws_cluster.py
+++ b/presto/aws/ec2/aws_cluster.py
@@ -1,0 +1,1069 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Manage an ephemeral Presto CPU benchmark fleet on direct EC2 instances."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import shlex
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+PROJECT_TAG = "cudf-performance"
+EXPERIMENT_TAG = "20260824_aws_102"
+DEFAULT_STATE_ROOT = Path.home() / ".cache" / "velox-testing" / "aws-ec2"
+
+
+class ClusterError(RuntimeError):
+    """A user-actionable cluster orchestration failure."""
+
+
+def load_env(path: Path) -> dict[str, str]:
+    values: dict[str, str] = {}
+    for line_number, raw_line in enumerate(path.read_text().splitlines(), 1):
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if "=" not in line:
+            raise ClusterError(f"{path}:{line_number}: expected KEY=VALUE")
+        key, value = line.split("=", 1)
+        key = key.strip()
+        value = value.strip()
+        if not key.replace("_", "").isalnum() or not key[0].isalpha():
+            raise ClusterError(f"{path}:{line_number}: invalid key {key!r}")
+        if len(value) >= 2 and value[0] == value[-1] and value[0] in "'\"":
+            value = value[1:-1]
+        values[key] = value
+    return values
+
+
+def require(config: dict[str, str], *keys: str) -> None:
+    missing = [key for key in keys if not config.get(key)]
+    if missing:
+        raise ClusterError(f"missing required configuration: {', '.join(missing)}")
+
+
+def positive_int(config: dict[str, str], key: str) -> int:
+    try:
+        value = int(config[key])
+    except (KeyError, ValueError) as error:
+        raise ClusterError(f"{key} must be an integer") from error
+    if value <= 0:
+        raise ClusterError(f"{key} must be greater than zero")
+    return value
+
+
+def nonnegative_int(config: dict[str, str], key: str) -> int:
+    try:
+        value = int(config[key])
+    except (KeyError, ValueError) as error:
+        raise ClusterError(f"{key} must be an integer") from error
+    if value < 0:
+        raise ClusterError(f"{key} must be greater than or equal to zero")
+    return value
+
+
+def utc_now() -> dt.datetime:
+    return dt.datetime.now(dt.timezone.utc)
+
+
+def shell_join(parts: list[str]) -> str:
+    return shlex.join(parts)
+
+
+@dataclass
+class Instance:
+    instance_id: str
+    role: str
+    state: str
+    private_ip: str
+    private_dns: str
+    instance_type: str
+    launch_time: str
+
+
+class Aws:
+    def __init__(self, config: dict[str, str], dry_run: bool = False):
+        self.config = config
+        self.dry_run = dry_run
+
+    def base(self, region: str | None = None) -> list[str]:
+        command = ["aws"]
+        if self.config.get("AWS_PROFILE"):
+            command += ["--profile", self.config["AWS_PROFILE"]]
+        command += ["--region", region or self.config["AWS_REGION"]]
+        return command
+
+    def run(
+        self,
+        service_args: list[str],
+        *,
+        json_output: bool = False,
+        allow_dry_run: bool = True,
+        region: str | None = None,
+    ) -> Any:
+        command = self.base(region=region) + service_args
+        if self.dry_run and allow_dry_run:
+            print(f"DRY-RUN {shell_join(command)}")
+            return {} if json_output else ""
+        if json_output:
+            command += ["--output", "json"]
+        completed = subprocess.run(
+            command,
+            check=False,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        if completed.returncode:
+            detail = completed.stderr.strip() or completed.stdout.strip()
+            raise ClusterError(f"command failed: {shell_join(command)}\n{detail}")
+        if json_output:
+            return json.loads(completed.stdout or "{}")
+        return completed.stdout
+
+
+class Cluster:
+    def __init__(
+        self,
+        config: dict[str, str],
+        run_id: str,
+        workers: int,
+        state_root: Path,
+        dry_run: bool,
+    ):
+        self.config = config
+        self.run_id = run_id
+        self.workers = workers
+        self.state_dir = state_root / run_id
+        self.aws = Aws(config, dry_run=dry_run)
+        self.dry_run = dry_run
+
+    def validate(self, cloud: bool = True) -> None:
+        require(
+            self.config,
+            "AWS_REGION",
+            "COORDINATOR_INSTANCE_TYPE",
+            "WORKER_INSTANCE_TYPE",
+            "VELOX_TESTING_REPOSITORY",
+            "VELOX_TESTING_FETCH_REF",
+            "VELOX_TESTING_REF",
+            "COORDINATOR_IMAGE",
+            "WORKER_IMAGE",
+            "HIVE_METASTORE_S3_URI",
+            "SCHEMA_NAME",
+            "OWNER",
+            "HIVE_MAX_SPLIT_SIZE",
+            "DYNAMIC_FILTERING_ENABLED",
+            "CPU_EXCHANGE_TUNING_ENABLED",
+            "ASYNC_CACHE_SSD_GIB",
+            "ASYNC_CACHE_NUM_SHARDS",
+        )
+        if cloud:
+            require(
+                self.config,
+                "SUBNET_ID",
+                "SECURITY_GROUP_ID",
+                "IAM_INSTANCE_PROFILE",
+            )
+            generic_ami = self.config.get("AMI_ID") or self.config.get("AMI_SSM_PARAMETER")
+            coordinator_ami = self.config.get("COORDINATOR_AMI_ID") or self.config.get(
+                "COORDINATOR_AMI_SSM_PARAMETER"
+            )
+            worker_ami = self.config.get("WORKER_AMI_ID") or self.config.get(
+                "WORKER_AMI_SSM_PARAMETER"
+            )
+            if not generic_ami and not (coordinator_ami and worker_ami):
+                raise ClusterError(
+                    "set AMI_ID/AMI_SSM_PARAMETER or role-specific coordinator and worker AMIs"
+                )
+        for key in (
+            "ROOT_VOLUME_GIB",
+            "EXPIRY_HOURS",
+            "SSM_READY_TIMEOUT_SECONDS",
+            "SSM_COMMAND_TIMEOUT_SECONDS",
+            "WORKER_READY_TIMEOUT_SECONDS",
+            "VCPU_PER_WORKER",
+            "TASK_MAX_DRIVERS_PER_TASK",
+            "HIVE_SPLIT_LOADER_CONCURRENCY",
+            "COORDINATOR_HEAP_GIB",
+            "COORDINATOR_HEADROOM_GIB",
+            "COORDINATOR_QUERY_TOTAL_MEMORY_PER_NODE_GIB",
+            "COORDINATOR_QUERY_MEMORY_PER_NODE_GIB",
+            "WORKER_SYSTEM_MEMORY_GIB",
+            "WORKER_QUERY_MEMORY_GIB",
+            "WORKER_MEMORY_LIMIT_GIB",
+            "WORKER_MEMORY_SHRINK_GIB",
+        ):
+            positive_int(self.config, key)
+        if self.workers not in (1, 2, 8, 16, 32):
+            raise ClusterError("worker count must be one of: 1, 2, 8, 16, 32")
+        if not self.run_id.replace("-", "").replace("_", "").isalnum():
+            raise ClusterError("RunId may contain only letters, digits, '-' and '_'")
+        source_ref = self.config["VELOX_TESTING_REF"]
+        if len(source_ref) != 40 or any(character not in "0123456789abcdefABCDEF" for character in source_ref):
+            raise ClusterError("VELOX_TESTING_REF must be a full 40-character commit SHA")
+        bundle_uri = self.config.get("HARNESS_BUNDLE_S3_URI", "")
+        bundle_sha = self.config.get("HARNESS_BUNDLE_SHA256", "")
+        if bool(bundle_uri) != bool(bundle_sha):
+            raise ClusterError("set both HARNESS_BUNDLE_S3_URI and HARNESS_BUNDLE_SHA256, or neither")
+        if bundle_sha and (
+            len(bundle_sha) != 64 or any(character not in "0123456789abcdefABCDEF" for character in bundle_sha)
+        ):
+            raise ClusterError("HARNESS_BUNDLE_SHA256 must contain 64 hexadecimal characters")
+        if self.config["ASYNC_DATA_CACHE_ENABLED"] not in ("true", "false"):
+            raise ClusterError("ASYNC_DATA_CACHE_ENABLED must be true or false")
+        for key in ("DYNAMIC_FILTERING_ENABLED", "CPU_EXCHANGE_TUNING_ENABLED"):
+            if self.config[key] not in ("true", "false"):
+                raise ClusterError(f"{key} must be true or false")
+        split_size = self.config["HIVE_MAX_SPLIT_SIZE"]
+        if not split_size.endswith("MB") or not split_size[:-2].isdigit():
+            raise ClusterError("HIVE_MAX_SPLIT_SIZE must be an integer number of MB")
+        if int(split_size[:-2]) <= 0:
+            raise ClusterError("HIVE_MAX_SPLIT_SIZE must be greater than zero")
+        ssd_gib = nonnegative_int(self.config, "ASYNC_CACHE_SSD_GIB")
+        positive_int(self.config, "ASYNC_CACHE_NUM_SHARDS")
+        if ssd_gib and not self.config.get("ASYNC_CACHE_SSD_PATH"):
+            raise ClusterError("ASYNC_CACHE_SSD_PATH is required when ASYNC_CACHE_SSD_GIB is nonzero")
+        if ssd_gib and not self.config["ASYNC_CACHE_SSD_PATH"].startswith("/mnt/nvme/"):
+            raise ClusterError("ASYNC_CACHE_SSD_PATH must be under /mnt/nvme/")
+        if positive_int(self.config, "WORKER_QUERY_MEMORY_GIB") >= positive_int(
+            self.config, "WORKER_SYSTEM_MEMORY_GIB"
+        ):
+            raise ClusterError("WORKER_QUERY_MEMORY_GIB must be less than WORKER_SYSTEM_MEMORY_GIB")
+        if positive_int(self.config, "COORDINATOR_QUERY_MEMORY_PER_NODE_GIB") >= positive_int(
+            self.config, "COORDINATOR_QUERY_TOTAL_MEMORY_PER_NODE_GIB"
+        ):
+            raise ClusterError(
+                "COORDINATOR_QUERY_MEMORY_PER_NODE_GIB must be less than COORDINATOR_QUERY_TOTAL_MEMORY_PER_NODE_GIB"
+            )
+        coordinator_required_heap = positive_int(
+            self.config, "COORDINATOR_QUERY_TOTAL_MEMORY_PER_NODE_GIB"
+        ) + positive_int(self.config, "COORDINATOR_HEADROOM_GIB")
+        if coordinator_required_heap > positive_int(self.config, "COORDINATOR_HEAP_GIB"):
+            raise ClusterError(
+                "COORDINATOR_HEAP_GIB must be at least "
+                "COORDINATOR_QUERY_TOTAL_MEMORY_PER_NODE_GIB + COORDINATOR_HEADROOM_GIB"
+            )
+
+    def tags(self, role: str, expiry: str) -> list[dict[str, str]]:
+        return [
+            {"Key": "Name", "Value": f"presto-cpu-{role}-{self.run_id}"},
+            {"Key": "Project", "Value": PROJECT_TAG},
+            {"Key": "Experiment", "Value": EXPERIMENT_TAG},
+            {"Key": "RunId", "Value": self.run_id},
+            {"Key": "Role", "Value": role},
+            {"Key": "Owner", "Value": self.config["OWNER"]},
+            {"Key": "ExpiresAt", "Value": expiry},
+        ]
+
+    def resolve_ami(self, role: str) -> str:
+        role_prefix = role.upper()
+        ami_id = self.config.get(f"{role_prefix}_AMI_ID") or self.config.get("AMI_ID")
+        if ami_id:
+            return ami_id
+        parameter = self.config.get(f"{role_prefix}_AMI_SSM_PARAMETER") or self.config.get(
+            "AMI_SSM_PARAMETER"
+        )
+        if not parameter:
+            raise ClusterError(f"no AMI configured for {role}")
+        response = self.aws.run(
+            [
+                "ssm",
+                "get-parameter",
+                "--name",
+                parameter,
+            ],
+            json_output=True,
+        )
+        return "ami-dry-run" if self.dry_run else response["Parameter"]["Value"]
+
+    def resolve_hourly_price(self, instance_type: str) -> float | None:
+        filters = [
+            {"Type": "TERM_MATCH", "Field": "instanceType", "Value": instance_type},
+            {
+                "Type": "TERM_MATCH",
+                "Field": "regionCode",
+                "Value": self.config["AWS_REGION"],
+            },
+            {"Type": "TERM_MATCH", "Field": "operatingSystem", "Value": "Linux"},
+            {"Type": "TERM_MATCH", "Field": "tenancy", "Value": "Shared"},
+            {"Type": "TERM_MATCH", "Field": "preInstalledSw", "Value": "NA"},
+            {"Type": "TERM_MATCH", "Field": "capacitystatus", "Value": "Used"},
+        ]
+        response = self.aws.run(
+            [
+                "pricing",
+                "get-products",
+                "--service-code",
+                "AmazonEC2",
+                "--filters",
+                json.dumps(filters, separators=(",", ":")),
+                "--max-results",
+                "100",
+            ],
+            json_output=True,
+            region="us-east-1",
+        )
+        if self.dry_run:
+            return None
+        prices: set[float] = set()
+        for encoded_product in response.get("PriceList", []):
+            product = json.loads(encoded_product)
+            for term in product.get("terms", {}).get("OnDemand", {}).values():
+                for dimension in term.get("priceDimensions", {}).values():
+                    usd = dimension.get("pricePerUnit", {}).get("USD")
+                    if usd is not None:
+                        prices.add(float(usd))
+        nonzero = sorted(price for price in prices if price > 0)
+        if len(nonzero) != 1:
+            raise ClusterError(
+                f"expected one on-demand Linux price for {instance_type} in "
+                f"{self.config['AWS_REGION']}; found {nonzero}"
+            )
+        return nonzero[0]
+
+    def launch_role(self, role: str, count: int, expiry: str, ami_id: str) -> list[str]:
+        instance_type = self.config["COORDINATOR_INSTANCE_TYPE" if role == "coordinator" else "WORKER_INSTANCE_TYPE"]
+        mappings = [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "VolumeSize": positive_int(self.config, "ROOT_VOLUME_GIB"),
+                    "VolumeType": "gp3",
+                    "DeleteOnTermination": True,
+                },
+            }
+        ]
+        tag_specifications = [
+            {"ResourceType": "instance", "Tags": self.tags(role, expiry)},
+            {"ResourceType": "volume", "Tags": self.tags(role, expiry)},
+        ]
+        args = [
+            "ec2",
+            "run-instances",
+            "--image-id",
+            ami_id,
+            "--instance-type",
+            instance_type,
+            "--count",
+            str(count),
+            "--subnet-id",
+            self.config["SUBNET_ID"],
+            "--security-group-ids",
+            self.config["SECURITY_GROUP_ID"],
+            "--iam-instance-profile",
+            f"Name={self.config['IAM_INSTANCE_PROFILE']}",
+            "--metadata-options",
+            "HttpTokens=required,HttpEndpoint=enabled,HttpPutResponseHopLimit=2",
+            "--block-device-mappings",
+            json.dumps(mappings, separators=(",", ":")),
+            "--instance-initiated-shutdown-behavior",
+            "terminate",
+            "--user-data",
+            (f"#!/usr/bin/env bash\nshutdown -h +{positive_int(self.config, 'EXPIRY_HOURS') * 60}\n"),
+            "--client-token",
+            f"{self.run_id}-{role}",
+            "--tag-specifications",
+            json.dumps(tag_specifications, separators=(",", ":")),
+        ]
+        if self.config.get("PLACEMENT_GROUP"):
+            args += ["--placement", f"GroupName={self.config['PLACEMENT_GROUP']}"]
+        response = self.aws.run(args, json_output=True)
+        if self.dry_run:
+            return []
+        return [item["InstanceId"] for item in response["Instances"]]
+
+    def launch(self) -> None:
+        self.validate(cloud=True)
+        expiry = (utc_now() + dt.timedelta(hours=positive_int(self.config, "EXPIRY_HOURS"))).isoformat()
+        coordinator_ami_id = self.resolve_ami("coordinator")
+        worker_ami_id = self.resolve_ami("worker")
+        coordinator_price = self.resolve_hourly_price(self.config["COORDINATOR_INSTANCE_TYPE"])
+        worker_price = self.resolve_hourly_price(self.config["WORKER_INSTANCE_TYPE"])
+        coordinator_ids: list[str] = []
+        worker_ids: list[str] = []
+        try:
+            coordinator_ids = self.launch_role("coordinator", 1, expiry, coordinator_ami_id)
+            worker_ids = self.launch_role("worker", self.workers, expiry, worker_ami_id)
+            if self.dry_run:
+                return
+            instance_ids = coordinator_ids + worker_ids
+            self.aws.run(["ec2", "wait", "instance-running", "--instance-ids", *instance_ids])
+            self.aws.run(["ec2", "wait", "instance-status-ok", "--instance-ids", *instance_ids])
+            self.write_manifest(
+                {
+                    "run_id": self.run_id,
+                    "created_at": utc_now().isoformat(),
+                    "expires_at": expiry,
+                    "worker_count": self.workers,
+                    "coordinator_ami_id": coordinator_ami_id,
+                    "worker_ami_id": worker_ami_id,
+                    "coordinator_instance_ids": coordinator_ids,
+                    "worker_instance_ids": worker_ids,
+                    "coordinator_hourly_price_usd": coordinator_price,
+                    "worker_hourly_price_usd": worker_price,
+                    "source_ref": self.config["VELOX_TESTING_REF"],
+                    "coordinator_image": self.config["COORDINATOR_IMAGE"],
+                    "worker_image": self.config["WORKER_IMAGE"],
+                    "harness_bundle_s3_uri": self.config.get("HARNESS_BUNDLE_S3_URI", ""),
+                    "harness_bundle_sha256": self.config.get("HARNESS_BUNDLE_SHA256", ""),
+                    "async_data_cache": self.config["ASYNC_DATA_CACHE_ENABLED"] == "true",
+                }
+            )
+            self.wait_for_ssm(instance_ids)
+            print(json.dumps(self.inventory_json(), indent=2))
+        except (ClusterError, OSError):
+            if not self.dry_run:
+                try:
+                    self.terminate()
+                except (ClusterError, OSError) as cleanup_error:
+                    print(
+                        f"warning: launch rollback failed: {cleanup_error}",
+                        file=sys.stderr,
+                    )
+            raise
+
+    def inventory_json(self) -> list[dict[str, str]]:
+        return [item.__dict__ for item in self.inventory()]
+
+    def inventory(self) -> list[Instance]:
+        response = self.aws.run(
+            [
+                "ec2",
+                "describe-instances",
+                "--filters",
+                f"Name=tag:Project,Values={PROJECT_TAG}",
+                f"Name=tag:Experiment,Values={EXPERIMENT_TAG}",
+                f"Name=tag:RunId,Values={self.run_id}",
+                f"Name=tag:Owner,Values={self.config['OWNER']}",
+                "Name=instance-state-name,Values=pending,running,stopping,stopped",
+            ],
+            json_output=True,
+            allow_dry_run=False,
+        )
+        instances: list[Instance] = []
+        for reservation in response.get("Reservations", []):
+            for raw in reservation.get("Instances", []):
+                tags = {tag["Key"]: tag["Value"] for tag in raw.get("Tags", [])}
+                instances.append(
+                    Instance(
+                        instance_id=raw["InstanceId"],
+                        role=tags.get("Role", "unknown"),
+                        state=raw["State"]["Name"],
+                        private_ip=raw.get("PrivateIpAddress", ""),
+                        private_dns=raw.get("PrivateDnsName", ""),
+                        instance_type=raw["InstanceType"],
+                        launch_time=str(raw["LaunchTime"]),
+                    )
+                )
+        return sorted(instances, key=lambda item: (item.role, item.instance_id))
+
+    def expected_inventory(self) -> tuple[Instance, list[Instance]]:
+        items = self.inventory()
+        coordinators = [item for item in items if item.role == "coordinator"]
+        workers = [item for item in items if item.role == "worker"]
+        if len(coordinators) != 1 or len(workers) != self.workers:
+            raise ClusterError(
+                f"RunId {self.run_id}: expected 1 coordinator and {self.workers} "
+                f"workers; found {len(coordinators)} and {len(workers)}"
+            )
+        non_running = [item.instance_id for item in items if item.state != "running"]
+        if non_running:
+            raise ClusterError(f"instances are not running: {', '.join(non_running)}")
+        return coordinators[0], workers
+
+    def wait_for_ssm(self, instance_ids: list[str]) -> None:
+        deadline = time.monotonic() + positive_int(self.config, "SSM_READY_TIMEOUT_SECONDS")
+        while time.monotonic() < deadline:
+            response = self.aws.run(
+                [
+                    "ssm",
+                    "describe-instance-information",
+                    "--filters",
+                    "Key=InstanceIds,Values=" + ",".join(instance_ids),
+                ],
+                json_output=True,
+            )
+            online = {
+                item["InstanceId"]
+                for item in response.get("InstanceInformationList", [])
+                if item.get("PingStatus") == "Online"
+            }
+            if online == set(instance_ids):
+                return
+            time.sleep(10)
+        missing = sorted(set(instance_ids) - online)
+        raise ClusterError(f"instances did not become SSM Online: {', '.join(missing)}")
+
+    def send_command(
+        self,
+        instance_ids: list[str],
+        commands: list[str],
+        comment: str,
+        *,
+        wait: bool = True,
+    ) -> str:
+        execution_timeout = positive_int(self.config, "SSM_COMMAND_TIMEOUT_SECONDS")
+        parameters = json.dumps(
+            {
+                "commands": commands,
+                "executionTimeout": [str(execution_timeout)],
+            },
+            separators=(",", ":"),
+        )
+        args = [
+            "ssm",
+            "send-command",
+            "--document-name",
+            "AWS-RunShellScript",
+            "--instance-ids",
+            *instance_ids,
+            "--comment",
+            comment[:100],
+            "--parameters",
+            parameters,
+        ]
+        if self.config.get("RESULTS_S3_ROOT"):
+            parsed = self.config["RESULTS_S3_ROOT"].removeprefix("s3://")
+            bucket, _, prefix = parsed.partition("/")
+            args += ["--output-s3-bucket-name", bucket]
+            if prefix:
+                args += [
+                    "--output-s3-key-prefix",
+                    f"{prefix.rstrip('/')}/{self.run_id}/ssm",
+                ]
+        response = self.aws.run(args, json_output=True)
+        if self.dry_run:
+            return "dry-run-command"
+        command_id = response["Command"]["CommandId"]
+        if wait:
+            for instance_id in instance_ids:
+                self.wait_for_command(
+                    command_id,
+                    instance_id,
+                    timeout_seconds=execution_timeout + 300,
+                )
+        return command_id
+
+    def wait_for_command(self, command_id: str, instance_id: str, timeout_seconds: int) -> None:
+        deadline = time.monotonic() + timeout_seconds
+        terminal = {"Success", "Cancelled", "TimedOut", "Failed", "Cancelling"}
+        while time.monotonic() < deadline:
+            response = self.aws.run(
+                [
+                    "ssm",
+                    "list-command-invocations",
+                    "--command-id",
+                    command_id,
+                    "--instance-id",
+                    instance_id,
+                    "--details",
+                ],
+                json_output=True,
+            )
+            invocations = response.get("CommandInvocations", [])
+            if not invocations:
+                time.sleep(5)
+                continue
+            status = invocations[0].get("Status", "")
+            if status not in terminal:
+                time.sleep(5)
+                continue
+            if status == "Success":
+                return
+            invocation = self.aws.run(
+                [
+                    "ssm",
+                    "get-command-invocation",
+                    "--command-id",
+                    command_id,
+                    "--instance-id",
+                    instance_id,
+                ],
+                json_output=True,
+            )
+            raise ClusterError(
+                f"SSM command {command_id} ended as {status} on {instance_id}: "
+                f"{invocation.get('StandardErrorContent', '').strip()}"
+            )
+        raise ClusterError(
+            f"timed out waiting {timeout_seconds}s for SSM command {command_id} "
+            f"on {instance_id}; the remote command may still be running"
+        )
+
+    def bootstrap(self) -> None:
+        self.validate(cloud=True)
+        coordinator, workers = self.expected_inventory()
+        repository = shlex.quote(self.config["VELOX_TESTING_REPOSITORY"])
+        fetch_ref = shlex.quote(self.config["VELOX_TESTING_FETCH_REF"])
+        ref = shlex.quote(self.config["VELOX_TESTING_REF"])
+        commands = [
+            "set -eu",
+            "export DEBIAN_FRONTEND=noninteractive",
+            "apt-get update -y",
+            ("apt-get install -y ca-certificates curl docker.io git jq numactl python3 python3-venv unzip"),
+            "systemctl enable --now docker",
+            (
+                "if ! command -v aws >/dev/null; then "
+                "case \"$(uname -m)\" in "
+                "x86_64) aws_arch=x86_64 ;; "
+                "aarch64|arm64) aws_arch=aarch64 ;; "
+                "*) echo 'unsupported architecture for AWS CLI' >&2; exit 1 ;; "
+                "esac; "
+                "curl -fsSLo /tmp/awscliv2.zip "
+                "\"https://awscli.amazonaws.com/awscli-exe-linux-${aws_arch}.zip\"; "
+                "rm -rf /tmp/aws; unzip -q /tmp/awscliv2.zip -d /tmp; "
+                "/tmp/aws/install; fi"
+            ),
+            "rm -rf /opt/velox-testing",
+            f"git clone --filter=blob:none {repository} /opt/velox-testing",
+            f"git -C /opt/velox-testing fetch origin {fetch_ref}",
+            (f'test "$(git -C /opt/velox-testing rev-parse FETCH_HEAD)" = {ref}'),
+            f"git -C /opt/velox-testing checkout --detach {ref}",
+        ]
+        if self.config.get("HARNESS_BUNDLE_S3_URI"):
+            bundle_uri = shlex.quote(self.config["HARNESS_BUNDLE_S3_URI"])
+            bundle_sha = shlex.quote(self.config["HARNESS_BUNDLE_SHA256"])
+            commands += [
+                f"aws s3 cp {bundle_uri} /tmp/presto-aws-harness.tar.gz --only-show-errors",
+                (f"echo '{bundle_sha}  /tmp/presto-aws-harness.tar.gz' | sha256sum --check --strict"),
+                "tar -xzf /tmp/presto-aws-harness.tar.gz -C /opt/velox-testing",
+            ]
+        bootstrap_prefix = (
+            "bash /opt/velox-testing/presto/aws/ec2/remote/bootstrap_node.sh "
+        )
+        bootstrap_suffix = (
+            shlex.quote(self.config["COORDINATOR_IMAGE"])
+            + " "
+            + shlex.quote(self.config["WORKER_IMAGE"])
+            + " "
+            + shlex.quote(self.config["HIVE_METASTORE_S3_URI"])
+        )
+        coordinator_command_id = self.send_command(
+            [coordinator.instance_id],
+            [*commands, f"{bootstrap_prefix}coordinator {bootstrap_suffix}"],
+            f"bootstrap coordinator {self.run_id}",
+        )
+        self.record_command("bootstrap_coordinator", coordinator_command_id)
+        worker_command_id = self.send_command(
+            [item.instance_id for item in workers],
+            [*commands, f"{bootstrap_prefix}worker {bootstrap_suffix}"],
+            f"bootstrap workers {self.run_id}",
+        )
+        self.record_command("bootstrap_workers", worker_command_id)
+
+    def remote_env(self, coordinator_address: str, role: str, worker_index: int | None = None) -> str:
+        values = {
+            "RUN_ID": self.run_id,
+            "ROLE": role,
+            "WORKER_COUNT": str(self.workers),
+            "WORKER_INDEX": "" if worker_index is None else str(worker_index),
+            "COORDINATOR_ADDRESS": coordinator_address,
+            "AWS_REGION": self.config["AWS_REGION"],
+            "VCPU_PER_WORKER": self.config["VCPU_PER_WORKER"],
+            "TASK_MAX_DRIVERS_PER_TASK": self.config["TASK_MAX_DRIVERS_PER_TASK"],
+            "HIVE_MAX_SPLIT_SIZE": self.config["HIVE_MAX_SPLIT_SIZE"],
+            "HIVE_SPLIT_LOADER_CONCURRENCY": self.config[
+                "HIVE_SPLIT_LOADER_CONCURRENCY"
+            ],
+            "DYNAMIC_FILTERING_ENABLED": self.config["DYNAMIC_FILTERING_ENABLED"],
+            "CPU_EXCHANGE_TUNING_ENABLED": self.config[
+                "CPU_EXCHANGE_TUNING_ENABLED"
+            ],
+            "COORDINATOR_HEAP_GIB": self.config["COORDINATOR_HEAP_GIB"],
+            "COORDINATOR_HEADROOM_GIB": self.config["COORDINATOR_HEADROOM_GIB"],
+            "COORDINATOR_QUERY_TOTAL_MEMORY_PER_NODE_GIB": self.config["COORDINATOR_QUERY_TOTAL_MEMORY_PER_NODE_GIB"],
+            "COORDINATOR_QUERY_MEMORY_PER_NODE_GIB": self.config["COORDINATOR_QUERY_MEMORY_PER_NODE_GIB"],
+            "WORKER_SYSTEM_MEMORY_GIB": self.config["WORKER_SYSTEM_MEMORY_GIB"],
+            "WORKER_QUERY_MEMORY_GIB": self.config["WORKER_QUERY_MEMORY_GIB"],
+            "WORKER_MEMORY_LIMIT_GIB": self.config["WORKER_MEMORY_LIMIT_GIB"],
+            "WORKER_MEMORY_SHRINK_GIB": self.config["WORKER_MEMORY_SHRINK_GIB"],
+            "ASYNC_DATA_CACHE_ENABLED": self.config["ASYNC_DATA_CACHE_ENABLED"],
+            "ASYNC_CACHE_SSD_GIB": self.config["ASYNC_CACHE_SSD_GIB"],
+            "ASYNC_CACHE_SSD_PATH": self.config.get("ASYNC_CACHE_SSD_PATH", ""),
+            "ASYNC_CACHE_NUM_SHARDS": self.config["ASYNC_CACHE_NUM_SHARDS"],
+            "COORDINATOR_IMAGE": self.config["COORDINATOR_IMAGE"],
+            "WORKER_IMAGE": self.config["WORKER_IMAGE"],
+        }
+        return " ".join(f"{key}={shlex.quote(value)}" for key, value in values.items())
+
+    def start(self) -> None:
+        self.validate(cloud=True)
+        coordinator, workers = self.expected_inventory()
+        address = coordinator.private_ip or coordinator.private_dns
+        if nonnegative_int(self.config, "ASYNC_CACHE_SSD_GIB"):
+            cache_path = shlex.quote(self.config["ASYNC_CACHE_SSD_PATH"])
+            prepare_command_id = self.send_command(
+                [worker.instance_id for worker in workers],
+                [
+                    "set -eu",
+                    (
+                        "device=$(lsblk -dpno NAME,MODEL | "
+                        "awk '$0 ~ /Amazon EC2 NVMe Instance Storage/ {print $1; exit}'); "
+                        "test -n \"$device\"; test -b \"$device\"; "
+                        "if ! blkid \"$device\" >/dev/null 2>&1; then "
+                        "mkfs.ext4 -F \"$device\"; fi"
+                    ),
+                    "mkdir -p /mnt/nvme",
+                    "mountpoint -q /mnt/nvme || mount \"$device\" /mnt/nvme",
+                    f"mkdir -p {cache_path}",
+                    f"chmod 0777 /mnt/nvme {cache_path}",
+                ],
+                f"prepare NVMe cache {self.run_id}",
+                wait=True,
+            )
+            self.record_command("prepare_nvme_cache", prepare_command_id)
+        command_id = self.send_command(
+            [coordinator.instance_id],
+            [
+                "set -eu",
+                (
+                    f"{self.remote_env(address, 'coordinator')} "
+                    "bash /opt/velox-testing/presto/aws/ec2/remote/configure_and_start.sh"
+                ),
+            ],
+            f"start coordinator {self.run_id}",
+        )
+        self.record_command("start_coordinator", command_id)
+        for index, worker in enumerate(workers):
+            command_id = self.send_command(
+                [worker.instance_id],
+                [
+                    "set -eu",
+                    (
+                        f"{self.remote_env(address, 'worker', index)} "
+                        "bash /opt/velox-testing/presto/aws/ec2/remote/configure_and_start.sh"
+                    ),
+                ],
+                f"start worker {index} {self.run_id}",
+            )
+            self.record_command(f"start_worker_{index}", command_id)
+        timeout = self.config["WORKER_READY_TIMEOUT_SECONDS"]
+        command_id = self.send_command(
+            [coordinator.instance_id],
+            [
+                "set -eu",
+                (
+                    "bash /opt/velox-testing/presto/aws/ec2/remote/"
+                    f"wait_for_cluster.sh {shlex.quote(address)} {self.workers} {timeout}"
+                ),
+            ],
+            f"wait for workers {self.run_id}",
+        )
+        self.record_command("wait_for_cluster", command_id)
+
+    def run_benchmark(
+        self,
+        queries: str,
+        iterations: int,
+        tag: str,
+        record_name: str = "benchmark",
+    ) -> None:
+        self.validate(cloud=True)
+        coordinator, _ = self.expected_inventory()
+        address = coordinator.private_ip or coordinator.private_dns
+        result_uri = self.result_uri()
+        commands = [
+            "set -eu",
+            (
+                f"AWS_DEFAULT_REGION={shlex.quote(self.config['AWS_REGION'])} "
+                f"AWS_REGION={shlex.quote(self.config['AWS_REGION'])} "
+                "HOME=/root "
+                "bash /opt/velox-testing/presto/aws/ec2/remote/run_benchmark.sh "
+                f"{shlex.quote(address)} {shlex.quote(self.config['SCHEMA_NAME'])} "
+                f"{shlex.quote(queries)} {iterations} {shlex.quote(tag)} "
+                f"{shlex.quote(result_uri)}"
+            ),
+        ]
+        command_id = self.send_command([coordinator.instance_id], commands, f"benchmark {self.run_id}", wait=True)
+        self.record_command(record_name, command_id)
+
+    def run_cold_series(self, queries: str, repetitions: int, tag_prefix: str) -> None:
+        self.validate(cloud=True)
+        if self.config["ASYNC_DATA_CACHE_ENABLED"] != "false":
+            raise ClusterError("run-cold-series requires ASYNC_DATA_CACHE_ENABLED=false")
+        coordinator, workers = self.expected_inventory()
+        instance_ids = [coordinator.instance_id, *[item.instance_id for item in workers]]
+        for repetition in range(1, repetitions + 1):
+            clear_command_id = self.send_command(
+                instance_ids,
+                [
+                    "set -eu",
+                    "sync",
+                    "echo 3 > /proc/sys/vm/drop_caches",
+                ],
+                f"drop host caches repetition {repetition} {self.run_id}",
+                wait=True,
+            )
+            self.record_command(f"drop_host_caches_{repetition}", clear_command_id)
+            self.run_benchmark(
+                queries,
+                1,
+                f"{tag_prefix}_cold_{repetition}",
+                record_name=f"cold_benchmark_{repetition}",
+            )
+
+    def run_cache_series(self, queries: str, tag_prefix: str) -> None:
+        self.validate(cloud=True)
+        coordinator, workers = self.expected_inventory()
+        address = coordinator.private_ip or coordinator.private_dns
+        instance_ids = [coordinator.instance_id, *[worker.instance_id for worker in workers]]
+        drop_command_id = self.send_command(
+            instance_ids,
+            [
+                "set -eu",
+                "sync",
+                "echo 3 > /proc/sys/vm/drop_caches",
+            ],
+            f"drop host caches {self.run_id}",
+            wait=True,
+        )
+        self.record_command("drop_host_caches", drop_command_id)
+        if self.config["ASYNC_DATA_CACHE_ENABLED"] == "true":
+            cache_types = ["memory"]
+            if nonnegative_int(self.config, "ASYNC_CACHE_SSD_GIB"):
+                cache_types.append("ssd")
+            for cache_type in cache_types:
+                expected = f"Cleared {cache_type} cache"
+                clear_command_id = self.send_command(
+                    [worker.instance_id for worker in workers],
+                    [
+                        "set -eu",
+                        (
+                            "response=$(curl -fsS "
+                            f"'http://localhost:8080/v1/operation/server/clearCache?type={cache_type}'"
+                            "); printf '%s\\n' \"$response\"; "
+                            f"test \"$response\" = {shlex.quote(expected)}"
+                        ),
+                    ],
+                    f"clear worker {cache_type} caches {self.run_id}",
+                    wait=True,
+                )
+                self.record_command(f"clear_worker_{cache_type}_caches", clear_command_id)
+        commands = [
+            "set -eu",
+            (
+                f"AWS_DEFAULT_REGION={shlex.quote(self.config['AWS_REGION'])} "
+                f"AWS_REGION={shlex.quote(self.config['AWS_REGION'])} "
+                "HOME=/root "
+                "bash /opt/velox-testing/presto/aws/ec2/remote/run_cache_series.sh "
+                f"{shlex.quote(address)} {shlex.quote(self.config['SCHEMA_NAME'])} "
+                f"{shlex.quote(queries)} {shlex.quote(tag_prefix)} "
+                f"{shlex.quote(self.result_uri())}"
+            ),
+        ]
+        command_id = self.send_command(
+            [coordinator.instance_id],
+            commands,
+            f"cache series {self.run_id}",
+            wait=True,
+        )
+        self.record_command("cache_series", command_id)
+
+    def collect(self) -> None:
+        self.validate(cloud=True)
+        inventory = self.inventory()
+        running = [item for item in inventory if item.state == "running"]
+        if not running:
+            raise ClusterError(f"RunId {self.run_id}: no running instances to collect")
+        expected = self.workers + 1
+        if len(running) != expected:
+            print(
+                f"warning: collecting {len(running)} of {expected} expected running instances",
+                file=sys.stderr,
+            )
+        result_uri = self.result_uri()
+        for item in running:
+            commands = [
+                "set -eu",
+                (
+                    "bash /opt/velox-testing/presto/aws/ec2/remote/collect_node.sh "
+                    f"{shlex.quote(self.run_id)} {shlex.quote(item.role)} "
+                    f"{shlex.quote(item.instance_id)} {shlex.quote(result_uri)}"
+                ),
+            ]
+            command_id = self.send_command([item.instance_id], commands, f"collect {item.instance_id}")
+            self.record_command(f"collect_{item.instance_id}", command_id)
+
+    def stop(self) -> None:
+        coordinator, workers = self.expected_inventory()
+        command_id = self.send_command(
+            [coordinator.instance_id, *[item.instance_id for item in workers]],
+            [
+                "set -eu",
+                "docker rm -f presto-coordinator presto-native-worker-cpu 2>/dev/null || true",
+            ],
+            f"stop {self.run_id}",
+        )
+        self.record_command("stop", command_id)
+
+    def terminate(self) -> None:
+        instances = self.inventory()
+        if not instances:
+            print(f"RunId {self.run_id}: no live instances found")
+            return
+        ids = [item.instance_id for item in instances]
+        self.aws.run(["ec2", "terminate-instances", "--instance-ids", *ids])
+        if not self.dry_run:
+            self.aws.run(["ec2", "wait", "instance-terminated", "--instance-ids", *ids])
+        print(f"RunId {self.run_id}: terminated {len(ids)} instances")
+
+    def list_stale(self) -> None:
+        response = self.aws.run(
+            [
+                "ec2",
+                "describe-instances",
+                "--filters",
+                f"Name=tag:Project,Values={PROJECT_TAG}",
+                f"Name=tag:Experiment,Values={EXPERIMENT_TAG}",
+                "Name=instance-state-name,Values=pending,running,stopping,stopped",
+            ],
+            json_output=True,
+            allow_dry_run=False,
+        )
+        now = utc_now()
+        stale: list[dict[str, str]] = []
+        for reservation in response.get("Reservations", []):
+            for raw in reservation.get("Instances", []):
+                tags = {tag["Key"]: tag["Value"] for tag in raw.get("Tags", [])}
+                expiry_text = tags.get("ExpiresAt", "")
+                if not expiry_text:
+                    continue
+                try:
+                    expiry = dt.datetime.fromisoformat(expiry_text)
+                except ValueError:
+                    continue
+                if expiry <= now:
+                    stale.append(
+                        {
+                            "instance_id": raw["InstanceId"],
+                            "run_id": tags.get("RunId", ""),
+                            "role": tags.get("Role", ""),
+                            "owner": tags.get("Owner", ""),
+                            "expires_at": expiry_text,
+                            "state": raw["State"]["Name"],
+                        }
+                    )
+        print(json.dumps(sorted(stale, key=lambda item: item["expires_at"]), indent=2))
+
+    def result_uri(self) -> str:
+        require(self.config, "RESULTS_S3_ROOT")
+        return f"{self.config['RESULTS_S3_ROOT'].rstrip('/')}/{self.run_id}"
+
+    def write_manifest(self, payload: dict[str, Any]) -> None:
+        self.state_dir.mkdir(parents=True, exist_ok=True)
+        (self.state_dir / "run_manifest.json").write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+
+    def record_command(self, name: str, command_id: str) -> None:
+        if self.dry_run:
+            return
+        self.state_dir.mkdir(parents=True, exist_ok=True)
+        path = self.state_dir / "ssm_commands.json"
+        commands = json.loads(path.read_text()) if path.exists() else {}
+        commands[name] = {"command_id": command_id, "recorded_at": utc_now().isoformat()}
+        path.write_text(json.dumps(commands, indent=2, sort_keys=True) + "\n")
+
+
+def default_run_id() -> str:
+    return "aws102-" + utc_now().strftime("%Y%m%dT%H%M%SZ").lower()
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--config", type=Path, required=True)
+    parser.add_argument("--run-id", default=default_run_id())
+    parser.add_argument("--workers", type=int)
+    parser.add_argument("--state-root", type=Path, default=DEFAULT_STATE_ROOT)
+    parser.add_argument("--dry-run", action="store_true")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    for name in (
+        "validate",
+        "launch",
+        "status",
+        "bootstrap",
+        "start",
+        "collect",
+        "stop",
+        "terminate",
+        "list-stale",
+    ):
+        subparsers.add_parser(name)
+    run_parser = subparsers.add_parser("run")
+    run_parser.add_argument("--queries", default="1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22")
+    run_parser.add_argument("--iterations", type=int, default=5)
+    run_parser.add_argument("--tag", default="sf1k_q1q22")
+    cache_parser = subparsers.add_parser("run-cache-series")
+    cache_parser.add_argument(
+        "--queries",
+        default="1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22",
+    )
+    cache_parser.add_argument("--tag-prefix", default="sf1k_cache")
+    cold_parser = subparsers.add_parser("run-cold-series")
+    cold_parser.add_argument(
+        "--queries",
+        default="1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22",
+    )
+    cold_parser.add_argument("--repetitions", type=int, default=3)
+    cold_parser.add_argument("--tag-prefix", default="sf1k")
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    try:
+        config = load_env(args.config)
+        workers = args.workers or positive_int(config, "WORKER_COUNT")
+        cluster = Cluster(
+            config,
+            run_id=args.run_id,
+            workers=workers,
+            state_root=args.state_root,
+            dry_run=args.dry_run,
+        )
+        if args.command == "validate":
+            cluster.validate(cloud=True)
+            print("configuration is valid")
+        elif args.command == "launch":
+            cluster.launch()
+        elif args.command == "status":
+            print(json.dumps(cluster.inventory_json(), indent=2))
+        elif args.command == "bootstrap":
+            cluster.bootstrap()
+        elif args.command == "start":
+            cluster.start()
+        elif args.command == "run":
+            if args.iterations <= 0:
+                raise ClusterError("--iterations must be greater than zero")
+            cluster.run_benchmark(args.queries, args.iterations, args.tag)
+        elif args.command == "run-cache-series":
+            cluster.run_cache_series(args.queries, args.tag_prefix)
+        elif args.command == "run-cold-series":
+            if args.repetitions <= 0:
+                raise ClusterError("--repetitions must be greater than zero")
+            cluster.run_cold_series(args.queries, args.repetitions, args.tag_prefix)
+        elif args.command == "collect":
+            cluster.collect()
+        elif args.command == "stop":
+            cluster.stop()
+        elif args.command == "terminate":
+            cluster.terminate()
+        elif args.command == "list-stale":
+            cluster.list_stale()
+        return 0
+    except (ClusterError, OSError) as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/presto/aws/ec2/aws_config.env.example
+++ b/presto/aws/ec2/aws_config.env.example
@@ -1,0 +1,65 @@
+# AWS account and placement. Keep real values outside the repository.
+AWS_PROFILE=
+AWS_REGION=us-east-2
+AMI_ID=
+AMI_SSM_PARAMETER=/aws/service/canonical/ubuntu/server/24.04/stable/current/amd64/hvm/ebs-gp3/ami-id
+# Optional role-specific overrides for mixed x86 coordinator / ARM worker fleets.
+COORDINATOR_AMI_ID=
+COORDINATOR_AMI_SSM_PARAMETER=
+WORKER_AMI_ID=
+WORKER_AMI_SSM_PARAMETER=
+SUBNET_ID=
+SECURITY_GROUP_ID=
+IAM_INSTANCE_PROFILE=
+
+# Fleet shape. WORKER_COUNT is overridden by --workers when needed.
+COORDINATOR_INSTANCE_TYPE=m7a.4xlarge
+WORKER_INSTANCE_TYPE=m7a.4xlarge
+WORKER_COUNT=8
+ROOT_VOLUME_GIB=100
+
+# Reproducible software inputs.
+VELOX_TESTING_REPOSITORY=https://github.com/<fork>/velox-testing.git
+VELOX_TESTING_FETCH_REF=refs/heads/aws-102-ec2-cpu-cluster
+VELOX_TESTING_REF=<full-cluster-branch-commit-sha>
+# Optional for an uncommitted smoke-test overlay. Set both or neither.
+HARNESS_BUNDLE_S3_URI=
+HARNESS_BUNDLE_SHA256=
+COORDINATOR_IMAGE=ghcr.io/y-scope/presto:0.299
+WORKER_IMAGE=ghcr.io/y-scope/presto-native:0.299
+
+# Benchmark data and output. Pin image digests before qualification.
+HIVE_METASTORE_S3_URI=s3://rapids-tpch/presto-gpu/sf1k_v2_float/hive_metastore/
+SCHEMA_NAME=tpch_sf1k_v2_float_s3
+RESULTS_S3_ROOT=
+
+# Runtime sizing. One native worker runs on every worker EC2 instance.
+VCPU_PER_WORKER=16
+# Explicit CPU tuning overlay. Defaults reproduce the generated CPU override.
+TASK_MAX_DRIVERS_PER_TASK=16
+HIVE_MAX_SPLIT_SIZE=256MB
+HIVE_SPLIT_LOADER_CONCURRENCY=32
+DYNAMIC_FILTERING_ENABLED=false
+CPU_EXCHANGE_TUNING_ENABLED=true
+COORDINATOR_HEAP_GIB=54
+COORDINATOR_HEADROOM_GIB=4
+COORDINATOR_QUERY_TOTAL_MEMORY_PER_NODE_GIB=48
+COORDINATOR_QUERY_MEMORY_PER_NODE_GIB=44
+WORKER_SYSTEM_MEMORY_GIB=50
+WORKER_QUERY_MEMORY_GIB=44
+WORKER_MEMORY_LIMIT_GIB=54
+WORKER_MEMORY_SHRINK_GIB=16
+ASYNC_DATA_CACHE_ENABLED=false
+ASYNC_CACHE_SSD_GIB=0
+ASYNC_CACHE_SSD_PATH=
+ASYNC_CACHE_NUM_SHARDS=16
+
+# Fleet safety and ownership.
+OWNER=
+EXPIRY_HOURS=8
+SSM_READY_TIMEOUT_SECONDS=900
+SSM_COMMAND_TIMEOUT_SECONDS=21600
+WORKER_READY_TIMEOUT_SECONDS=600
+
+# Optional. Leave empty for ordinary same-AZ placement.
+PLACEMENT_GROUP=

--- a/presto/aws/ec2/remote/bootstrap_node.sh
+++ b/presto/aws/ec2/remote/bootstrap_node.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+if [[ $# -ne 4 ]]; then
+  echo "usage: bootstrap_node.sh <role> <coordinator-image> <worker-image> <metastore-s3-uri>" >&2
+  exit 2
+fi
+
+role=$1
+coordinator_image=$2
+worker_image=$3
+metastore_uri=$4
+runtime_root=/opt/presto-aws
+
+if [[ ${role} != coordinator && ${role} != worker ]]; then
+  echo "role must be coordinator or worker" >&2
+  exit 2
+fi
+
+mkdir -p \
+  "${runtime_root}/base_config" \
+  "${runtime_root}/final_config" \
+  "${runtime_root}/logs" \
+  "${runtime_root}/metastore" \
+  "${runtime_root}/results" \
+  "${runtime_root}/telemetry"
+
+python3 -m venv "${runtime_root}/venv"
+"${runtime_root}/venv/bin/pip" install --disable-pip-version-check \
+  -r /opt/velox-testing/presto/testing/requirements.txt
+
+if [[ ${role} == coordinator ]]; then
+  docker pull "${coordinator_image}"
+  local_image=${coordinator_image}
+else
+  docker pull "${worker_image}"
+  local_image=${worker_image}
+fi
+
+aws s3 sync "${metastore_uri}" "${runtime_root}/metastore/" --only-show-errors
+
+token=$(curl -fsS -X PUT \
+  -H 'X-aws-ec2-metadata-token-ttl-seconds: 21600' \
+  http://169.254.169.254/latest/api/token)
+role_name=$(curl -fsS \
+  -H "X-aws-ec2-metadata-token: ${token}" \
+  http://169.254.169.254/latest/meta-data/iam/security-credentials/)
+credential_document=$(curl -fsS \
+  -H "X-aws-ec2-metadata-token: ${token}" \
+  "http://169.254.169.254/latest/meta-data/iam/security-credentials/${role_name}")
+credential_code=$(jq -r .Code <<<"${credential_document}")
+if [[ "${credential_code}" != "Success" ]]; then
+  echo "instance-profile credential probe failed: ${credential_code}" >&2
+  exit 1
+fi
+
+aws sts get-caller-identity >/dev/null
+
+cat >"${runtime_root}/bootstrap_info.json" <<EOF
+{
+  "coordinator_image": "${coordinator_image}",
+  "worker_image": "${worker_image}",
+  "role": "${role}",
+  "local_image_id": "$(docker image inspect --format '{{.Id}}' "${local_image}")",
+  "iam_role": "${role_name}",
+  "credential_expiration": "$(jq -r .Expiration <<<"${credential_document}")",
+  "metastore_uri": "${metastore_uri}",
+  "bootstrapped_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+}
+EOF

--- a/presto/aws/ec2/remote/collect_node.sh
+++ b/presto/aws/ec2/remote/collect_node.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+if [[ $# -ne 4 ]]; then
+  echo "usage: collect_node.sh <run-id> <role> <instance-id> <result-s3-uri>" >&2
+  exit 2
+fi
+
+run_id=$1
+role=$2
+instance_id=$3
+result_uri=$4
+runtime_root=/opt/presto-aws
+artifact_root="${runtime_root}/artifacts/${role}-${instance_id}"
+
+rm -rf "${artifact_root}"
+mkdir -p "${artifact_root}"
+
+cp -a "${runtime_root}/logs" "${artifact_root}/" 2>/dev/null || true
+cp -a "${runtime_root}/telemetry" "${artifact_root}/" 2>/dev/null || true
+cp -a "${runtime_root}/base_config" "${artifact_root}/" 2>/dev/null || true
+cp -a "${runtime_root}/final_config" "${artifact_root}/" 2>/dev/null || true
+cp -a "${runtime_root}/config_history" "${artifact_root}/" 2>/dev/null || true
+cp -a "${runtime_root}/results" "${artifact_root}/" 2>/dev/null || true
+cp "${runtime_root}"/*.json "${artifact_root}/" 2>/dev/null || true
+cp "${runtime_root}"/*.sha256 "${artifact_root}/" 2>/dev/null || true
+cp "${runtime_root}"/*.diff "${artifact_root}/" 2>/dev/null || true
+
+docker ps -a --no-trunc >"${artifact_root}/docker_ps.txt" 2>&1 || true
+docker inspect presto-coordinator presto-native-worker-cpu \
+  >"${artifact_root}/docker_inspect.json" 2>/dev/null || true
+docker logs presto-coordinator >"${artifact_root}/coordinator_container.log" 2>&1 || true
+docker logs presto-native-worker-cpu >"${artifact_root}/worker_container.log" 2>&1 || true
+
+uname -a >"${artifact_root}/uname.txt"
+lscpu --json >"${artifact_root}/lscpu.json"
+lsmem --json >"${artifact_root}/lsmem.json"
+ip -json address >"${artifact_root}/ip_address.json"
+ip -s -json link >"${artifact_root}/ip_link_stats.json"
+lsblk --json --bytes --output NAME,PATH,MODEL,SERIAL,SIZE,FSTYPE,MOUNTPOINTS \
+  >"${artifact_root}/lsblk.json"
+cp /proc/diskstats "${artifact_root}/diskstats.txt"
+df -B1 --output=source,fstype,size,used,avail,target \
+  >"${artifact_root}/filesystems.txt"
+if [[ ${role} == worker ]]; then
+  curl -fsS http://localhost:8080/v1/info/metrics \
+    >"${artifact_root}/worker_metrics.prom" 2>&1 || true
+  curl -fsS http://localhost:8080/v1/status \
+    >"${artifact_root}/worker_status.json" 2>&1 || true
+fi
+journalctl -u docker --no-pager >"${artifact_root}/docker_journal.log" 2>&1 || true
+dmesg --ctime >"${artifact_root}/dmesg.log" 2>&1 || true
+
+cat >"${artifact_root}/collection.json" <<EOF
+{
+  "run_id": "${run_id}",
+  "role": "${role}",
+  "instance_id": "${instance_id}",
+  "collected_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+}
+EOF
+
+aws s3 sync "${artifact_root}/" \
+  "${result_uri}/nodes/${role}-${instance_id}/" --only-show-errors

--- a/presto/aws/ec2/remote/configure_and_start.sh
+++ b/presto/aws/ec2/remote/configure_and_start.sh
@@ -1,0 +1,291 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+required=(
+  RUN_ID ROLE WORKER_COUNT COORDINATOR_ADDRESS AWS_REGION VCPU_PER_WORKER
+  TASK_MAX_DRIVERS_PER_TASK HIVE_MAX_SPLIT_SIZE
+  HIVE_SPLIT_LOADER_CONCURRENCY DYNAMIC_FILTERING_ENABLED
+  CPU_EXCHANGE_TUNING_ENABLED
+  COORDINATOR_HEAP_GIB COORDINATOR_HEADROOM_GIB
+  COORDINATOR_QUERY_TOTAL_MEMORY_PER_NODE_GIB
+  COORDINATOR_QUERY_MEMORY_PER_NODE_GIB WORKER_SYSTEM_MEMORY_GIB
+  WORKER_QUERY_MEMORY_GIB WORKER_MEMORY_LIMIT_GIB WORKER_MEMORY_SHRINK_GIB
+  ASYNC_DATA_CACHE_ENABLED ASYNC_CACHE_SSD_GIB ASYNC_CACHE_NUM_SHARDS
+  COORDINATOR_IMAGE WORKER_IMAGE
+)
+for name in "${required[@]}"; do
+  if [[ -z ${!name:-} ]]; then
+    echo "missing required environment variable: ${name}" >&2
+    exit 2
+  fi
+done
+
+if [[ ${ROLE} != coordinator && ${ROLE} != worker ]]; then
+  echo "ROLE must be coordinator or worker" >&2
+  exit 2
+fi
+if [[ ${ROLE} == worker && -z ${WORKER_INDEX:-} ]]; then
+  echo "WORKER_INDEX is required for worker role" >&2
+  exit 2
+fi
+
+repo=/opt/velox-testing
+runtime_root=/opt/presto-aws
+generated="${repo}/presto/docker/config/generated/cpu"
+base="${runtime_root}/base_config/${ROLE}"
+final="${runtime_root}/final_config/${ROLE}"
+assembled="${runtime_root}/runtime_etc"
+
+set_property() {
+  local path=$1 key=$2 value=$3
+  python3 - "${path}" "${key}" "${value}" <<'PY'
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+key = sys.argv[2]
+value = sys.argv[3]
+prefix = f"{key}="
+lines = path.read_text().splitlines()
+matches = [index for index, line in enumerate(lines) if line.startswith(prefix)]
+if len(matches) != 1:
+    raise SystemExit(f"expected exactly one {key} in {path}; found {len(matches)}")
+lines[matches[0]] = f"{key}={value}"
+path.write_text("\n".join(lines) + "\n")
+PY
+}
+
+upsert_property() {
+  local path=$1 key=$2 value=$3
+  python3 - "${path}" "${key}" "${value}" <<'PY'
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+key = sys.argv[2]
+value = sys.argv[3]
+prefix = f"{key}="
+lines = path.read_text().splitlines()
+matches = [index for index, line in enumerate(lines) if line.startswith(prefix)]
+if len(matches) > 1:
+    raise SystemExit(f"expected at most one {key} in {path}; found {len(matches)}")
+if matches:
+    lines[matches[0]] = f"{key}={value}"
+else:
+    lines.append(f"{key}={value}")
+path.write_text("\n".join(lines) + "\n")
+PY
+}
+
+delete_property() {
+  local path=$1 key=$2
+  python3 - "${path}" "${key}" <<'PY'
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+prefix = f"{sys.argv[2]}="
+lines = [line for line in path.read_text().splitlines() if not line.startswith(prefix)]
+path.write_text("\n".join(lines) + "\n")
+PY
+}
+
+cd "${repo}/presto/scripts"
+OVERWRITE_CONFIG=true \
+NUM_WORKERS="${WORKER_COUNT}" \
+VARIANT_TYPE=cpu \
+VCPU_PER_WORKER="${VCPU_PER_WORKER}" \
+  ./generate_presto_config.sh
+
+rm -rf "${base}" "${final}" "${assembled}"
+mkdir -p "${base}" "${final}" "${assembled}" "${runtime_root}/data"
+
+if [[ ${ROLE} == coordinator ]]; then
+  cp -a "${generated}/etc_common/." "${base}/"
+  cp "${generated}/etc_coordinator/config_native.properties" "${base}/config.properties"
+  cp "${generated}/etc_coordinator/node.properties" "${base}/node.properties"
+  mkdir -p "${base}/catalog"
+  cp "${generated}/etc_coordinator/catalog/hive.properties" "${base}/catalog/hive.properties"
+else
+  worker_source="${generated}/etc_worker_0"
+  cp -a "${generated}/etc_common/." "${base}/"
+  cp "${worker_source}/config_native.properties" "${base}/config.properties"
+  cp "${worker_source}/node.properties" "${base}/node.properties"
+  mkdir -p "${base}/catalog"
+  cp "${worker_source}/catalog/hive.properties" "${base}/catalog/hive.properties"
+fi
+cp -a "${base}/." "${final}/"
+delete_property "${final}/catalog/hive.properties" hive.max-split-size
+printf 'hive.max-split-size=%s\n' "${HIVE_MAX_SPLIT_SIZE}" \
+  >>"${final}/catalog/hive.properties"
+delete_property "${final}/catalog/hive.properties" hive.split-loader-concurrency
+printf 'hive.split-loader-concurrency=%s\n' "${HIVE_SPLIT_LOADER_CONCURRENCY}" \
+  >>"${final}/catalog/hive.properties"
+
+if [[ ${ROLE} == coordinator ]]; then
+  set_property "${final}/config.properties" discovery.uri \
+    "http://${COORDINATOR_ADDRESS}:8080"
+  set_property "${final}/config.properties" query-manager.required-workers \
+    "${WORKER_COUNT}"
+  set_property "${final}/config.properties" \
+    query-manager.required-workers-max-wait 10m
+  set_property "${final}/config.properties" query.max-total-memory-per-node \
+    "${COORDINATOR_QUERY_TOTAL_MEMORY_PER_NODE_GIB}GB"
+  set_property "${final}/config.properties" query.max-total-memory \
+    "$((COORDINATOR_QUERY_TOTAL_MEMORY_PER_NODE_GIB * WORKER_COUNT))GB"
+  set_property "${final}/config.properties" query.max-memory-per-node \
+    "${COORDINATOR_QUERY_MEMORY_PER_NODE_GIB}GB"
+  set_property "${final}/config.properties" query.max-memory \
+    "$((COORDINATOR_QUERY_MEMORY_PER_NODE_GIB * WORKER_COUNT))GB"
+  set_property "${final}/config.properties" memory.heap-headroom-per-node \
+    "${COORDINATOR_HEADROOM_GIB}GB"
+  set_property "${final}/config.properties" single-node-execution-enabled false
+  set_property "${final}/config.properties" experimental.enable-dynamic-filtering \
+    "${DYNAMIC_FILTERING_ENABLED}"
+  python3 - "${final}/jvm.config" "${COORDINATOR_HEAP_GIB}" <<'PY'
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+heap = sys.argv[2]
+lines = path.read_text().splitlines()
+lines = [
+    f"-Xmx{heap}G" if line.startswith("-Xmx") else
+    f"-Xms{heap}G" if line.startswith("-Xms") else line
+    for line in lines
+]
+path.write_text("\n".join(lines) + "\n")
+PY
+else
+  set_property "${final}/config.properties" http-server.http.port 8080
+  set_property "${final}/config.properties" discovery.uri \
+    "http://${COORDINATOR_ADDRESS}:8080"
+  set_property "${final}/config.properties" single-node-execution-enabled false
+  set_property "${final}/config.properties" task.max-drivers-per-task \
+    "${TASK_MAX_DRIVERS_PER_TASK}"
+  set_property "${final}/config.properties" system-memory-gb \
+    "${WORKER_SYSTEM_MEMORY_GIB}"
+  set_property "${final}/config.properties" query-memory-gb \
+    "${WORKER_QUERY_MEMORY_GIB}"
+  set_property "${final}/config.properties" query.max-memory-per-node \
+    "${WORKER_QUERY_MEMORY_GIB}GB"
+  set_property "${final}/config.properties" system-mem-limit-gb \
+    "${WORKER_MEMORY_LIMIT_GIB}"
+  set_property "${final}/config.properties" system-mem-shrink-gb \
+    "${WORKER_MEMORY_SHRINK_GIB}"
+  set_property "${final}/config.properties" async-data-cache-enabled \
+    "${ASYNC_DATA_CACHE_ENABLED}"
+  upsert_property "${final}/config.properties" async-cache-ssd-gb \
+    "${ASYNC_CACHE_SSD_GIB}"
+  upsert_property "${final}/config.properties" async-cache-num-shards \
+    "${ASYNC_CACHE_NUM_SHARDS}"
+  upsert_property "${final}/config.properties" runtime-metrics-collection-enabled \
+    true
+  if [[ ${CPU_EXCHANGE_TUNING_ENABLED} == false ]]; then
+    for key in \
+      exchange.http-client.enable-connection-pool \
+      exchange.max-buffer-size \
+      sink.max-buffer-size \
+      exchange.max-response-size \
+      exchange.client-threads \
+      exchange.http-client.max-connections \
+      exchange.http-client.max-connections-per-server \
+      exchange.http-client.max-requests-queued-per-destination \
+      exchange.http-client.request-timeout; do
+      delete_property "${final}/config.properties" "${key}"
+    done
+  fi
+  if ((ASYNC_CACHE_SSD_GIB > 0)); then
+    if [[ -z ${ASYNC_CACHE_SSD_PATH:-} ]]; then
+      echo "ASYNC_CACHE_SSD_PATH is required for SSD cache" >&2
+      exit 2
+    fi
+    upsert_property "${final}/config.properties" async-cache-ssd-path \
+      "${ASYNC_CACHE_SSD_PATH}"
+  fi
+  set_property "${final}/node.properties" node.id \
+    "aws-${RUN_ID}-worker-${WORKER_INDEX}"
+fi
+
+cp -a "${final}/." "${assembled}/"
+find "${base}" -type f -print0 | sort -z | xargs -0 sha256sum \
+  >"${runtime_root}/base_config_${ROLE}.sha256"
+find "${final}" -type f -print0 | sort -z | xargs -0 sha256sum \
+  >"${runtime_root}/final_config_${ROLE}.sha256"
+diff -ru "${base}" "${final}" >"${runtime_root}/config_${ROLE}.diff" || true
+tuning_id=$(
+  printf '%s\n' \
+    "drivers=${TASK_MAX_DRIVERS_PER_TASK}" \
+    "split=${HIVE_MAX_SPLIT_SIZE}" \
+    "loader=${HIVE_SPLIT_LOADER_CONCURRENCY}" \
+    "dynamic_filtering=${DYNAMIC_FILTERING_ENABLED}" \
+    "exchange_tuning=${CPU_EXCHANGE_TUNING_ENABLED}" |
+    sha256sum | cut -c1-12
+)
+history="${runtime_root}/config_history/${tuning_id}/${ROLE}"
+rm -rf "${history}"
+mkdir -p "${history}"
+cp -a "${final}/." "${history}/"
+cat >"${history}/tuning.json" <<EOF
+{
+  "task_max_drivers_per_task": ${TASK_MAX_DRIVERS_PER_TASK},
+  "hive_max_split_size": "${HIVE_MAX_SPLIT_SIZE}",
+  "hive_split_loader_concurrency": ${HIVE_SPLIT_LOADER_CONCURRENCY},
+  "dynamic_filtering_enabled": ${DYNAMIC_FILTERING_ENABLED},
+  "cpu_exchange_tuning_enabled": ${CPU_EXCHANGE_TUNING_ENABLED}
+}
+EOF
+
+docker rm -f presto-coordinator presto-native-worker-cpu 2>/dev/null || true
+timestamp=$(date -u +%Y%m%dT%H%M%SZ)
+
+if [[ ${ROLE} == coordinator ]]; then
+  docker run -d \
+    --name presto-coordinator \
+    --network host \
+    --restart no \
+    -e "AWS_DEFAULT_REGION=${AWS_REGION}" \
+    -e "AWS_REGION=${AWS_REGION}" \
+    -e "SERVER_START_TIMESTAMP=${timestamp}" \
+    -v "${assembled}:/opt/presto-server/etc:ro" \
+    -v "${runtime_root}/metastore:/var/lib/presto/data/hive/metastore" \
+    -v "${runtime_root}/data:/var/lib/presto/data/local" \
+    -v "${runtime_root}/logs:/opt/presto-server/logs" \
+    -v "${repo}/presto/docker/launch_coordinator.sh:/opt/launch_coordinator.sh:ro" \
+    --entrypoint bash \
+    "${COORDINATOR_IMAGE}" \
+    /opt/launch_coordinator.sh
+else
+  cache_mount_args=()
+  if ((ASYNC_CACHE_SSD_GIB > 0)); then
+    cache_mount_args=(-v /mnt/nvme:/mnt/nvme)
+  fi
+  docker run -d \
+    --name presto-native-worker-cpu \
+    --network host \
+    --restart no \
+    --cap-add SYS_NICE \
+    -e "AWS_DEFAULT_REGION=${AWS_REGION}" \
+    -e "AWS_REGION=${AWS_REGION}" \
+    -e "SERVER_START_TIMESTAMP=${timestamp}" \
+    -v "${assembled}:/opt/presto-server/etc:ro" \
+    -v "${runtime_root}/metastore:/var/lib/presto/data/hive/metastore" \
+    -v "${runtime_root}/data:/var/lib/presto/data/local" \
+    -v "${runtime_root}/logs:/opt/presto-server/logs" \
+    "${cache_mount_args[@]}" \
+    -v "${repo}/presto/docker/launch_presto_servers.sh:/opt/launch_presto_servers.sh:ro" \
+    --entrypoint bash \
+    "${WORKER_IMAGE}" \
+    /opt/launch_presto_servers.sh
+fi
+
+if [[ -f ${runtime_root}/telemetry/${ROLE}.sampler.pid ]]; then
+  kill "$(cat "${runtime_root}/telemetry/${ROLE}.sampler.pid")" 2>/dev/null || true
+fi
+nohup bash "${repo}/presto/aws/ec2/remote/sample_host.sh" \
+  "${ROLE}" "${runtime_root}/telemetry/${ROLE}.jsonl" \
+  >"${runtime_root}/telemetry/${ROLE}.sampler.log" 2>&1 &
+echo "$!" >"${runtime_root}/telemetry/${ROLE}.sampler.pid"

--- a/presto/aws/ec2/remote/run_benchmark.sh
+++ b/presto/aws/ec2/remote/run_benchmark.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+if [[ $# -ne 6 ]]; then
+  echo "usage: run_benchmark.sh <coordinator> <schema> <queries> <iterations> <tag> <result-s3-uri>" >&2
+  exit 2
+fi
+
+coordinator=$1
+schema=$2
+queries=$3
+iterations=$4
+tag=$5
+result_uri=$6
+repo=/opt/velox-testing
+runtime_root=/opt/presto-aws
+output="${runtime_root}/results/${tag}"
+
+mkdir -p "${output}"
+cat >"${output}/driver_info.json" <<EOF
+{
+  "coordinator": "${coordinator}",
+  "schema": "${schema}",
+  "queries": "${queries}",
+  "iterations": ${iterations},
+  "tag": "${tag}",
+  "started_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+}
+EOF
+
+sync_results() {
+  aws s3 sync "${runtime_root}/results/" "${result_uri}/benchmark/" \
+    --only-show-errors
+}
+trap 'sync_results || true' EXIT
+
+export PATH="${runtime_root}/venv/bin:${PATH}"
+export LOGS_DIR="${runtime_root}/logs"
+cd "${repo}/presto/scripts"
+
+status=0
+timeout --signal=TERM --kill-after=60s 14400s ./run_benchmark.sh \
+  --benchmark-type tpch \
+  --hostname "${coordinator}" \
+  --port 8080 \
+  --queries "${queries}" \
+  --schema-name "${schema}" \
+  --iterations "${iterations}" \
+  --output-dir "${output}" \
+  --tag "${tag}" \
+  --metrics \
+  --skip-drop-cache \
+  --verbose \
+  >"${output}/benchmark.log" 2>&1 || status=$?
+
+python3 - "${output}/driver_info.json" "${status}" <<'PY'
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+path = Path(sys.argv[1])
+payload = json.loads(path.read_text())
+payload["exit_code"] = int(sys.argv[2])
+payload["finished_at"] = datetime.now(timezone.utc).isoformat()
+path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+PY
+
+upload_status=0
+sync_results || upload_status=$?
+trap - EXIT
+if ((upload_status != 0)); then
+  echo "benchmark artifact upload failed with exit code ${upload_status}" >&2
+  exit "${upload_status}"
+fi
+exit "${status}"

--- a/presto/aws/ec2/remote/run_cache_series.sh
+++ b/presto/aws/ec2/remote/run_cache_series.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+if [[ $# -ne 5 ]]; then
+  echo "usage: run_cache_series.sh <coordinator> <schema> <queries> <tag-prefix> <result-s3-uri>" >&2
+  exit 2
+fi
+
+coordinator=$1
+schema=$2
+queries=$3
+tag_prefix=$4
+result_uri=$5
+runner=/opt/velox-testing/presto/aws/ec2/remote/run_benchmark.sh
+runtime_root=/opt/presto-aws
+
+before_nodes=$(curl -fsS "http://${coordinator}:8080/v1/node" \
+  | jq -c '[.[].uri] | sort | unique')
+printf '%s\n' "${before_nodes}" >"${runtime_root}/results/${tag_prefix}_nodes_before.json"
+
+snapshot_worker_metrics() {
+  local label=$1 output_dir uri base_url worker_name
+  output_dir="${runtime_root}/results/${tag_prefix}_metrics/${label}"
+  mkdir -p "${output_dir}"
+  while IFS= read -r uri; do
+    base_url=${uri%/v1/status}
+    worker_name=$(sed 's#^http://##; s#[/:]#_#g' <<<"${base_url}")
+    curl -fsS "${base_url}/v1/info/metrics" \
+      >"${output_dir}/${worker_name}.prom" || true
+    curl -fsS "${base_url}/v1/status" \
+      >"${output_dir}/${worker_name}_status.json" || true
+  done < <(jq -r '.[]' <<<"${before_nodes}")
+}
+
+snapshot_worker_metrics before_cold
+bash "${runner}" "${coordinator}" "${schema}" "${queries}" 1 \
+  "${tag_prefix}_cold_fill" "${result_uri}"
+snapshot_worker_metrics after_cold
+
+for pass in 1 2 3 4; do
+  bash "${runner}" "${coordinator}" "${schema}" "${queries}" 1 \
+    "${tag_prefix}_warm_${pass}" "${result_uri}"
+  snapshot_worker_metrics "after_warm_${pass}"
+done
+
+after_nodes=$(curl -fsS "http://${coordinator}:8080/v1/node" \
+  | jq -c '[.[].uri] | sort | unique')
+printf '%s\n' "${after_nodes}" >"${runtime_root}/results/${tag_prefix}_nodes_after.json"
+if [[ ${before_nodes} != "${after_nodes}" ]]; then
+  echo "worker membership changed during cache series" >&2
+  diff -u \
+    "${runtime_root}/results/${tag_prefix}_nodes_before.json" \
+    "${runtime_root}/results/${tag_prefix}_nodes_after.json" >&2 || true
+  exit 1
+fi
+
+aws s3 sync "${runtime_root}/results/" "${result_uri}/benchmark/" \
+  --only-show-errors

--- a/presto/aws/ec2/remote/sample_host.sh
+++ b/presto/aws/ec2/remote/sample_host.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+if [[ $# -ne 2 ]]; then
+  echo "usage: sample_host.sh <role> <output-jsonl>" >&2
+  exit 2
+fi
+
+role=$1
+output=$2
+mkdir -p "$(dirname "${output}")"
+
+while true; do
+  python3 - "${role}" >>"${output}" <<'PY'
+import json
+import os
+import resource
+import time
+from pathlib import Path
+
+role = os.sys.argv[1]
+meminfo = {}
+for line in Path("/proc/meminfo").read_text().splitlines():
+    key, value = line.split(":", 1)
+    meminfo[key] = int(value.strip().split()[0]) * 1024
+
+load1, load5, load15 = os.getloadavg()
+network = {}
+for line in Path("/proc/net/dev").read_text().splitlines()[2:]:
+    interface, counters = line.split(":", 1)
+    fields = counters.split()
+    interface = interface.strip()
+    if interface != "lo":
+        network[interface] = {
+            "rx_bytes": int(fields[0]),
+            "rx_packets": int(fields[1]),
+            "tx_bytes": int(fields[8]),
+            "tx_packets": int(fields[9]),
+        }
+
+disks = {}
+for line in Path("/proc/diskstats").read_text().splitlines():
+    fields = line.split()
+    name = fields[2]
+    if name.startswith("nvme"):
+        disks[name] = {
+            "reads_completed": int(fields[3]),
+            "sectors_read": int(fields[5]),
+            "writes_completed": int(fields[7]),
+            "sectors_written": int(fields[9]),
+            "io_time_ms": int(fields[12]),
+        }
+
+print(json.dumps({
+    "timestamp_unix": time.time(),
+    "role": role,
+    "load": [load1, load5, load15],
+    "mem_total_bytes": meminfo["MemTotal"],
+    "mem_available_bytes": meminfo["MemAvailable"],
+    "swap_free_bytes": meminfo.get("SwapFree", 0),
+    "network": network,
+    "disks": disks,
+    "sampler_max_rss_kib": resource.getrusage(resource.RUSAGE_SELF).ru_maxrss,
+}, separators=(",", ":")))
+PY
+  docker stats --no-stream --format '{{json .}}' 2>/dev/null \
+    | python3 -c '
+import json
+import sys
+import time
+for line in sys.stdin:
+    print(json.dumps({
+        "timestamp_unix": time.time(),
+        "role": sys.argv[1],
+        "docker": json.loads(line),
+    }, separators=(",", ":")))
+' "${role}" >>"${output}" || true
+  sleep 5
+done

--- a/presto/aws/ec2/remote/wait_for_cluster.sh
+++ b/presto/aws/ec2/remote/wait_for_cluster.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+if [[ $# -ne 3 ]]; then
+  echo "usage: wait_for_cluster.sh <coordinator-address> <workers> <timeout-seconds>" >&2
+  exit 2
+fi
+
+coordinator=$1
+workers=$2
+timeout=$3
+deadline=$((SECONDS + timeout))
+
+until [[ $(curl -fsS "http://${coordinator}:8080/v1/info/state" || true) == '"ACTIVE"' ]]; do
+  if ((SECONDS >= deadline)); then
+    echo "coordinator did not become ACTIVE within ${timeout}s" >&2
+    docker logs presto-coordinator >&2 || true
+    exit 1
+  fi
+  sleep 5
+done
+
+while true; do
+  node_json=$(curl -fsS "http://${coordinator}:8080/v1/node" || echo '[]')
+  # Discovery can retain stale descriptors briefly after workers restart.
+  # Count unique worker endpoints so an in-place service restart does not
+  # make a healthy cluster appear oversized.
+  count=$(jq '[.[].uri] | unique | length' <<<"${node_json}")
+  if [[ ${count} -eq ${workers} ]]; then
+    printf '%s\n' "${node_json}" >/opt/presto-aws/registered_workers.json
+    exit 0
+  fi
+  if ((SECONDS >= deadline)); then
+    echo "expected ${workers} workers; observed ${count}" >&2
+    printf '%s\n' "${node_json}" >&2
+    exit 1
+  fi
+  sleep 5
+done

--- a/presto/aws/ec2/summarize_results.py
+++ b/presto/aws/ec2/summarize_results.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Apply the AWS 102 timing rules to benchmark_result.json files."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+from pathlib import Path
+from typing import Any
+
+
+def load_result(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text())
+    tpch = payload.get("tpch", {})
+    failures = tpch.get("failed_queries", {})
+    if failures:
+        raise ValueError(f"{path}: failed queries are present: {sorted(failures)}")
+    raw = tpch.get("raw_times_ms")
+    if not isinstance(raw, dict) or not raw:
+        raise ValueError(f"{path}: tpch.raw_times_ms is missing or empty")
+    return raw
+
+
+def query_sort_key(name: str) -> tuple[int, str]:
+    try:
+        return int(name.removeprefix("Q")), name
+    except ValueError:
+        return 10**9, name
+
+
+def baseline(path: Path) -> dict[str, Any]:
+    raw = load_result(path)
+    per_query_ms: dict[str, float] = {}
+    for query, values in raw.items():
+        if not isinstance(values, list) or len(values) != 5:
+            raise ValueError(f"{path}: {query} must contain exactly five iterations")
+        per_query_ms[query] = statistics.fmean(values[1:])
+    ordered = dict(sorted(per_query_ms.items(), key=lambda item: query_sort_key(item[0])))
+    return {
+        "mode": "cache_off_s3",
+        "source": str(path),
+        "warmup_iterations_excluded": 1,
+        "measured_iterations": 4,
+        "per_query_mean_ms": ordered,
+        "suite_runtime_ms": sum(ordered.values()),
+        "suite_runtime_seconds": sum(ordered.values()) / 1000,
+    }
+
+
+def cache_series(paths: list[Path]) -> dict[str, Any]:
+    if len(paths) != 5:
+        raise ValueError("cache series requires one cold-fill and four warm results")
+    loaded = [load_result(path) for path in paths]
+    query_sets = [set(result) for result in loaded]
+    if any(query_set != query_sets[0] for query_set in query_sets[1:]):
+        raise ValueError("cache-series result files contain different query sets")
+    for path, result in zip(paths, loaded, strict=True):
+        for query, values in result.items():
+            if not isinstance(values, list) or len(values) != 1:
+                raise ValueError(f"{path}: {query} must contain one suite-major iteration")
+
+    cold_per_query = {query: loaded[0][query][0] for query in sorted(loaded[0], key=query_sort_key)}
+    warm_per_query = {
+        query: statistics.fmean(result[query][0] for result in loaded[1:])
+        for query in sorted(loaded[0], key=query_sort_key)
+    }
+    return {
+        "mode": "cache_on_cold_fill_and_warm_reuse",
+        "sources": [str(path) for path in paths],
+        "cold_fill": {
+            "per_query_ms": cold_per_query,
+            "suite_runtime_ms": sum(cold_per_query.values()),
+            "suite_runtime_seconds": sum(cold_per_query.values()) / 1000,
+        },
+        "warm_reuse": {
+            "measured_suite_passes": 4,
+            "per_query_mean_ms": warm_per_query,
+            "suite_runtime_ms": sum(warm_per_query.values()),
+            "suite_runtime_seconds": sum(warm_per_query.values()) / 1000,
+        },
+    }
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    modes = parser.add_mutually_exclusive_group(required=True)
+    modes.add_argument("--baseline", type=Path, metavar="RESULT")
+    modes.add_argument(
+        "--cache-series",
+        type=Path,
+        nargs=5,
+        metavar=("COLD", "WARM1", "WARM2", "WARM3", "WARM4"),
+    )
+    parser.add_argument("--output", type=Path)
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    try:
+        summary = baseline(args.baseline) if args.baseline else cache_series(args.cache_series)
+    except (OSError, ValueError, json.JSONDecodeError) as error:
+        raise SystemExit(f"error: {error}") from error
+    rendered = json.dumps(summary, indent=2, sort_keys=True) + "\n"
+    if args.output:
+        args.output.write_text(rendered)
+    else:
+        print(rendered, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/presto/aws/ec2/test_aws_cluster.py
+++ b/presto/aws/ec2/test_aws_cluster.py
@@ -1,0 +1,223 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import contextlib
+import io
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import aws_cluster
+import summarize_results
+
+
+def valid_config() -> dict[str, str]:
+    return {
+        "AWS_PROFILE": "",
+        "AWS_REGION": "us-east-2",
+        "AMI_ID": "ami-example",
+        "SUBNET_ID": "subnet-example",
+        "SECURITY_GROUP_ID": "sg-example",
+        "IAM_INSTANCE_PROFILE": "benchmark-role",
+        "COORDINATOR_INSTANCE_TYPE": "m7a.4xlarge",
+        "WORKER_INSTANCE_TYPE": "m7a.4xlarge",
+        "WORKER_COUNT": "8",
+        "ROOT_VOLUME_GIB": "100",
+        "VELOX_TESTING_REPOSITORY": "https://example.com/velox-testing.git",
+        "VELOX_TESTING_FETCH_REF": "refs/heads/example",
+        "VELOX_TESTING_REF": "d" * 40,
+        "COORDINATOR_IMAGE": "example/coordinator@sha256:abc",
+        "WORKER_IMAGE": "example/worker@sha256:def",
+        "HIVE_METASTORE_S3_URI": "s3://example/metastore/",
+        "SCHEMA_NAME": "tpch_sf1k",
+        "RESULTS_S3_ROOT": "s3://example/results",
+        "VCPU_PER_WORKER": "16",
+        "TASK_MAX_DRIVERS_PER_TASK": "16",
+        "HIVE_MAX_SPLIT_SIZE": "256MB",
+        "HIVE_SPLIT_LOADER_CONCURRENCY": "32",
+        "DYNAMIC_FILTERING_ENABLED": "false",
+        "CPU_EXCHANGE_TUNING_ENABLED": "true",
+        "COORDINATOR_HEAP_GIB": "16",
+        "COORDINATOR_HEADROOM_GIB": "4",
+        "COORDINATOR_QUERY_TOTAL_MEMORY_PER_NODE_GIB": "12",
+        "COORDINATOR_QUERY_MEMORY_PER_NODE_GIB": "10",
+        "WORKER_SYSTEM_MEMORY_GIB": "50",
+        "WORKER_QUERY_MEMORY_GIB": "44",
+        "WORKER_MEMORY_LIMIT_GIB": "54",
+        "WORKER_MEMORY_SHRINK_GIB": "16",
+        "ASYNC_DATA_CACHE_ENABLED": "false",
+        "ASYNC_CACHE_SSD_GIB": "0",
+        "ASYNC_CACHE_SSD_PATH": "",
+        "ASYNC_CACHE_NUM_SHARDS": "16",
+        "OWNER": "tester",
+        "EXPIRY_HOURS": "8",
+        "SSM_READY_TIMEOUT_SECONDS": "900",
+        "SSM_COMMAND_TIMEOUT_SECONDS": "21600",
+        "WORKER_READY_TIMEOUT_SECONDS": "600",
+        "PLACEMENT_GROUP": "",
+    }
+
+
+class EnvTest(unittest.TestCase):
+    def test_load_env_handles_comments_and_quotes(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "config.env"
+            path.write_text("# comment\nA=one\nB='two words'\n\n")
+            self.assertEqual(aws_cluster.load_env(path), {"A": "one", "B": "two words"})
+
+    def test_load_env_rejects_non_assignments(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "config.env"
+            path.write_text("not an assignment\n")
+            with self.assertRaises(aws_cluster.ClusterError):
+                aws_cluster.load_env(path)
+
+
+class ClusterTest(unittest.TestCase):
+    def make_cluster(self, config: dict[str, str] | None = None, workers: int = 8) -> aws_cluster.Cluster:
+        return aws_cluster.Cluster(
+            config or valid_config(),
+            run_id="test-run",
+            workers=workers,
+            state_root=Path("/tmp/unused-state"),
+            dry_run=True,
+        )
+
+    def test_validation_accepts_supported_shapes(self) -> None:
+        for workers in (1, 2, 8, 16, 32):
+            self.make_cluster(workers=workers).validate()
+
+    def test_validation_accepts_role_specific_amis(self) -> None:
+        config = valid_config()
+        config["AMI_ID"] = ""
+        config["COORDINATOR_AMI_ID"] = "ami-x86"
+        config["WORKER_AMI_ID"] = "ami-arm"
+        cluster = self.make_cluster(config)
+        cluster.validate()
+        self.assertEqual(cluster.resolve_ami("coordinator"), "ami-x86")
+        self.assertEqual(cluster.resolve_ami("worker"), "ami-arm")
+
+    def test_validation_rejects_unplanned_shape(self) -> None:
+        with self.assertRaisesRegex(aws_cluster.ClusterError, "worker count"):
+            self.make_cluster(workers=3).validate()
+
+    def test_validation_rejects_unsafe_worker_memory(self) -> None:
+        config = valid_config()
+        config["WORKER_QUERY_MEMORY_GIB"] = "50"
+        with self.assertRaisesRegex(aws_cluster.ClusterError, "must be less"):
+            self.make_cluster(config).validate()
+
+    def test_validation_rejects_coordinator_memory_larger_than_heap(self) -> None:
+        config = valid_config()
+        config["COORDINATOR_QUERY_TOTAL_MEMORY_PER_NODE_GIB"] = "13"
+        with self.assertRaisesRegex(aws_cluster.ClusterError, "must be at least"):
+            self.make_cluster(config).validate()
+
+    def test_validation_requires_complete_harness_bundle_identity(self) -> None:
+        config = valid_config()
+        config["HARNESS_BUNDLE_S3_URI"] = "s3://example/harness.tar.gz"
+        with self.assertRaisesRegex(aws_cluster.ClusterError, "set both"):
+            self.make_cluster(config).validate()
+
+    def test_launch_dry_run_is_two_idempotent_fleet_calls(self) -> None:
+        output = io.StringIO()
+        with contextlib.redirect_stdout(output):
+            self.make_cluster().launch()
+        rendered = output.getvalue()
+        self.assertEqual(rendered.count("ec2 run-instances"), 2)
+        self.assertIn("--client-token test-run-coordinator", rendered)
+        self.assertIn("--client-token test-run-worker", rendered)
+        self.assertIn("--count 8", rendered)
+        self.assertIn("HttpTokens=required", rendered)
+        self.assertNotIn("terminate-instances", rendered)
+
+    def test_tags_scope_resources_to_run(self) -> None:
+        tags = {item["Key"]: item["Value"] for item in self.make_cluster().tags("worker", "2026-08-25T00:00:00+00:00")}
+        self.assertEqual(tags["Project"], "cudf-performance")
+        self.assertEqual(tags["Experiment"], "20260824_aws_102")
+        self.assertEqual(tags["RunId"], "test-run")
+        self.assertEqual(tags["Role"], "worker")
+
+    def test_inventory_filters_by_owner_before_destructive_use(self) -> None:
+        cluster = self.make_cluster()
+        calls: list[list[str]] = []
+
+        def fake_run(arguments: list[str], **_: object) -> dict[str, list[object]]:
+            calls.append(arguments)
+            return {"Reservations": []}
+
+        cluster.aws.run = fake_run  # type: ignore[method-assign]
+        self.assertEqual(cluster.inventory(), [])
+        rendered = " ".join(calls[0])
+        self.assertIn("Name=tag:RunId,Values=test-run", rendered)
+        self.assertIn("Name=tag:Owner,Values=tester", rendered)
+
+    def test_remote_env_contains_fixed_scale_rules(self) -> None:
+        rendered = self.make_cluster(workers=16).remote_env("10.0.0.1", "worker", 3)
+        self.assertIn("WORKER_COUNT=16", rendered)
+        self.assertIn("WORKER_INDEX=3", rendered)
+        self.assertIn("COORDINATOR_ADDRESS=10.0.0.1", rendered)
+        self.assertIn("ASYNC_DATA_CACHE_ENABLED=false", rendered)
+        self.assertIn("TASK_MAX_DRIVERS_PER_TASK=16", rendered)
+        self.assertIn("HIVE_MAX_SPLIT_SIZE=256MB", rendered)
+
+    def test_validation_rejects_invalid_cpu_tuning_values(self) -> None:
+        config = valid_config()
+        config["HIVE_MAX_SPLIT_SIZE"] = "256"
+        with self.assertRaisesRegex(aws_cluster.ClusterError, "integer number of MB"):
+            self.make_cluster(config).validate()
+
+        config = valid_config()
+        config["CPU_EXCHANGE_TUNING_ENABLED"] = "yes"
+        with self.assertRaisesRegex(aws_cluster.ClusterError, "true or false"):
+            self.make_cluster(config).validate()
+
+    def test_ssm_dry_run_sets_long_execution_timeout(self) -> None:
+        output = io.StringIO()
+        with contextlib.redirect_stdout(output):
+            self.make_cluster().send_command(["i-example"], ["sleep 7200"], "long benchmark")
+        rendered = output.getvalue()
+        self.assertIn("executionTimeout", rendered)
+        self.assertIn("21600", rendered)
+
+
+class SummaryTest(unittest.TestCase):
+    def write_result(self, directory: str, name: str, raw: dict[str, list[int]]) -> Path:
+        path = Path(directory) / name
+        path.write_text(json.dumps({"tpch": {"raw_times_ms": raw, "failed_queries": {}}}))
+        return path
+
+    def test_baseline_discards_first_iteration(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            path = self.write_result(
+                directory,
+                "baseline.json",
+                {"Q1": [100, 20, 30, 40, 50], "Q2": [200, 10, 20, 30, 40]},
+            )
+            summary = summarize_results.baseline(path)
+            self.assertEqual(summary["per_query_mean_ms"], {"Q1": 35, "Q2": 25})
+            self.assertEqual(summary["suite_runtime_ms"], 60)
+
+    def test_cache_series_uses_four_suite_major_passes(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            paths = [
+                self.write_result(
+                    directory,
+                    f"pass-{index}.json",
+                    {"Q1": [100 - index * 10], "Q2": [200 - index * 20]},
+                )
+                for index in range(5)
+            ]
+            summary = summarize_results.cache_series(paths)
+            self.assertEqual(summary["cold_fill"]["suite_runtime_ms"], 300)
+            self.assertEqual(summary["warm_reuse"]["per_query_mean_ms"]["Q1"], 75)
+            self.assertEqual(summary["warm_reuse"]["suite_runtime_ms"], 225)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/presto/docker/config/template/etc_coordinator/catalog/hive.properties
+++ b/presto/docker/config/template/etc_coordinator/catalog/hive.properties
@@ -39,8 +39,9 @@ hive.split-loader-concurrency=16
 # Affinity scheduling
 hive.node-selection-strategy=SOFT_AFFINITY
 
-# AWS S3
-hive.s3.endpoint=s3.us-east-2.amazonaws.com
+# AWS S3. The region (and thus the endpoint) is resolved from the AWS_DEFAULT_REGION
+# env var that docker-compose passes into the container — the single source of truth.
+# No hardcoded hive.s3.endpoint here, so it can't drift from the configured region.
 hive.s3.ssl.enabled=true
 hive.s3.path-style-access=false
 hive.s3.use-instance-credentials=false

--- a/presto/docker/config/template/etc_coordinator/catalog/hive.properties
+++ b/presto/docker/config/template/etc_coordinator/catalog/hive.properties
@@ -38,3 +38,9 @@ hive.split-loader-concurrency=16
 
 # Affinity scheduling
 hive.node-selection-strategy=SOFT_AFFINITY
+
+# AWS S3
+hive.s3.endpoint=s3.us-east-2.amazonaws.com
+hive.s3.ssl.enabled=true
+hive.s3.path-style-access=false
+hive.s3.use-instance-credentials=false

--- a/presto/docker/config/template/etc_worker/catalog/hive.properties
+++ b/presto/docker/config/template/etc_worker/catalog/hive.properties
@@ -14,9 +14,7 @@ hive.metastore.catalog.dir=file:/var/lib/presto/data/hive/metastore
 # state and clean up artifacts without manual intervention.
 hive.allow-drop-table=true
 
-# AWS S3. The region (and thus the endpoint) is resolved from the AWS_DEFAULT_REGION
-# env var that docker-compose passes into the container — the single source of truth.
-# No hardcoded hive.s3.endpoint here, so it can't drift from the configured region.
+# AWS S3.
 hive.s3.ssl.enabled=true
 hive.s3.path-style-access=false
-hive.s3.use-instance-credentials=false
+

--- a/presto/docker/config/template/etc_worker/catalog/hive.properties
+++ b/presto/docker/config/template/etc_worker/catalog/hive.properties
@@ -17,4 +17,3 @@ hive.allow-drop-table=true
 # AWS S3.
 hive.s3.ssl.enabled=true
 hive.s3.path-style-access=false
-

--- a/presto/docker/config/template/etc_worker/catalog/hive.properties
+++ b/presto/docker/config/template/etc_worker/catalog/hive.properties
@@ -14,8 +14,9 @@ hive.metastore.catalog.dir=file:/var/lib/presto/data/hive/metastore
 # state and clean up artifacts without manual intervention.
 hive.allow-drop-table=true
 
-# AWS S3
-hive.s3.endpoint=s3.us-east-2.amazonaws.com
+# AWS S3. The region (and thus the endpoint) is resolved from the AWS_DEFAULT_REGION
+# env var that docker-compose passes into the container — the single source of truth.
+# No hardcoded hive.s3.endpoint here, so it can't drift from the configured region.
 hive.s3.ssl.enabled=true
 hive.s3.path-style-access=false
 hive.s3.use-instance-credentials=false

--- a/presto/docker/config/template/etc_worker/catalog/hive.properties
+++ b/presto/docker/config/template/etc_worker/catalog/hive.properties
@@ -13,3 +13,9 @@ hive.metastore.catalog.dir=file:/var/lib/presto/data/hive/metastore
 # Allow DROP TABLE statements. Enabled to make smoke/perf tests able to reset
 # state and clean up artifacts without manual intervention.
 hive.allow-drop-table=true
+
+# AWS S3
+hive.s3.endpoint=s3.us-east-2.amazonaws.com
+hive.s3.ssl.enabled=true
+hive.s3.path-style-access=false
+hive.s3.use-instance-credentials=false

--- a/presto/docker/docker-compose.common.yml
+++ b/presto/docker/docker-compose.common.yml
@@ -22,9 +22,15 @@ services:
       - 8080:8080
     environment:
       - SERVER_START_TIMESTAMP=${SERVER_START_TIMESTAMP:-}
+      - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID:-}
+      - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY:-}
+      - AWS_SESSION_TOKEN=${AWS_SESSION_TOKEN:-}
+      # Region for the AWS default chain. Must match the data bucket / hive.s3.endpoint.
+      - AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION:-us-east-2}
+      - AWS_REGION=${AWS_REGION:-us-east-2}
     volumes:
       - ./launch_coordinator.sh:/opt/launch_coordinator.sh:ro
-    entrypoint: ["bash", "/opt/launch_coordinator.sh"]
+    entrypoint: [ "bash", "/opt/launch_coordinator.sh" ]
     command: []
 
   presto-base-native-worker:
@@ -44,3 +50,10 @@ services:
     environment:
       - GLOG_logtostderr=1
       - SERVER_START_TIMESTAMP=${SERVER_START_TIMESTAMP:-}
+      - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID:-}
+      - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY:-}
+      - AWS_SESSION_TOKEN=${AWS_SESSION_TOKEN:-}
+      # KvikIO's S3 endpoint builds https://<bucket>.s3.<region>.amazonaws.com/<obj>
+      # from an s3:// URL and REQUIRES a region. Must match the data bucket / hive.s3.endpoint.
+      - AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION:-us-east-2}
+      - AWS_REGION=${AWS_REGION:-us-east-2}

--- a/presto/docker/docker-compose.common.yml
+++ b/presto/docker/docker-compose.common.yml
@@ -25,9 +25,8 @@ services:
       - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID:-}
       - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY:-}
       - AWS_SESSION_TOKEN=${AWS_SESSION_TOKEN:-}
-      # Region for the AWS default chain. Must match the data bucket / hive.s3.endpoint.
-      - AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION:-us-east-2}
-      - AWS_REGION=${AWS_REGION:-us-east-2}
+      - AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION:-}
+      - AWS_REGION=${AWS_REGION:-}
     volumes:
       - ./launch_coordinator.sh:/opt/launch_coordinator.sh:ro
     entrypoint: [ "bash", "/opt/launch_coordinator.sh" ]
@@ -53,7 +52,5 @@ services:
       - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID:-}
       - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY:-}
       - AWS_SESSION_TOKEN=${AWS_SESSION_TOKEN:-}
-      # KvikIO's S3 endpoint builds https://<bucket>.s3.<region>.amazonaws.com/<obj>
-      # from an s3:// URL and REQUIRES a region. Must match the data bucket / hive.s3.endpoint.
-      - AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION:-us-east-2}
-      - AWS_REGION=${AWS_REGION:-us-east-2}
+      - AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION:-}
+      - AWS_REGION=${AWS_REGION:-}

--- a/presto/scripts/register_external_tables.sh
+++ b/presto/scripts/register_external_tables.sh
@@ -11,8 +11,8 @@ print_help() {
 Usage: $0 [OPTIONS]
 
 Registers benchmark external tables in a Presto Hive schema whose data lives at an
-arbitrary EXTERNAL_LOCATION URI. The location scheme is not interpreted here, so any
-URI works (e.g. file:, s3://).
+EXTERNAL_LOCATION URI (e.g. s3://, file:). Each table's column types are derived from
+the Parquet at the location (via DuckDB).
 
 The tables are created with EXTERNAL_LOCATION = <base>/<table_name>, where <base>
 is the --external-location-base value (which must already include the scale-factor
@@ -129,11 +129,30 @@ set_presto_coordinator_defaults
 source "${SCRIPT_DIR}/common_functions.sh"
 wait_for_worker_node_registration "$HOST_NAME" "$PORT"
 
-SCHEMAS_DIR=$(readlink -f "${SCRIPT_DIR}/../testing/common/schemas/${BENCHMARK_TYPE}")
+STATIC_SCHEMAS_DIR=$(readlink -f "${SCRIPT_DIR}/../testing/common/schemas/${BENCHMARK_TYPE}")
+mapfile -t TABLE_NAMES < <(cd "$STATIC_SCHEMAS_DIR" && ls -1 *.sql | sed 's/\.sql$//')
+
+SCHEMA_GEN_SCRIPT_PATH=$(readlink -f "${SCRIPT_DIR}/../../benchmark_data_tools/generate_table_schemas.py")
 CREATE_TABLES_SCRIPT_PATH=$(readlink -f "${SCRIPT_DIR}/../testing/integration_tests/create_hive_tables.py")
 REQUIREMENTS_PATH=$(readlink -f "${SCRIPT_DIR}/../testing/requirements.txt")
 
+TEMP_SCHEMA_DIR=$(readlink -f "${SCRIPT_DIR}/temp-external-schema-dir")
+function cleanup() {
+  rm -rf "$TEMP_SCHEMA_DIR"
+}
+trap cleanup EXIT
+rm -rf "$TEMP_SCHEMA_DIR"
+
 echo "Registering ${BENCHMARK_TYPE} tables in schema '${SCHEMA_NAME}' at base: ${EXTERNAL_LOCATION_BASE}"
+
+"${SCRIPT_DIR}/../../scripts/run_py_script.sh" \
+  -p "$SCHEMA_GEN_SCRIPT_PATH" \
+  -r "$REQUIREMENTS_PATH" \
+  -- \
+  --benchmark-type "$BENCHMARK_TYPE" \
+  --schemas-dir-path "$TEMP_SCHEMA_DIR" \
+  --external-location-base "$EXTERNAL_LOCATION_BASE" \
+  --table-names "${TABLE_NAMES[@]}"
 
 # HOSTNAME/PORT are read by create_hive_tables.py to connect to the coordinator.
 HOSTNAME="$HOST_NAME" PORT="$PORT" "${SCRIPT_DIR}/../../scripts/run_py_script.sh" \
@@ -141,7 +160,7 @@ HOSTNAME="$HOST_NAME" PORT="$PORT" "${SCRIPT_DIR}/../../scripts/run_py_script.sh
   -r "$REQUIREMENTS_PATH" \
   -- \
   --schema-name "$SCHEMA_NAME" \
-  --schemas-dir-path "$SCHEMAS_DIR" \
+  --schemas-dir-path "$TEMP_SCHEMA_DIR" \
   --external-location-base "$EXTERNAL_LOCATION_BASE"
 
 echo "Done registering ${BENCHMARK_TYPE} external tables in hive.${SCHEMA_NAME}"

--- a/presto/scripts/register_external_tables.sh
+++ b/presto/scripts/register_external_tables.sh
@@ -1,0 +1,147 @@
+#!/bin/bash
+
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+# SPDX-License-Identifier: Apache-2.0
+
+set -e
+
+print_help() {
+  cat << EOF
+
+Usage: $0 [OPTIONS]
+
+Registers benchmark external tables in a Presto Hive schema whose data lives at an
+arbitrary EXTERNAL_LOCATION URI. The location scheme is not interpreted here, so any
+URI works (e.g. file:, s3://).
+
+The tables are created with EXTERNAL_LOCATION = <base>/<table_name>, where <base>
+is the --external-location-base value (which must already include the scale-factor
+directory, e.g. s3://bucket/prefix/sf100).
+
+NOTE: This script assumes a Presto server is already running.
+
+OPTIONS:
+    -h, --help                      Show this help message.
+    -b, --benchmark-type            Benchmark type: "tpch" or "tpcds" (required).
+    -s, --schema-name               Name of the Hive schema to (re)create tables in (required).
+                                    The schema is dropped and recreated.
+    -l, --external-location-base    Full URI base that contains one subdirectory per table,
+                                    e.g. s3://my-bucket/velox/sf100 (required). "/<table_name>"
+                                    will be appended per table.
+    -H, --hostname                  Hostname of the Presto coordinator (default: localhost).
+    -p, --port                      Port number of the Presto coordinator (default: 8080).
+
+EXAMPLES:
+    $0 -b tpch -s tpch_sf100_s3 -l s3://my-bucket/velox/sf100
+    $0 --benchmark-type tpch --schema-name tpch_sf100_s3 \\
+       --external-location-base s3://my-bucket/velox/sf100 -H localhost -p 8080
+
+EOF
+}
+
+parse_args() {
+  while [[ $# -gt 0 ]]; do
+    case $1 in
+      -h|--help)
+        print_help
+        exit 0
+        ;;
+      -b|--benchmark-type)
+        if [[ -n $2 ]]; then
+          BENCHMARK_TYPE=$2
+          shift 2
+        else
+          echo "Error: --benchmark-type requires a value"
+          exit 1
+        fi
+        ;;
+      -s|--schema-name)
+        if [[ -n $2 ]]; then
+          SCHEMA_NAME=$2
+          shift 2
+        else
+          echo "Error: --schema-name requires a value"
+          exit 1
+        fi
+        ;;
+      -l|--external-location-base)
+        if [[ -n $2 ]]; then
+          EXTERNAL_LOCATION_BASE=$2
+          shift 2
+        else
+          echo "Error: --external-location-base requires a value"
+          exit 1
+        fi
+        ;;
+      -H|--hostname)
+        if [[ -n $2 ]]; then
+          HOST_NAME=$2
+          shift 2
+        else
+          echo "Error: --hostname requires a value"
+          exit 1
+        fi
+        ;;
+      -p|--port)
+        if [[ -n $2 ]]; then
+          PORT=$2
+          shift 2
+        else
+          echo "Error: --port requires a value"
+          exit 1
+        fi
+        ;;
+      *)
+        echo "Error: Unknown argument $1"
+        print_help
+        exit 1
+        ;;
+    esac
+  done
+}
+
+parse_args "$@"
+
+if [[ -z ${BENCHMARK_TYPE} || ! ${BENCHMARK_TYPE} =~ ^tpc(h|ds)$ ]]; then
+  echo "Error: A valid benchmark type (tpch or tpcds) is required. Use the -b or --benchmark-type argument."
+  print_help
+  exit 1
+fi
+
+if [[ -z ${SCHEMA_NAME} ]]; then
+  echo "Error: A schema name is required. Use the -s or --schema-name argument."
+  print_help
+  exit 1
+fi
+
+if [[ -z ${EXTERNAL_LOCATION_BASE} ]]; then
+  echo "Error: An external location base is required. Use the -l or --external-location-base argument."
+  print_help
+  exit 1
+fi
+
+# Compute the directory where this script resides
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+source "${SCRIPT_DIR}/presto_connection_defaults.sh"
+set_presto_coordinator_defaults
+
+source "${SCRIPT_DIR}/common_functions.sh"
+wait_for_worker_node_registration "$HOST_NAME" "$PORT"
+
+SCHEMAS_DIR=$(readlink -f "${SCRIPT_DIR}/../testing/common/schemas/${BENCHMARK_TYPE}")
+CREATE_TABLES_SCRIPT_PATH=$(readlink -f "${SCRIPT_DIR}/../testing/integration_tests/create_hive_tables.py")
+REQUIREMENTS_PATH=$(readlink -f "${SCRIPT_DIR}/../testing/requirements.txt")
+
+echo "Registering ${BENCHMARK_TYPE} tables in schema '${SCHEMA_NAME}' at base: ${EXTERNAL_LOCATION_BASE}"
+
+# HOSTNAME/PORT are read by create_hive_tables.py to connect to the coordinator.
+HOSTNAME="$HOST_NAME" PORT="$PORT" "${SCRIPT_DIR}/../../scripts/run_py_script.sh" \
+  -p "$CREATE_TABLES_SCRIPT_PATH" \
+  -r "$REQUIREMENTS_PATH" \
+  -- \
+  --schema-name "$SCHEMA_NAME" \
+  --schemas-dir-path "$SCHEMAS_DIR" \
+  --external-location-base "$EXTERNAL_LOCATION_BASE"
+
+echo "Done registering ${BENCHMARK_TYPE} external tables in hive.${SCHEMA_NAME}"

--- a/presto/scripts/run_benchmark.sh
+++ b/presto/scripts/run_benchmark.sh
@@ -24,6 +24,8 @@ This script runs the specified type of benchmark.
 OPTIONS:
     -h, --help              Show this help message.
     -b, --benchmark-type    Type of benchmark to run. Only "tpch" and "tpcds" are currently supported.
+    -f, --scale-factor      Scale factor of the benchmark data. Required for remote (e.g. S3) tables to
+                            skip reading a local metadata.json to derive it. Optional for local tables.
     -q, --queries           Set of benchmark queries to run. This should be a comma separate list of query numbers.
                             By default, all benchmark queries are run.
     --queries-file          Path to a custom JSON file containing query definitions. When specified, queries are loaded
@@ -95,6 +97,15 @@ parse_args() {
           shift 2
         else
           echo "Error: --queries requires a value"
+          exit 1
+        fi
+        ;;
+      -f|--scale-factor)
+        if [[ -n $2 ]]; then
+          SCALE_FACTOR=$2
+          shift 2
+        else
+          echo "Error: --scale-factor requires a value"
           exit 1
         fi
         ;;
@@ -245,6 +256,10 @@ PYTEST_ARGS=("--schema-name ${SCHEMA_NAME}")
 
 if [[ -n ${QUERIES} ]]; then
   PYTEST_ARGS+=("--queries ${QUERIES}")
+fi
+
+if [[ -n ${SCALE_FACTOR} ]]; then
+  PYTEST_ARGS+=("--scale-factor ${SCALE_FACTOR}")
 fi
 
 if [[ -n ${QUERIES_FILE} ]]; then

--- a/presto/scripts/run_benchmark.sh
+++ b/presto/scripts/run_benchmark.sh
@@ -24,8 +24,6 @@ This script runs the specified type of benchmark.
 OPTIONS:
     -h, --help              Show this help message.
     -b, --benchmark-type    Type of benchmark to run. Only "tpch" and "tpcds" are currently supported.
-    -f, --scale-factor      Scale factor of the benchmark data. Required for remote (e.g. S3) tables to
-                            skip reading a local metadata.json to derive it. Optional for local tables.
     -q, --queries           Set of benchmark queries to run. This should be a comma separate list of query numbers.
                             By default, all benchmark queries are run.
     --queries-file          Path to a custom JSON file containing query definitions. When specified, queries are loaded
@@ -97,15 +95,6 @@ parse_args() {
           shift 2
         else
           echo "Error: --queries requires a value"
-          exit 1
-        fi
-        ;;
-      -f|--scale-factor)
-        if [[ -n $2 ]]; then
-          SCALE_FACTOR=$2
-          shift 2
-        else
-          echo "Error: --scale-factor requires a value"
           exit 1
         fi
         ;;
@@ -256,10 +245,6 @@ PYTEST_ARGS=("--schema-name ${SCHEMA_NAME}")
 
 if [[ -n ${QUERIES} ]]; then
   PYTEST_ARGS+=("--queries ${QUERIES}")
-fi
-
-if [[ -n ${SCALE_FACTOR} ]]; then
-  PYTEST_ARGS+=("--scale-factor ${SCALE_FACTOR}")
 fi
 
 if [[ -n ${QUERIES_FILE} ]]; then

--- a/presto/testing/common/schemas/tpcds/call_center.sql
+++ b/presto/testing/common/schemas/tpcds/call_center.sql
@@ -30,4 +30,4 @@ CREATE TABLE hive.{schema}.call_center (
     cc_country VARCHAR,
     cc_gmt_offset DOUBLE,
     cc_tax_percentage DOUBLE
-) WITH (FORMAT = 'PARQUET', EXTERNAL_LOCATION = 'file:{file_path}')
+) WITH (FORMAT = 'PARQUET', EXTERNAL_LOCATION = '{location}')

--- a/presto/testing/common/schemas/tpcds/catalog_page.sql
+++ b/presto/testing/common/schemas/tpcds/catalog_page.sql
@@ -8,4 +8,4 @@ CREATE TABLE hive.{schema}.catalog_page (
     cp_catalog_page_number INTEGER,
     cp_description VARCHAR,
     cp_type VARCHAR
-) WITH (FORMAT = 'PARQUET', EXTERNAL_LOCATION = 'file:{file_path}')
+) WITH (FORMAT = 'PARQUET', EXTERNAL_LOCATION = '{location}')

--- a/presto/testing/common/schemas/tpcds/catalog_returns.sql
+++ b/presto/testing/common/schemas/tpcds/catalog_returns.sql
@@ -26,4 +26,4 @@ CREATE TABLE hive.{schema}.catalog_returns (
     cr_reversed_charge DOUBLE,
     cr_store_credit DOUBLE,
     cr_net_loss DOUBLE
-) WITH (FORMAT = 'PARQUET', EXTERNAL_LOCATION = 'file:{file_path}')
+) WITH (FORMAT = 'PARQUET', EXTERNAL_LOCATION = '{location}')

--- a/presto/testing/common/schemas/tpcds/catalog_sales.sql
+++ b/presto/testing/common/schemas/tpcds/catalog_sales.sql
@@ -33,4 +33,4 @@ CREATE TABLE hive.{schema}.catalog_sales (
     cs_net_paid_inc_ship DOUBLE,
     cs_net_paid_inc_ship_tax DOUBLE,
     cs_net_profit DOUBLE
-) WITH (FORMAT = 'PARQUET', EXTERNAL_LOCATION = 'file:{file_path}')
+) WITH (FORMAT = 'PARQUET', EXTERNAL_LOCATION = '{location}')

--- a/presto/testing/common/schemas/tpcds/customer.sql
+++ b/presto/testing/common/schemas/tpcds/customer.sql
@@ -17,4 +17,4 @@ CREATE TABLE hive.{schema}.customer (
     c_login VARCHAR,
     c_email_address VARCHAR,
     c_last_review_date_sk INTEGER
-) WITH (FORMAT = 'PARQUET', EXTERNAL_LOCATION = 'file:{file_path}')
+) WITH (FORMAT = 'PARQUET', EXTERNAL_LOCATION = '{location}')

--- a/presto/testing/common/schemas/tpcds/customer_address.sql
+++ b/presto/testing/common/schemas/tpcds/customer_address.sql
@@ -12,4 +12,4 @@ CREATE TABLE hive.{schema}.customer_address (
     ca_country VARCHAR,
     ca_gmt_offset DOUBLE,
     ca_location_type VARCHAR
-) WITH (FORMAT = 'PARQUET', EXTERNAL_LOCATION = 'file:{file_path}')
+) WITH (FORMAT = 'PARQUET', EXTERNAL_LOCATION = '{location}')

--- a/presto/testing/common/schemas/tpcds/customer_demographics.sql
+++ b/presto/testing/common/schemas/tpcds/customer_demographics.sql
@@ -8,4 +8,4 @@ CREATE TABLE hive.{schema}.customer_demographics (
     cd_dep_count INTEGER,
     cd_dep_employed_count INTEGER,
     cd_dep_college_count INTEGER
-) WITH (FORMAT = 'PARQUET', EXTERNAL_LOCATION = 'file:{file_path}')
+) WITH (FORMAT = 'PARQUET', EXTERNAL_LOCATION = '{location}')

--- a/presto/testing/common/schemas/tpcds/date_dim.sql
+++ b/presto/testing/common/schemas/tpcds/date_dim.sql
@@ -27,4 +27,4 @@ CREATE TABLE hive.{schema}.date_dim (
     d_current_month VARCHAR,
     d_current_quarter VARCHAR,
     d_current_year VARCHAR
-) WITH (FORMAT = 'PARQUET', EXTERNAL_LOCATION = 'file:{file_path}')
+) WITH (FORMAT = 'PARQUET', EXTERNAL_LOCATION = '{location}')

--- a/presto/testing/common/schemas/tpcds/household_demographics.sql
+++ b/presto/testing/common/schemas/tpcds/household_demographics.sql
@@ -4,4 +4,4 @@ CREATE TABLE hive.{schema}.household_demographics (
     hd_buy_potential VARCHAR,
     hd_dep_count INTEGER,
     hd_vehicle_count INTEGER
-) WITH (FORMAT = 'PARQUET', EXTERNAL_LOCATION = 'file:{file_path}')
+) WITH (FORMAT = 'PARQUET', EXTERNAL_LOCATION = '{location}')

--- a/presto/testing/common/schemas/tpcds/income_band.sql
+++ b/presto/testing/common/schemas/tpcds/income_band.sql
@@ -2,4 +2,4 @@ CREATE TABLE hive.{schema}.income_band (
     ib_income_band_sk INTEGER,
     ib_lower_bound INTEGER,
     ib_upper_bound INTEGER
-) WITH (FORMAT = 'PARQUET', EXTERNAL_LOCATION = 'file:{file_path}')
+) WITH (FORMAT = 'PARQUET', EXTERNAL_LOCATION = '{location}')

--- a/presto/testing/common/schemas/tpcds/inventory.sql
+++ b/presto/testing/common/schemas/tpcds/inventory.sql
@@ -3,4 +3,4 @@ CREATE TABLE hive.{schema}.inventory (
     inv_item_sk INTEGER,
     inv_warehouse_sk INTEGER,
     inv_quantity_on_hand INTEGER
-) WITH (FORMAT = 'PARQUET', EXTERNAL_LOCATION = 'file:{file_path}')
+) WITH (FORMAT = 'PARQUET', EXTERNAL_LOCATION = '{location}')

--- a/presto/testing/common/schemas/tpcds/item.sql
+++ b/presto/testing/common/schemas/tpcds/item.sql
@@ -21,4 +21,4 @@ CREATE TABLE hive.{schema}.item (
     i_container VARCHAR,
     i_manager_id INTEGER,
     i_product_name VARCHAR
-) WITH (FORMAT = 'PARQUET', EXTERNAL_LOCATION = 'file:{file_path}')
+) WITH (FORMAT = 'PARQUET', EXTERNAL_LOCATION = '{location}')

--- a/presto/testing/common/schemas/tpcds/promotion.sql
+++ b/presto/testing/common/schemas/tpcds/promotion.sql
@@ -18,4 +18,4 @@ CREATE TABLE hive.{schema}.promotion (
     p_channel_details VARCHAR,
     p_purpose VARCHAR,
     p_discount_active VARCHAR
-) WITH (FORMAT = 'PARQUET', EXTERNAL_LOCATION = 'file:{file_path}')
+) WITH (FORMAT = 'PARQUET', EXTERNAL_LOCATION = '{location}')

--- a/presto/testing/common/schemas/tpcds/reason.sql
+++ b/presto/testing/common/schemas/tpcds/reason.sql
@@ -2,4 +2,4 @@ CREATE TABLE hive.{schema}.reason (
     r_reason_sk INTEGER,
     r_reason_id VARCHAR,
     r_reason_desc VARCHAR
-) WITH (FORMAT = 'PARQUET', EXTERNAL_LOCATION = 'file:{file_path}')
+) WITH (FORMAT = 'PARQUET', EXTERNAL_LOCATION = '{location}')

--- a/presto/testing/common/schemas/tpcds/ship_mode.sql
+++ b/presto/testing/common/schemas/tpcds/ship_mode.sql
@@ -5,4 +5,4 @@ CREATE TABLE hive.{schema}.ship_mode (
     sm_code VARCHAR,
     sm_carrier VARCHAR,
     sm_contract VARCHAR
-) WITH (FORMAT = 'PARQUET', EXTERNAL_LOCATION = 'file:{file_path}')
+) WITH (FORMAT = 'PARQUET', EXTERNAL_LOCATION = '{location}')

--- a/presto/testing/common/schemas/tpcds/store.sql
+++ b/presto/testing/common/schemas/tpcds/store.sql
@@ -28,4 +28,4 @@ CREATE TABLE hive.{schema}.store (
     s_country VARCHAR,
     s_gmt_offset DOUBLE,
     s_tax_percentage DOUBLE
-) WITH (FORMAT = 'PARQUET', EXTERNAL_LOCATION = 'file:{file_path}')
+) WITH (FORMAT = 'PARQUET', EXTERNAL_LOCATION = '{location}')

--- a/presto/testing/common/schemas/tpcds/store_returns.sql
+++ b/presto/testing/common/schemas/tpcds/store_returns.sql
@@ -19,4 +19,4 @@ CREATE TABLE hive.{schema}.store_returns (
     sr_reversed_charge DOUBLE,
     sr_store_credit DOUBLE,
     sr_net_loss DOUBLE
-) WITH (FORMAT = 'PARQUET', EXTERNAL_LOCATION = 'file:{file_path}')
+) WITH (FORMAT = 'PARQUET', EXTERNAL_LOCATION = '{location}')

--- a/presto/testing/common/schemas/tpcds/store_sales.sql
+++ b/presto/testing/common/schemas/tpcds/store_sales.sql
@@ -22,4 +22,4 @@ CREATE TABLE hive.{schema}.store_sales (
     ss_net_paid DOUBLE,
     ss_net_paid_inc_tax DOUBLE,
     ss_net_profit DOUBLE
-) WITH (FORMAT = 'PARQUET', EXTERNAL_LOCATION = 'file:{file_path}')
+) WITH (FORMAT = 'PARQUET', EXTERNAL_LOCATION = '{location}')

--- a/presto/testing/common/schemas/tpcds/time_dim.sql
+++ b/presto/testing/common/schemas/tpcds/time_dim.sql
@@ -9,4 +9,4 @@ CREATE TABLE hive.{schema}.time_dim (
     t_shift VARCHAR,
     t_sub_shift VARCHAR,
     t_meal_time VARCHAR
-) WITH (FORMAT = 'PARQUET', EXTERNAL_LOCATION = 'file:{file_path}')
+) WITH (FORMAT = 'PARQUET', EXTERNAL_LOCATION = '{location}')

--- a/presto/testing/common/schemas/tpcds/warehouse.sql
+++ b/presto/testing/common/schemas/tpcds/warehouse.sql
@@ -13,4 +13,4 @@ CREATE TABLE hive.{schema}.warehouse (
     w_zip VARCHAR,
     w_country VARCHAR,
     w_gmt_offset DOUBLE
-) WITH (FORMAT = 'PARQUET', EXTERNAL_LOCATION = 'file:{file_path}')
+) WITH (FORMAT = 'PARQUET', EXTERNAL_LOCATION = '{location}')

--- a/presto/testing/common/schemas/tpcds/web_page.sql
+++ b/presto/testing/common/schemas/tpcds/web_page.sql
@@ -13,4 +13,4 @@ CREATE TABLE hive.{schema}.web_page (
     wp_link_count INTEGER,
     wp_image_count INTEGER,
     wp_max_ad_count INTEGER
-) WITH (FORMAT = 'PARQUET', EXTERNAL_LOCATION = 'file:{file_path}')
+) WITH (FORMAT = 'PARQUET', EXTERNAL_LOCATION = '{location}')

--- a/presto/testing/common/schemas/tpcds/web_returns.sql
+++ b/presto/testing/common/schemas/tpcds/web_returns.sql
@@ -23,4 +23,4 @@ CREATE TABLE hive.{schema}.web_returns (
     wr_reversed_charge DOUBLE,
     wr_account_credit DOUBLE,
     wr_net_loss DOUBLE
-) WITH (FORMAT = 'PARQUET', EXTERNAL_LOCATION = 'file:{file_path}')
+) WITH (FORMAT = 'PARQUET', EXTERNAL_LOCATION = '{location}')

--- a/presto/testing/common/schemas/tpcds/web_sales.sql
+++ b/presto/testing/common/schemas/tpcds/web_sales.sql
@@ -33,4 +33,4 @@ CREATE TABLE hive.{schema}.web_sales (
     ws_net_paid_inc_ship DOUBLE,
     ws_net_paid_inc_ship_tax DOUBLE,
     ws_net_profit DOUBLE
-) WITH (FORMAT = 'PARQUET', EXTERNAL_LOCATION = 'file:{file_path}')
+) WITH (FORMAT = 'PARQUET', EXTERNAL_LOCATION = '{location}')

--- a/presto/testing/common/schemas/tpcds/web_site.sql
+++ b/presto/testing/common/schemas/tpcds/web_site.sql
@@ -25,4 +25,4 @@ CREATE TABLE hive.{schema}.web_site (
     web_country VARCHAR,
     web_gmt_offset DOUBLE,
     web_tax_percentage DOUBLE
-) WITH (FORMAT = 'PARQUET', EXTERNAL_LOCATION = 'file:{file_path}')
+) WITH (FORMAT = 'PARQUET', EXTERNAL_LOCATION = '{location}')

--- a/presto/testing/common/schemas/tpch/customer.sql
+++ b/presto/testing/common/schemas/tpch/customer.sql
@@ -7,4 +7,4 @@ CREATE TABLE hive.{schema}.customer (
     c_acctbal DECIMAL(15,2) NOT NULL,
     c_mktsegment VARCHAR NOT NULL,
     c_comment VARCHAR NOT NULL
-) WITH (FORMAT = 'PARQUET', EXTERNAL_LOCATION = 'file:{file_path}')
+) WITH (FORMAT = 'PARQUET', EXTERNAL_LOCATION = '{location}')

--- a/presto/testing/common/schemas/tpch/lineitem.sql
+++ b/presto/testing/common/schemas/tpch/lineitem.sql
@@ -15,4 +15,4 @@ CREATE TABLE hive.{schema}.lineitem (
     l_shipinstruct VARCHAR NOT NULL,
     l_shipmode VARCHAR NOT NULL,
     l_comment VARCHAR NOT NULL
-) WITH (FORMAT = 'PARQUET', EXTERNAL_LOCATION = 'file:{file_path}')
+) WITH (FORMAT = 'PARQUET', EXTERNAL_LOCATION = '{location}')

--- a/presto/testing/common/schemas/tpch/nation.sql
+++ b/presto/testing/common/schemas/tpch/nation.sql
@@ -3,4 +3,4 @@ CREATE TABLE hive.{schema}.nation (
     n_name VARCHAR NOT NULL,
     n_regionkey BIGINT NOT NULL,
     n_comment VARCHAR NOT NULL
-) WITH (FORMAT = 'PARQUET', EXTERNAL_LOCATION = 'file:{file_path}')
+) WITH (FORMAT = 'PARQUET', EXTERNAL_LOCATION = '{location}')

--- a/presto/testing/common/schemas/tpch/orders.sql
+++ b/presto/testing/common/schemas/tpch/orders.sql
@@ -8,4 +8,4 @@ CREATE TABLE hive.{schema}.orders (
     o_clerk VARCHAR NOT NULL,
     o_shippriority INTEGER NOT NULL,
     o_comment VARCHAR NOT NULL
-) WITH (FORMAT = 'PARQUET', EXTERNAL_LOCATION = 'file:{file_path}')
+) WITH (FORMAT = 'PARQUET', EXTERNAL_LOCATION = '{location}')

--- a/presto/testing/common/schemas/tpch/part.sql
+++ b/presto/testing/common/schemas/tpch/part.sql
@@ -8,4 +8,4 @@ CREATE TABLE hive.{schema}.part (
     p_container VARCHAR NOT NULL,
     p_retailprice DECIMAL(15,2) NOT NULL,
     p_comment VARCHAR NOT NULL
-) WITH (FORMAT = 'PARQUET', EXTERNAL_LOCATION = 'file:{file_path}')
+) WITH (FORMAT = 'PARQUET', EXTERNAL_LOCATION = '{location}')

--- a/presto/testing/common/schemas/tpch/partsupp.sql
+++ b/presto/testing/common/schemas/tpch/partsupp.sql
@@ -4,4 +4,4 @@ CREATE TABLE hive.{schema}.partsupp (
     ps_availqty INTEGER NOT NULL,
     ps_supplycost DECIMAL(15,2) NOT NULL,
     ps_comment VARCHAR NOT NULL
-) WITH (FORMAT = 'PARQUET', EXTERNAL_LOCATION = 'file:{file_path}')
+) WITH (FORMAT = 'PARQUET', EXTERNAL_LOCATION = '{location}')

--- a/presto/testing/common/schemas/tpch/region.sql
+++ b/presto/testing/common/schemas/tpch/region.sql
@@ -2,4 +2,4 @@ CREATE TABLE hive.{schema}.region (
     r_regionkey BIGINT NOT NULL,
     r_name VARCHAR NOT NULL,
     r_comment VARCHAR NOT NULL
-) WITH (FORMAT = 'PARQUET', EXTERNAL_LOCATION = 'file:{file_path}')
+) WITH (FORMAT = 'PARQUET', EXTERNAL_LOCATION = '{location}')

--- a/presto/testing/common/schemas/tpch/supplier.sql
+++ b/presto/testing/common/schemas/tpch/supplier.sql
@@ -6,4 +6,4 @@ CREATE TABLE hive.{schema}.supplier (
     s_phone VARCHAR NOT NULL,
     s_acctbal DECIMAL(15,2) NOT NULL,
     s_comment VARCHAR NOT NULL
-) WITH (FORMAT = 'PARQUET', EXTERNAL_LOCATION = 'file:{file_path}')
+) WITH (FORMAT = 'PARQUET', EXTERNAL_LOCATION = '{location}')

--- a/presto/testing/common/test_utils.py
+++ b/presto/testing/common/test_utils.py
@@ -3,37 +3,48 @@
 
 import os
 import re
+import sys
 
 import pytest
 
 from common.testing.test_utils import (
     get_abs_file_path,
     get_queries,  # noqa: F401
-    get_scale_factor_from_file,
 )
+
+sys.path.append(get_abs_file_path(__file__, "../../../benchmark_data_tools"))
 
 
 def get_table_external_location(schema_name, table, presto_cursor):
     create_table_text = presto_cursor.execute(f"SHOW CREATE TABLE hive.{schema_name}.{table}").fetchone()
-    test_pattern = r"external_location = 'file:/var/lib/presto/data/hive/data/integration_test/(.*)'"
-    user_pattern = r"external_location = 'file:/var/lib/presto/data/hive/data/user_data/(.*)'"
     assert len(create_table_text) == 1
-    test_match = re.search(test_pattern, create_table_text[0])
-    external_dir = ""
+    # Capture everything between two single quotes
+    location_match = re.search(r"external_location = '([^']*)'", create_table_text[0])
+    location = location_match.group(1) if location_match else ""
+    # For remote path
+    if location and not location.startswith("file:"):
+        return location
+    # For local path
+    test_match = re.search(r"^file:/var/lib/presto/data/hive/data/integration_test/(.*)$", location)
     if test_match:
         external_dir = get_abs_file_path(
             __file__, f"../../../common/testing/integration_tests/data/{test_match.group(1)}"
         )
     else:
-        user_match = re.search(user_pattern, create_table_text[0])
-        if user_match:
-            external_dir = f"{os.environ['PRESTO_DATA_DIR']}/{user_match.group(1)}"
+        user_match = re.search(r"^file:/var/lib/presto/data/hive/data/user_data/(.*)$", location)
+        external_dir = f"{os.environ['PRESTO_DATA_DIR']}/{user_match.group(1)}" if user_match else ""
     if not os.path.isdir(external_dir):
         raise Exception(
-            f"External location '{external_dir}' referenced by table hive.{schema_name}.{table} \
-does not exist"
+            f"External location '{external_dir}' referenced by table hive.{schema_name}.{table} does not exist"
         )
     return external_dir
+
+
+def read_scale_factor(metadata_uri):
+    """Read the scale factor from a metadata.json at metadata_uri (local path or s3://)."""
+    import duckdb_utils
+
+    return duckdb_utils.read_scale_factor(metadata_uri)
 
 
 def get_scale_factor(request, presto_cursor):
@@ -45,17 +56,18 @@ def get_scale_factor(request, presto_cursor):
     repository_path = ""
     if bool(schema_name):
         # If a schema name is specified, get the scale factor from the metadata file located
-        # where the table are fetching data from.
+        # where the table are fetching data from (can be local or remote).
         table = presto_cursor.execute(f"SHOW TABLES in {schema_name}").fetchone()[0]
         location = get_table_external_location(schema_name, table, presto_cursor)
         repository_path = os.path.dirname(location)
     else:
-        # default assumed location for metadata file.
         repository_path = get_abs_file_path(
             __file__, f"../../../common/testing/integration_tests/data/{benchmark_type}"
         )
     meta_file = f"{repository_path}/metadata.json"
-    if not os.path.exists(meta_file):
+    try:
+        return read_scale_factor(meta_file)
+    except Exception as error:
         raise pytest.UsageError(
             f"Could not find metadata file in data repository '{repository_path}'.\n"
             "Metadata file must be called 'metadata.json' and have the following format:\n"
@@ -63,5 +75,4 @@ def get_scale_factor(request, presto_cursor):
             '  "scale_factor": <scale_factor>\n'
             "}\n"
             "where <scale_factor> is a floating point number."
-        )
-    return get_scale_factor_from_file(meta_file)
+        ) from error

--- a/presto/testing/integration_tests/create_hive_tables.py
+++ b/presto/testing/integration_tests/create_hive_tables.py
@@ -77,5 +77,5 @@ if __name__ == "__main__":
         catalog="hive",
     )
     cursor = conn.cursor()
-    data_sub_directory = f"user_data/{args.data_dir_name}"
+    data_sub_directory = "" if args.external_location_base else f"user_data/{args.data_dir_name}"
     create_tables(cursor, args.schema_name, args.schemas_dir_path, data_sub_directory, args.external_location_base)

--- a/presto/testing/integration_tests/create_hive_tables.py
+++ b/presto/testing/integration_tests/create_hive_tables.py
@@ -7,17 +7,19 @@ import os
 import prestodb
 
 
-def create_tables(presto_cursor, schema_name, schemas_dir_path, data_sub_directory):
+def create_tables(presto_cursor, schema_name, schemas_dir_path, data_sub_directory, external_location_base=None):
     drop_schema(presto_cursor, schema_name)
     presto_cursor.execute(f"CREATE SCHEMA hive.{schema_name}")
 
     schemas = get_table_schemas(schemas_dir_path)
     for table_name, schema in schemas:
-        presto_cursor.execute(
-            schema.format(
-                file_path=f"/var/lib/presto/data/hive/data/{data_sub_directory}/{table_name}", schema=schema_name
-            )
-        )
+        # When external_location_base is set (e.g. s3://bucket/prefix/sf100), point the
+        # table at that base. Otherwise fall back to the local bind-mounted file path.
+        if external_location_base:
+            location = f"{external_location_base}/{table_name}"
+        else:
+            location = f"file:/var/lib/presto/data/hive/data/{data_sub_directory}/{table_name}"
+        presto_cursor.execute(schema.format(location=location, schema=schema_name))
 
 
 def get_table_schemas(schemas_dir):
@@ -51,7 +53,20 @@ if __name__ == "__main__":
         help="The path to the directory that will contain the schema files.",
     )
     parser.add_argument(
-        "--data-dir-name", type=str, required=True, help="The name of the directory that contains the benchmark data."
+        "--data-dir-name",
+        type=str,
+        required=False,
+        default="",
+        help="The name of the directory that contains the benchmark data. Only used to build the local "
+        "file: location. Not needed when --external-location-base is set.",
+    )
+    parser.add_argument(
+        "--external-location-base",
+        type=str,
+        required=False,
+        default=None,
+        help="Full URI base for the table EXTERNAL_LOCATION (e.g. s3://bucket/prefix/sf100). For each table "
+        "'/<table_name>' is appended. If omitted, the default local file: path is used.",
     )
     args = parser.parse_args()
 
@@ -63,4 +78,4 @@ if __name__ == "__main__":
     )
     cursor = conn.cursor()
     data_sub_directory = f"user_data/{args.data_dir_name}"
-    create_tables(cursor, args.schema_name, args.schemas_dir_path, data_sub_directory)
+    create_tables(cursor, args.schema_name, args.schemas_dir_path, data_sub_directory, args.external_location_base)

--- a/presto/testing/performance_benchmarks/run_context.py
+++ b/presto/testing/performance_benchmarks/run_context.py
@@ -8,7 +8,6 @@ read from worker log files (LOGS_DIR env var). Scale factor and n_workers come f
 schema and Presto /v1/node respectively.
 """
 
-import json
 import os
 import re
 from pathlib import Path
@@ -62,15 +61,12 @@ def _get_schema_info(hostname: str, port: int, user: str, schema_name: str) -> d
             return result
         table = tables[0][0]
         location = test_utils.get_table_external_location(schema_name, table, cursor)
-        meta_path = (Path(location).parent / "metadata.json").resolve()
-        if not meta_path.is_file():
-            return result
-        with open(meta_path) as f:
-            data = json.load(f)
-        sf = data.get("scale_factor") or data.get("options", {}).get("scale_factor")
+        # Use os.path instead of pathlib.Path to avoid messing up the remote path URI
+        parent = os.path.dirname(location)
+        sf = test_utils.read_scale_factor(f"{parent}/metadata.json")
         if sf is not None:
             result["scale_factor"] = sf
-        result["data_dir"] = str(Path(location).parent)
+        result["data_dir"] = parent
         return result
     except Exception as e:
         _debug(f"schema info lookup failed: {e}")


### PR DESCRIPTION
## Summary
- add an SSM-managed EC2 lifecycle for dedicated coordinators and distributed native workers
- support cache-off cold suites, AsyncDataCache warm suites, telemetry, artifact collection, and controlled CPU tuning
- support role-specific AMIs and images for mixed x86/ARM fleets

Depends on #376. Until that PR merges, this branch also contains its S3 commits; the final diff should be reviewed after rebasing onto `main`.

## Test plan
- [x] `python3 -m unittest presto.aws.ec2.test_aws_cluster`
- [x] `bash -n presto/aws/ec2/remote/configure_and_start.sh presto/aws/ec2/remote/collect_node.sh`
- [x] 8/16/32-worker M7a and M9gd cold SF1000 qualification
- [x] 8-worker M9gd cache-off, memory-cache, and memory+NVMe qualification
- [ ] 16/32-worker M9gd memory-cache qualification
- [ ] G7e GPU worker qualification at 1/2/3/4 workers