### PR TITLE
fix(ci): Raise nofile limit for Velox CPU tests

### DIFF
--- a/.github/workflows/velox-test.yml
+++ b/.github/workflows/velox-test.yml
@@ -97,8 +97,17 @@ jobs:
           IMAGE="${REGISTRY}/${IMAGE_NAME}:velox-${VELOX_SHORT_SHA}-${IMAGE_TAG}-${BUILD_DATE}${RUN_ID_SUFFIX}"
           echo "Testing image: ${IMAGE}"
           docker_pull_with_retry "${IMAGE}"
-          docker run --rm "${IMAGE}" bash -c \
-            "cd /opt/velox-build/release && ctest -j 16 --label-exclude cuda_driver --output-on-failure --no-tests=error"
+          docker run \
+            --rm \
+            --ulimit nofile=65536:65536 \
+            "${IMAGE}" \
+            bash -c \
+            "cd /opt/velox-build/release && \
+              ctest \
+                -j 16 \
+                --label-exclude cuda_driver \
+                --output-on-failure \
+                --no-tests=error"
 
   test-velox-gpu:
     name: test-velox-gpu (${{ matrix.image_tag }}, ${{ matrix.arch }}, ${{ matrix.gpu }})


### PR DESCRIPTION
## Summary

- set the Velox CPU test containers soft and hard `nofile` limits to 65,536

## Motivation

Both CPU architectures failed `TableEvolutionFuzzerTest.run` with simultaneous `Too many open files` errors:

- arm64: https://github.com/rapidsai/velox-testing/actions/runs/32334584972/job/96343233609
- amd64: https://github.com/rapidsai/velox-testing/actions/runs/32334584972/job/96343233617

Upstream Velox sets `ulimit -n 65536` immediately before its Linux test suites. Our workflow launches a separate Docker container without an explicit limit, so the test process instead receives the Docker daemon default. Docker Engine 29 changed the default container open-file limit from 1,048,576 to 1,024, making an explicit per-container limit important for reproducibility.

This uses `docker run --ulimit nofile=65536:65536` so both the soft and hard limits are established when the test container is created.

## Validation

- `yq eval . .github/workflows/velox-test.yml`
- `pre-commit run --files .github/workflows/velox-test.yml`
- `git diff --check`