### PR TITLE
Add g7e.48xlarge local-NVMe UCX Q18 workflow

### DIFF
--- a/presto/G7E48_LOCAL_NVME_UCX_Q18.md
+++ b/presto/G7E48_LOCAL_NVME_UCX_Q18.md
@@ -1,0 +1,91 @@
+# g7e.48xlarge local-NVMe Q18 over EFA/SRD
+
+This recipe reproduces the compression-free SF3K Q18 experiment on the audited
+AWS `g7e.48xlarge` topology. Table data is read from local NVMe; S3 is used only
+to populate the disposable NVMe copy before the benchmark.
+
+The tested software stack is:
+
+- Presto `a2ef306cbfe7fe507f52c04ccfbe665df27d1f7b`, based on Daniel Bauer's
+  August 19 UCX-exchange branch.
+- Velox `a7f4ebca783b40773a125e6831234641c17be93c`, immediately before Matt
+  Gara's adaptive exchange-compression commit.
+- EFA-enabled UCX 1.21 based on `ae68ab20f59f00385ab30aee94b501056eb417bf`
+  with OpenUCX commit `966d94d31` backported. That upstream fix caches CUDA
+  allocation attributes while the allocating context is current.
+
+No exchange-compression property is added by this branch. The run script fails
+if one appears in the generated worker configuration.
+
+## Stage SF3K on NVMe
+
+After every EC2 stop/start, restore the disposable data directory:
+
+```bash
+export AWS_REGION=us-east-2 AWS_DEFAULT_REGION=us-east-2
+export PRESTO_DATA_DIR=/opt/dlami/nvme/dmakkar/Presto/data/tpch
+mkdir -p "$PRESTO_DATA_DIR/sf3k_v2_float"
+aws s3 sync \
+  s3://rapids-tpch/presto-gpu/sf3k_v2_float/ \
+  "$PRESTO_DATA_DIR/sf3k_v2_float/" \
+  --exclude 'hive_metastore/*' \
+  --only-show-errors \
+  --no-follow-symlinks
+```
+
+The expected table-data inventory is 264 files and 954,780,613,952 bytes.
+Verify it before comparing results:
+
+```bash
+find "$PRESTO_DATA_DIR/sf3k_v2_float" -type f -printf '%s\n' |
+  awk '{objects += 1; bytes += $1} END {print objects, bytes}'
+```
+
+## Create and analyze the local schema once
+
+Use the CPU Velox worker for this one-time step. The Hive metastore persists on
+EBS, so ordinary EC2 restarts require only the NVMe sync above.
+
+```bash
+export PRESTO_IMAGE_TAG=<image-tag>
+export PRESTO_DATA_DIR=/opt/dlami/nvme/dmakkar/Presto/data/tpch
+cd presto/scripts
+./setup_benchmark_tables.sh \
+  --benchmark-type tpch \
+  --schema-name tianyu_nvme_sf3k_v2_float \
+  --data-dir-name sf3k_v2_float
+```
+
+## Run Q18
+
+The audited mapping pairs GPU workers 0/1, 2/3, 4/5, and 6/7 with EFA devices
+`rdmap145s0`, `rdmap162s0`, `rdmap179s0`, and `rdmap196s0`, respectively. Verify
+those names before using a different AMI or instance.
+
+```bash
+export PRESTO_IMAGE_TAG=<image-tag>
+export PRESTO_DATA_DIR=/opt/dlami/nvme/dmakkar/Presto/data/tpch
+export UCX_RUNTIME_ROOT=<efa-enabled-ucx-install-prefix>
+export RESULTS_DIR=$HOME/Development/results
+export BUILD_WORKER=true # First run only; builds with all host cores.
+presto/scripts/run_g7e48_local_nvme_q18.sh
+```
+
+Unset `BUILD_WORKER` on later runs to reuse the built worker image.
+
+The script enables the opt-in `--ucx-efa-runtime` launch path, sets each ENA to
+16 combined queues, launches eight GPU workers in one host-network container,
+and runs two Q18 iterations. The second iteration is the hot measurement. The
+compression-free acceptance target is under 6 seconds.
+
+The worker configuration intentionally uses:
+
+- `ucxx.error_handling=false` and `ucxx.blocking_polling=false` for SRD progress;
+- 32 MiB CUDA rendezvous fragments on one rail;
+- `UCX_CUDA_COPY_ASYNC_MEM_TYPE=cuda-managed`, keeping application
+  `cudaMallocAsync` buffers on UCX's fragment pipeline;
+- the upstream allocation-cache fix rather than
+  `UCX_CUDA_COPY_RETAIN_PRIMARY_CTX` or a requested-type override;
+- 10 million partition-output rows to bound SF3K memory pressure; and
+- benchmark-scoped `native_cudf_exchange_enabled=true`, leaving metadata and
+  setup queries on the ordinary exchange path.

--- a/presto/docker/config/template/etc_coordinator/config_native.properties
+++ b/presto/docker/config/template/etc_coordinator/config_native.properties
@@ -23,6 +23,10 @@ memory.heap-headroom-per-node={{ .HeadroomGb }}GB
 node-scheduler.max-pending-splits-per-task=2000
 # Cap concurrent splits per node for balanced scheduling.
 node-scheduler.max-splits-per-node=2000
+# Preserve deterministic split-to-worker affinity for hot cache reuse. Use the
+# scheduler default-sized ring so a larger worker set is not underrepresented.
+node-scheduler.node-selection-hash-strategy=CONSISTENT_HASHING
+node-scheduler.consistent-hashing-min-virtual-node-count=1000
 
 # Optimizer flags
 # Use known constraints to simplify plan and filters.

--- a/presto/docker/config/template/overrides/gpu/etc_worker/config_native.properties
+++ b/presto/docker/config/template/overrides/gpu/etc_worker/config_native.properties
@@ -5,19 +5,24 @@ cudf.exchange=false
 # overwritten when cudf.exchange is enabled (ignored otherwise)
 cudf.exchange.server.port=0000
 cudf.memory_resource=async
+cudf.streaming_groupby_api_enabled=true
 
 # Disable JIT because it takes a few iterations to warm up jit cache in all workers
 cudf.jit_expression_enabled=false
 # Turn on to use intra-node exchange optimization.
 # NOTE: In cudf exchange 20260212 branch, this is needed for UCX to use nvlink.
 cudf.intra_node_exchange=true
+# EFA/SRD requires active UCXX progress polling and transports that do not
+# provide peer-failure handling.
+ucxx.error_handling=false
+ucxx.blocking_polling=false
 
-# Use 100M rows per chunk for cudf partitioned output.
+# Bound partition output for SF3K Q18 memory pressure.
 # NOTE: This is not yet propagated to the worker properly because only a fixed set of query configs are supported.
 #       https://github.com/prestodb/presto/blob/a62672886152c8c6b61cf301d246f217d850e357/presto-native-execution/presto_cpp/main/PrestoToVeloxQueryConfig.cpp#L106-L224
 #       As a result, this needs to be hardcoded right now.
-cudf.partitioned_output_batch_rows=100000000
+cudf.partitioned_output_batch_rows=10000000
 
 # Enable cudf rebatching before aggregations.
 cudf.concat_optimization_enabled=true
-cudf.batch_size_min_threshold=100000000
+cudf.batch_size_min_threshold=40000000

--- a/presto/docker/docker-compose.common.yml
+++ b/presto/docker/docker-compose.common.yml
@@ -42,6 +42,7 @@ services:
         - VELOX_SHA=${VELOX_SHA:-}
         - VELOX_BRANCH=${VELOX_BRANCH:-}
         - VELOX_REPOSITORY=${VELOX_REPO:-}
+        - KVIKIO_BUILD_NSYS_PLUGIN=${KVIKIO_BUILD_NSYS_PLUGIN:-ON}
     environment:
       - GLOG_logtostderr=1
       - SERVER_START_TIMESTAMP=${SERVER_START_TIMESTAMP:-}

--- a/presto/docker/docker-compose/template/docker-compose.native-gpu.yml.jinja
+++ b/presto/docker/docker-compose/template/docker-compose.native-gpu.yml.jinja
@@ -30,19 +30,14 @@ x-presto-native-worker-gpu: &gpu_worker_base
             - driver: nvidia
               count: all
               capabilities: [gpu]
-  # devices:
-    #   # required for GDS
-    #   - /dev/infiniband/rdma_cm
-    #   - /dev/infiniband/uverbs0
-    #   - /dev/infiniband/uverbs1
-    #   - /dev/infiniband/uverbs2
-    #   - /dev/infiniband/uverbs3
-    #   - /dev/infiniband/uverbs4
-    #   - /dev/infiniband/uverbs5
-    #   - /dev/infiniband/uverbs6
-    #   - /dev/infiniband/uverbs7
-    #   - /dev/infiniband/uverbs8
-    #   - /dev/infiniband/uverbs9
+{% if ucx_efa %}
+  devices:
+    - /dev/infiniband/rdma_cm
+    - /dev/infiniband/uverbs0
+    - /dev/infiniband/uverbs1
+    - /dev/infiniband/uverbs2
+    - /dev/infiniband/uverbs3
+{% endif %}
   depends_on:
     - presto-coordinator
   volumes:
@@ -70,15 +65,32 @@ services:
   presto-native-worker-gpu-{{ gpu_id }}:
     <<: *gpu_worker_base
     container_name: presto-native-worker-gpu-{{ gpu_id }}
+{% if ucx_efa %}
+    network_mode: host
+{% endif %}
     environment:
       WORKER_ID: {{ gpu_id }}
       NVIDIA_VISIBLE_DEVICES: all
       PROFILE: ${PROFILE:-}
       PROFILE_ARGS: ${PROFILE_ARGS:-}
       SERVER_START_TIMESTAMP: ${SERVER_START_TIMESTAMP:-}
+{% if ucx_efa %}
+      LD_LIBRARY_PATH: /opt/ucx-runtime/lib:/opt/ucx-runtime/lib/ucx:/usr/lib64/presto-native-libs
+      UCX_MODULE_DIR: /opt/ucx-runtime/lib/ucx
+      UCX_LOG_LEVEL: ${UCX_LOG_LEVEL:-info}
+      UCX_RNDV_PIPELINE_ERROR_HANDLING: ${UCX_RNDV_PIPELINE_ERROR_HANDLING:-n}
+      UCX_RNDV_FRAG_SIZE: ${UCX_RNDV_FRAG_SIZE:-cuda:32M}
+      UCX_RNDV_FRAG_MEM_TYPES: ${UCX_RNDV_FRAG_MEM_TYPES:-cuda}
+      UCX_CUDA_COPY_ASYNC_MEM_TYPE: ${UCX_CUDA_COPY_ASYNC_MEM_TYPE:-cuda-managed}
+      UCX_MAX_RNDV_RAILS: ${UCX_MAX_RNDV_RAILS:-1}
+      UCX_TLS: ${UCX_TLS:-tcp,srd,cuda_copy}
+      UCX_NET_DEVICES: ${UCX_NET_DEVICES_GPU_{{ gpu_id }}:-}
+      UCX_SOCKADDR_TLS_PRIORITY: ${UCX_SOCKADDR_TLS_PRIORITY:-tcp}
+{% else %}
       UCX_LOG_LEVEL: info #debug
       UCX_RNDV_PIPELINE_ERROR_HANDLING: y
       UCX_TLS: tcp,cuda_copy,cuda_ipc
+{% endif %}
       UCX_TCP_CM_REUSEADDR: y
       UCX_PROTO_INFO: y
       # don't know, leave it for now
@@ -87,6 +99,9 @@ services:
       KVIKIO_NTHREADS: {{ kvikio_threads }}
       CUDA_VISIBLE_DEVICES: {{ gpu_id }}
     volumes:
+{% if ucx_efa %}
+      - ${UCX_RUNTIME_ROOT:-/dev/null}:/opt/ucx-runtime:ro
+{% endif %}
       - ../../config/generated/gpu/etc_common:/opt/presto-server/etc
       - ../../config/generated/gpu/etc_worker_{{ gpu_id }}/node.properties:/opt/presto-server/etc/node.properties
       - ../../config/generated/gpu/etc_worker_{{ gpu_id }}/config_native.properties:/opt/presto-server/etc/config.properties
@@ -97,6 +112,9 @@ services:
   presto-native-worker-gpu:
     <<: *gpu_worker_base
     container_name: presto-native-worker-gpu
+{% if ucx_efa %}
+    network_mode: host
+{% endif %}
 {%- if workers %}
     command: ["bash", "/opt/presto_profiling_wrapper.sh"{% for gpu_id in workers %}, "{{ gpu_id }}"{% endfor %}]
     environment:
@@ -104,9 +122,25 @@ services:
       PROFILE: ${PROFILE:-}
       PROFILE_ARGS: ${PROFILE_ARGS:-}
       SERVER_START_TIMESTAMP: ${SERVER_START_TIMESTAMP:-}
+{% if ucx_efa %}
+      LD_LIBRARY_PATH: /opt/ucx-runtime/lib:/opt/ucx-runtime/lib/ucx:/usr/lib64/presto-native-libs
+      UCX_MODULE_DIR: /opt/ucx-runtime/lib/ucx
+      UCX_LOG_LEVEL: ${UCX_LOG_LEVEL:-info}
+      UCX_RNDV_PIPELINE_ERROR_HANDLING: ${UCX_RNDV_PIPELINE_ERROR_HANDLING:-n}
+      UCX_RNDV_FRAG_SIZE: ${UCX_RNDV_FRAG_SIZE:-cuda:32M}
+      UCX_RNDV_FRAG_MEM_TYPES: ${UCX_RNDV_FRAG_MEM_TYPES:-cuda}
+      UCX_CUDA_COPY_ASYNC_MEM_TYPE: ${UCX_CUDA_COPY_ASYNC_MEM_TYPE:-cuda-managed}
+      UCX_MAX_RNDV_RAILS: ${UCX_MAX_RNDV_RAILS:-1}
+      UCX_TLS: ${UCX_TLS:-tcp,srd,cuda_copy}
+      UCX_SOCKADDR_TLS_PRIORITY: ${UCX_SOCKADDR_TLS_PRIORITY:-tcp}
+{% for gpu_id in workers %}
+      UCX_NET_DEVICES_GPU_{{ gpu_id }}: ${UCX_NET_DEVICES_GPU_{{ gpu_id }}:-}
+{% endfor %}
+{% else %}
       UCX_LOG_LEVEL: info #debug
       UCX_RNDV_PIPELINE_ERROR_HANDLING: y
       UCX_TLS: tcp,cuda_copy,cuda_ipc
+{% endif %}
       UCX_TCP_CM_REUSEADDR: y
       UCX_PROTO_INFO: y
       # don't know, leave it for now
@@ -120,9 +154,23 @@ services:
       PROFILE: ${PROFILE:-}
       PROFILE_ARGS: ${PROFILE_ARGS:-}
       SERVER_START_TIMESTAMP: ${SERVER_START_TIMESTAMP:-}
+{% if ucx_efa %}
+      LD_LIBRARY_PATH: /opt/ucx-runtime/lib:/opt/ucx-runtime/lib/ucx:/usr/lib64/presto-native-libs
+      UCX_MODULE_DIR: /opt/ucx-runtime/lib/ucx
+      UCX_LOG_LEVEL: ${UCX_LOG_LEVEL:-info}
+      UCX_RNDV_PIPELINE_ERROR_HANDLING: ${UCX_RNDV_PIPELINE_ERROR_HANDLING:-n}
+      UCX_RNDV_FRAG_SIZE: ${UCX_RNDV_FRAG_SIZE:-cuda:32M}
+      UCX_RNDV_FRAG_MEM_TYPES: ${UCX_RNDV_FRAG_MEM_TYPES:-cuda}
+      UCX_CUDA_COPY_ASYNC_MEM_TYPE: ${UCX_CUDA_COPY_ASYNC_MEM_TYPE:-cuda-managed}
+      UCX_MAX_RNDV_RAILS: ${UCX_MAX_RNDV_RAILS:-1}
+      UCX_TLS: ${UCX_TLS:-tcp,srd,cuda_copy}
+      UCX_NET_DEVICES: ${UCX_NET_DEVICES:-}
+      UCX_SOCKADDR_TLS_PRIORITY: ${UCX_SOCKADDR_TLS_PRIORITY:-tcp}
+{% else %}
       UCX_LOG_LEVEL: info #debug
       UCX_RNDV_PIPELINE_ERROR_HANDLING: y
       UCX_TLS: tcp,cuda_copy,cuda_ipc
+{% endif %}
       UCX_TCP_CM_REUSEADDR: y
       UCX_PROTO_INFO: y
       # don't know, leave it for now
@@ -132,6 +180,9 @@ services:
       CUDA_VISIBLE_DEVICES: 0
 {%- endif %}
     volumes:
+{% if ucx_efa %}
+      - ${UCX_RUNTIME_ROOT:-/dev/null}:/opt/ucx-runtime:ro
+{% endif %}
 {%- if workers %}
       # Mount all etc directories for workers {{ workers|join(', ') }}
 {%- for gpu_id in workers %}

--- a/presto/docker/launch_presto_servers.sh
+++ b/presto/docker/launch_presto_servers.sh
@@ -49,6 +49,15 @@ launch_worker() {
     fi
 
     cuda_env=("CUDA_VISIBLE_DEVICES=$worker_id")
+    local ucx_device_env_name="UCX_NET_DEVICES_GPU_${worker_id}"
+    local ucx_device="${UCX_NET_DEVICES:-}"
+    if [[ -n "${!ucx_device_env_name:-}" ]]; then
+      ucx_device="${!ucx_device_env_name}"
+    fi
+    if [[ -n "$ucx_device" ]]; then
+      cuda_env+=("UCX_NET_DEVICES=$ucx_device")
+      echo "UCX network device: $ucx_device"
+    fi
     gpu_name="$(nvidia-smi --query-gpu=name --format=csv,noheader 2>/dev/null -i "$worker_id")"
   # No GPU: fall back to NUMA interleaving across all nodes for CPU workers.
   # Requires SYS_NICE capability in the container (set via cap_add in docker-compose).

--- a/presto/docker/native_build.dockerfile
+++ b/presto/docker/native_build.dockerfile
@@ -18,6 +18,7 @@ ARG EXTRA_CMAKE_FLAGS="\
     -DVELOX_BUILD_TESTING=OFF \
     -DPRESTO_STATS_REPORTER_TYPE=PROMETHEUS"
 ARG CUDA_ARCHITECTURES="75;80;86;90;100;120"
+ARG KVIKIO_BUILD_NSYS_PLUGIN=ON
 ARG TARGETARCH
 ARG ENABLE_SCCACHE=OFF
 ARG SCCACHE_SERVER_LOG="sccache=info"
@@ -66,7 +67,7 @@ RUN \
     --mount=type=cache,target=${BUILD_BASE_DIR} \
     --mount=type=cache,target=/root/.cache/sccache/preprocessor \
     --mount=type=cache,target=/root/.cache/sccache-dist-client \
-    --mount=type=secret,id=github_token,env=SCCACHE_DIST_AUTH_TOKEN \
+    --mount=type=secret,id=github_token,target=/run/secrets/github_token \
     --mount=type=secret,id=aws_credentials,target=/root/.aws/credentials \
     --mount=type=bind,source=velox-testing/scripts/sccache/sccache_setup.sh,target=/sccache_setup.sh,ro \
 <<EOF
@@ -86,6 +87,12 @@ if [ -f "${BUILD_BASE_DIR}/CMakeCache.txt" ]; then
 fi
 
 if [ "$ENABLE_SCCACHE" = "ON" ]; then
+  if [ -f /run/secrets/github_token ]; then
+    set +x;
+    SCCACHE_DIST_AUTH_TOKEN=$(cat /run/secrets/github_token);
+    export SCCACHE_DIST_AUTH_TOKEN;
+    set -x;
+  fi;
   if [ -n "${SCCACHE_NO_DIST_COMPILE:-}" ]; then
     export SCCACHE_NO_DIST_COMPILE=1;
   fi
@@ -93,6 +100,9 @@ if [ "$ENABLE_SCCACHE" = "ON" ]; then
   EXTRA_CMAKE_FLAGS="${EXTRA_CMAKE_FLAGS} -DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache -DCMAKE_CUDA_COMPILER_LAUNCHER=sccache";
   export NVCC_APPEND_FLAGS="${NVCC_APPEND_FLAGS:+$NVCC_APPEND_FLAGS }-t=100";
 fi
+
+EXTRA_CMAKE_FLAGS="${EXTRA_CMAKE_FLAGS} -DKvikIO_BUILD_NSYS_PLUGIN=${KVIKIO_BUILD_NSYS_PLUGIN}";
+export EXTRA_CMAKE_FLAGS;
 
 make --directory="/presto_native_staging/presto" cmake-and-build BUILD_TYPE=${BUILD_TYPE} BUILD_DIR="" BUILD_BASE_DIR=${BUILD_BASE_DIR};
 

--- a/presto/scripts/generate_presto_config.sh
+++ b/presto/scripts/generate_presto_config.sh
@@ -60,6 +60,21 @@ function duplicate_worker_configs() {
   sed -i "s+cudf.exchange.server.port=.*+cudf.exchange.server.port=${exch_port}+g" ${worker_native_config}
   # Give each worker a unique id.
   sed -i "s+node\.id.*+node\.id=worker_${worker_id}+g" ${worker_config}/node.properties
+
+  # EFA workers use host networking. They share the host address, use unique
+  # HTTP/UCX ports, and reach the coordinator through its published host port.
+  if [[ "${PRESTO_WORKER_HOST_NETWORK:-false}" == "true" ]]; then
+    local internal_address="${PRESTO_WORKER_INTERNAL_ADDRESS:?PRESTO_WORKER_INTERNAL_ADDRESS must be set for host-network workers}"
+    sed -i "s+discovery\.uri=.*+discovery.uri=http://127.0.0.1:8080+g" \
+      "${worker_config}/config_native.properties" \
+      "${worker_config}/config_java.properties"
+    if grep -q '^node\.internal-address=' "${worker_config}/node.properties"; then
+      sed -i "s+node\.internal-address=.*+node.internal-address=${internal_address}+g" \
+        "${worker_config}/node.properties"
+    else
+      echo "node.internal-address=${internal_address}" >> "${worker_config}/node.properties"
+    fi
+  fi
 }
 
 # get host values

--- a/presto/scripts/run_g7e48_local_nvme_q18.sh
+++ b/presto/scripts/run_g7e48_local_nvme_q18.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# Reproduce the compression-free, local-NVMe SF3K Q18 EFA/SRD benchmark on
+# the audited g7e.48xlarge topology. Iteration 1 warms caches; iteration 2 is
+# the reported hot result.
+set -Eeuo pipefail
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+
+: "${PRESTO_IMAGE_TAG:?set PRESTO_IMAGE_TAG to the coordinator/worker image tag}"
+: "${PRESTO_DATA_DIR:?set PRESTO_DATA_DIR to the parent of sf3k_v2_float on NVMe}"
+: "${UCX_RUNTIME_ROOT:?set UCX_RUNTIME_ROOT to an EFA-enabled UCX install}"
+export KVIKIO_BUILD_NSYS_PLUGIN=OFF
+
+SCHEMA=${SCHEMA:-tianyu_nvme_sf3k_v2_float}
+RESULTS_DIR=${RESULTS_DIR:-$HOME/Development/results}
+RESULT_TAG=${RESULT_TAG:-g7e48_local_nvme_sf3k_q18_ucx_srd_no_compression_i2}
+
+if [[ -z ${PRESTO_WORKER_INTERNAL_ADDRESS:-} ]]; then
+  PRESTO_WORKER_INTERNAL_ADDRESS=$(ip -4 -o addr show dev enp135s0 | awk '{split($4, a, "/"); print a[1]; exit}')
+  export PRESTO_WORKER_INTERNAL_ADDRESS
+fi
+: "${PRESTO_WORKER_INTERNAL_ADDRESS:?could not determine the host private IPv4 address}"
+
+export UCX_NET_DEVICES_GPU_0='rdmap145s0:1,enp135s0'
+export UCX_NET_DEVICES_GPU_1='rdmap145s0:1,enp135s0'
+export UCX_NET_DEVICES_GPU_2='rdmap162s0:1,enp135s0'
+export UCX_NET_DEVICES_GPU_3='rdmap162s0:1,enp135s0'
+export UCX_NET_DEVICES_GPU_4='rdmap179s0:1,enp135s0'
+export UCX_NET_DEVICES_GPU_5='rdmap179s0:1,enp135s0'
+export UCX_NET_DEVICES_GPU_6='rdmap196s0:1,enp135s0'
+export UCX_NET_DEVICES_GPU_7='rdmap196s0:1,enp135s0'
+
+export UCX_TLS='tcp,srd,cuda_copy'
+export UCX_SOCKADDR_TLS_PRIORITY=tcp
+export UCX_RNDV_PIPELINE_ERROR_HANDLING=n
+export UCX_RNDV_FRAG_SIZE='cuda:32M'
+export UCX_RNDV_FRAG_MEM_TYPES=cuda
+export UCX_CUDA_COPY_ASYNC_MEM_TYPE=cuda-managed
+export UCX_MAX_RNDV_RAILS=1
+export UCX_PROTO_INFO=y
+export UCX_LOG_LEVEL=info
+
+for device in rdma_cm uverbs0 uverbs1 uverbs2 uverbs3; do
+  [[ -c "/dev/infiniband/$device" ]] || {
+    echo "Missing /dev/infiniband/$device" >&2
+    exit 1
+  }
+done
+
+for nic in enp135s0 enp153s0 enp170s0 enp187s0; do
+  sudo -n ethtool -L "$nic" combined 16
+  [[ $(ethtool -l "$nic" | awk '/Current hardware settings:/{current=1; next} current && /Combined:/{print $2; exit}') == 16 ]] || {
+    echo "$nic does not have 16 combined queues" >&2
+    exit 1
+  }
+done
+
+start_args=(
+  --ucx-efa-runtime "$UCX_RUNTIME_ROOT"
+  --overwrite-config
+  --single-container
+  --kvikio-threads 16
+  --num-drivers 2
+  --num-workers 8
+  --gpu-ids 0,1,2,3,4,5,6,7
+)
+if [[ ${BUILD_WORKER:-false} == true ]]; then
+  start_args+=(--build worker --num-threads "$(nproc)")
+fi
+if [[ ${NO_CACHE_BUILD:-false} == true ]]; then
+  start_args+=(--no-cache)
+fi
+
+"$SCRIPT_DIR/start_native_gpu_presto.sh" "${start_args[@]}"
+
+if grep -Rqs '^cudf\.exchange_compression=' \
+    "$SCRIPT_DIR/../docker/config/generated/gpu"/etc_worker_*/config_native.properties; then
+  echo "Compression configuration unexpectedly present in generated workers" >&2
+  exit 1
+fi
+
+"$SCRIPT_DIR/run_benchmark.sh" \
+  --benchmark-type tpch \
+  --queries 18 \
+  --schema-name "$SCHEMA" \
+  --iterations 2 \
+  --output-dir "$RESULTS_DIR" \
+  --tag "$RESULT_TAG" \
+  --skip-analyze-check

--- a/presto/scripts/start_presto_helper.sh
+++ b/presto/scripts/start_presto_helper.sh
@@ -180,7 +180,7 @@ if [[ "$VARIANT_TYPE" == "gpu" ]]; then
   LOCAL_NUM_WORKERS="${NUM_WORKERS:-0}"
 
   RENDER_SCRIPT_PATH=$(readlink -f "${SCRIPT_DIR}/../../template_rendering/render_docker_compose_template.py")
-  RENDER_ARGS="--template-path $TEMPLATE_PATH --output-path $RENDERED_PATH --num-workers $NUM_WORKERS --single-container $SINGLE_CONTAINER --kvikio-threads $KVIKIO_THREADS --sccache $ENABLE_SCCACHE"
+  RENDER_ARGS="--template-path $TEMPLATE_PATH --output-path $RENDERED_PATH --num-workers $NUM_WORKERS --single-container $SINGLE_CONTAINER --kvikio-threads $KVIKIO_THREADS --sccache $ENABLE_SCCACHE --ucx-efa $UCX_EFA"
   if [[ -n $GPU_IDS ]]; then
     RENDER_ARGS="$RENDER_ARGS --gpu-ids $GPU_IDS"
   fi

--- a/presto/scripts/start_presto_helper_parse_args.sh
+++ b/presto/scripts/start_presto_helper_parse_args.sh
@@ -25,6 +25,9 @@ OPTIONS:
                          Must be used with --num-workers. If not specified, defaults to "0,1,...,N-1"
                          where N is the value from --num-workers (GPU variant only).
     --single-container   Launch multiple Presto servers in a single container (GPU variant only).
+    --ucx-efa-runtime PATH Mount a host UCX installation and enable EFA/SRD worker networking
+                         (GPU variant only). Requires PRESTO_WORKER_INTERNAL_ADDRESS and
+                         the per-GPU UCX_NET_DEVICES_GPU_<id> variables.
     --build-type         Build type for native CPU and GPU image builds. Possible values are "release",
                          "relwithdebinfo", or "debug". Values are case insensitive. The default value
                          is "release".
@@ -45,6 +48,8 @@ OPTIONS:
 ENVIRONMENT VARIABLES:
     SCCACHE_AUTH_DIR     Directory containing sccache auth files (default: ~/.sccache-auth/).
     PRESTO_CTAS_SCRATCH_DIR    Optional writable host scratch directory mounted for temporary CTAS benchmark results.
+    PRESTO_WORKER_INTERNAL_ADDRESS  Host private IPv4 advertised by host-network workers.
+    UCX_NET_DEVICES_GPU_<id>       UCX devices assigned to each GPU worker.
 
 EXAMPLES:
     $SCRIPT_NAME --no-cache
@@ -72,6 +77,7 @@ export PROFILE=OFF
 export NUM_WORKERS=1
 export KVIKIO_THREADS=8
 export VCPU_PER_WORKER=""
+export UCX_EFA=false
 LOGS_DIR=""
 ENABLE_SCCACHE=false
 SCCACHE_AUTH_DIR="${SCCACHE_AUTH_DIR:-$HOME/.sccache-auth}"
@@ -146,6 +152,21 @@ parse_args() {
         export SINGLE_CONTAINER=true
         shift
         ;;
+      --ucx-efa-runtime)
+        if [[ -z ${2:-} ]]; then
+          echo "Error: --ucx-efa-runtime requires a UCX installation path"
+          exit 1
+        fi
+        export UCX_RUNTIME_ROOT
+        UCX_RUNTIME_ROOT=$(readlink -f "$2")
+        if [[ ! -x "$UCX_RUNTIME_ROOT/bin/ucx_info" ]]; then
+          echo "Error: UCX runtime does not contain bin/ucx_info: $UCX_RUNTIME_ROOT" >&2
+          exit 1
+        fi
+        export UCX_EFA=true
+        export PRESTO_WORKER_HOST_NETWORK=true
+        shift 2
+        ;;
       --build-type)
         if [[ -n $2 ]]; then
           # Convert value to lowercase using the "L" transformation operator.
@@ -218,6 +239,11 @@ parse_args() {
 
 parse_args "$@"
 
+if [[ "$UCX_EFA" == true && "$VARIANT_TYPE" != gpu ]]; then
+  echo "Error: --ucx-efa-runtime is supported only for the GPU variant" >&2
+  exit 1
+fi
+
 if [[ -n "${PRESTO_CTAS_SCRATCH_DIR:-}" ]]; then
   mkdir -p "${PRESTO_CTAS_SCRATCH_DIR}"
   PRESTO_CTAS_SCRATCH_DIR="$(readlink -f "${PRESTO_CTAS_SCRATCH_DIR}")"
@@ -274,4 +300,16 @@ if [[ -n $GPU_IDS ]]; then
     echo "Error: number of GPU IDs ($GPU_ID_COUNT) must match --num-workers ($NUM_WORKERS)"
     exit 1
   fi
+fi
+
+if [[ "$UCX_EFA" == true ]]; then
+  : "${PRESTO_WORKER_INTERNAL_ADDRESS:?set PRESTO_WORKER_INTERNAL_ADDRESS for --ucx-efa-runtime}"
+  IFS=',' read -ra ucx_gpu_ids <<< "${GPU_IDS:-0}"
+  for gpu_id in "${ucx_gpu_ids[@]}"; do
+    ucx_device_var="UCX_NET_DEVICES_GPU_${gpu_id}"
+    if [[ -z ${!ucx_device_var:-} ]]; then
+      echo "Error: set $ucx_device_var for --ucx-efa-runtime" >&2
+      exit 1
+    fi
+  done
 fi

--- a/presto/testing/performance_benchmarks/common_fixtures.py
+++ b/presto/testing/performance_benchmarks/common_fixtures.py
@@ -26,6 +26,7 @@ from .ctas import (
     finalize_ctas_results,
 )
 from .metrics_collector import collect_metrics
+from .presto_api import get_cluster_tag
 from .run_context import gather_run_context
 
 
@@ -148,6 +149,12 @@ def benchmark_query(request, presto_cursor, benchmark_queries, benchmark_result_
     bench_output_dir = get_output_dir(request.config)
     hostname = request.config.getoption("--hostname")
     port = request.config.getoption("--port")
+
+    # Query-discovery and scale-factor fixtures use this cursor before this
+    # fixture is constructed. Keep those host-resident metadata exchanges on
+    # the ordinary path, then enable UCX only for the benchmark executions.
+    if get_cluster_tag(hostname, port) == "native-gpu":
+        presto_cursor.execute("SET SESSION native_cudf_exchange_enabled = true").fetchall()
 
     if profile:
         assert profile_script_path is not None

--- a/template_rendering/render_docker_compose_template.py
+++ b/template_rendering/render_docker_compose_template.py
@@ -52,6 +52,14 @@ def parse_args():
         required=False,
         help="Enable sccache build secrets in the rendered compose file.",
     )
+    parser.add_argument(
+        "--ucx-efa",
+        type=str_to_bool,
+        default=False,
+        dest="ucx_efa",
+        required=False,
+        help="Enable host-mounted UCX and EFA/SRD worker networking.",
+    )
     return parser.parse_args()
 
 
@@ -94,6 +102,7 @@ def main() -> int:
         single_container=parsed_args.single_container,
         kvikio_threads=parsed_args.kvikio_threads,
         sccache=parsed_args.sccache,
+        ucx_efa=parsed_args.ucx_efa,
     )
 
     os.makedirs(os.path.dirname(parsed_args.output_path), exist_ok=True)


### PR DESCRIPTION
## Summary

- add an opt-in `--ucx-efa-runtime` GPU launch path that mounts an EFA-enabled UCX runtime, uses host networking, exposes four EFA devices, and assigns each GPU worker its topology-local UCX device
- enable benchmark-scoped cuDF exchange while leaving metadata and setup queries on the ordinary exchange path
- configure active UCXX polling, bounded SF3K partition output, and deterministic worker affinity for the local-NVMe Q18 workload
- add a self-contained g7e.48xlarge SF3K staging and Q18 reproduction guide/script
- keep ordinary CPU/GPU launches unchanged and make stale generated GPU Compose files safe for CPU setup/teardown
- make the optional KvikIO Nsight plugin configurable and use a file-mounted sccache token for older BuildKit compatibility

## Scope

This branch is based directly on `main`. It does not include Tianyu's S3-oriented `pioneer` history or the Velox-testing exchange-compression commits.

The tested worker deliberately used Velox `a7f4ebca783b40773a125e6831234641c17be93c`, immediately before Matt Gara's adaptive exchange-compression commit. No `cudf.exchange_compression` property was present in the generated worker configuration.

External tested pins are documented in `presto/G7E48_LOCAL_NVME_UCX_Q18.md`:

- Presto `a2ef306cbfe7fe507f52c04ccfbe665df27d1f7b`
- Velox `a7f4ebca783b40773a125e6831234641c17be93c`
- EFA-enabled UCX 1.21 with upstream allocation-cache fix `966d94d31`

## Validation

- shell syntax and Python byte-compilation checks passed
- EFA and ordinary Compose variants rendered and passed `docker compose config`
- compression-free GPU worker built successfully for SM120
- SF3K Q18 from local NVMe, 8 workers, 2 iterations:
  - first iteration: 10.077 s
  - hot second iteration: **4.793 s**
- result validation against the prior Q18 output: 1 passed, 0 failed
- 8 UCX exchanges and 0 HTTP exchanges
- SRD selected across all four EFA devices; no UCX errors, registration failures, assertions, or worker crashes
