### PR TITLE
Enable hybrid CUDA IPC and EFA GPU exchange

### DIFF
--- a/presto/docker/config/template/etc_coordinator/config_native.properties
+++ b/presto/docker/config/template/etc_coordinator/config_native.properties
@@ -23,6 +23,10 @@ memory.heap-headroom-per-node={{ .HeadroomGb }}GB
 node-scheduler.max-pending-splits-per-task=2000
 # Cap concurrent splits per node for balanced scheduling.
 node-scheduler.max-splits-per-node=2000
+# Preserve deterministic split-to-worker affinity for hot cache reuse. Use the
+# scheduler default-sized ring so a larger worker set is not underrepresented.
+node-scheduler.node-selection-hash-strategy=CONSISTENT_HASHING
+node-scheduler.consistent-hashing-min-virtual-node-count=1000
 
 # Optimizer flags
 # Use known constraints to simplify plan and filters.

--- a/presto/docker/config/template/overrides/gpu/etc_worker/config_native.properties
+++ b/presto/docker/config/template/overrides/gpu/etc_worker/config_native.properties
@@ -11,13 +11,17 @@ cudf.jit_expression_enabled=false
 # Turn on to use intra-node exchange optimization.
 # NOTE: In cudf exchange 20260212 branch, this is needed for UCX to use nvlink.
 cudf.intra_node_exchange=true
+# EFA/SRD requires active UCXX progress polling and transports that do not
+# provide peer-failure handling.
+ucxx.error_handling=false
+ucxx.blocking_polling=false
 
-# Use 100M rows per chunk for cudf partitioned output.
+# Bound partition output for SF3K Q18 memory pressure.
 # NOTE: This is not yet propagated to the worker properly because only a fixed set of query configs are supported.
 #       https://github.com/prestodb/presto/blob/a62672886152c8c6b61cf301d246f217d850e357/presto-native-execution/presto_cpp/main/PrestoToVeloxQueryConfig.cpp#L106-L224
 #       As a result, this needs to be hardcoded right now.
-cudf.partitioned_output_batch_rows=100000000
+cudf.partitioned_output_batch_rows=10000000
 
 # Enable cudf rebatching before aggregations.
 cudf.concat_optimization_enabled=true
-cudf.batch_size_min_threshold=100000000
+cudf.batch_size_min_threshold=40000000

--- a/presto/docker/docker-compose.common.yml
+++ b/presto/docker/docker-compose.common.yml
@@ -42,6 +42,7 @@ services:
         - VELOX_SHA=${VELOX_SHA:-}
         - VELOX_BRANCH=${VELOX_BRANCH:-}
         - VELOX_REPOSITORY=${VELOX_REPO:-}
+        - UCX_VERSION=${UCX_VERSION:-1.22.0}
     environment:
       - GLOG_logtostderr=1
       - SERVER_START_TIMESTAMP=${SERVER_START_TIMESTAMP:-}

--- a/presto/docker/docker-compose/template/docker-compose.native-gpu.yml.jinja
+++ b/presto/docker/docker-compose/template/docker-compose.native-gpu.yml.jinja
@@ -30,19 +30,14 @@ x-presto-native-worker-gpu: &gpu_worker_base
             - driver: nvidia
               count: all
               capabilities: [gpu]
-  # devices:
-    #   # required for GDS
-    #   - /dev/infiniband/rdma_cm
-    #   - /dev/infiniband/uverbs0
-    #   - /dev/infiniband/uverbs1
-    #   - /dev/infiniband/uverbs2
-    #   - /dev/infiniband/uverbs3
-    #   - /dev/infiniband/uverbs4
-    #   - /dev/infiniband/uverbs5
-    #   - /dev/infiniband/uverbs6
-    #   - /dev/infiniband/uverbs7
-    #   - /dev/infiniband/uverbs8
-    #   - /dev/infiniband/uverbs9
+{% if ucx_efa %}
+  devices:
+    - /dev/infiniband/rdma_cm
+    - /dev/infiniband/uverbs0
+    - /dev/infiniband/uverbs1
+    - /dev/infiniband/uverbs2
+    - /dev/infiniband/uverbs3
+{% endif %}
   depends_on:
     - presto-coordinator
   volumes:
@@ -70,18 +65,29 @@ services:
   presto-native-worker-gpu-{{ gpu_id }}:
     <<: *gpu_worker_base
     container_name: presto-native-worker-gpu-{{ gpu_id }}
+{% if ucx_efa %}
+    network_mode: host
+{% endif %}
     environment:
       WORKER_ID: {{ gpu_id }}
       NVIDIA_VISIBLE_DEVICES: all
       PROFILE: ${PROFILE:-}
       PROFILE_ARGS: ${PROFILE_ARGS:-}
       SERVER_START_TIMESTAMP: ${SERVER_START_TIMESTAMP:-}
-      UCX_LOG_LEVEL: info #debug
+{% if ucx_efa %}
+      UCX_RNDV_FRAG_SIZE: ${UCX_RNDV_FRAG_SIZE:-cuda:32M}
+      UCX_RNDV_FRAG_MEM_TYPES: ${UCX_RNDV_FRAG_MEM_TYPES:-cuda}
+      UCX_MAX_RNDV_RAILS: ${UCX_MAX_RNDV_RAILS:-1}
+      UCX_TLS: ${UCX_TLS:-tcp,srd,cuda_copy}
+      UCX_NET_DEVICES: ${UCX_NET_DEVICES_GPU_{{ gpu_id }}:-}
+      UCX_SOCKADDR_TLS_PRIORITY: ${UCX_SOCKADDR_TLS_PRIORITY:-tcp}
+{% else %}
       UCX_RNDV_PIPELINE_ERROR_HANDLING: y
       UCX_TLS: tcp,cuda_copy,cuda_ipc
+{% endif %}
+      UCX_LOG_LEVEL: info #debug
       UCX_TCP_CM_REUSEADDR: y
       UCX_PROTO_INFO: y
-      # don't know, leave it for now
       UCX_TCP_KEEPINTVL: 1ms
       UCX_KEEPALIVE_INTERVAL: 1ms
       KVIKIO_NTHREADS: {{ kvikio_threads }}
@@ -97,6 +103,9 @@ services:
   presto-native-worker-gpu:
     <<: *gpu_worker_base
     container_name: presto-native-worker-gpu
+{% if ucx_efa %}
+    network_mode: host
+{% endif %}
 {%- if workers %}
     command: ["bash", "/opt/presto_profiling_wrapper.sh"{% for gpu_id in workers %}, "{{ gpu_id }}"{% endfor %}]
     environment:
@@ -104,12 +113,22 @@ services:
       PROFILE: ${PROFILE:-}
       PROFILE_ARGS: ${PROFILE_ARGS:-}
       SERVER_START_TIMESTAMP: ${SERVER_START_TIMESTAMP:-}
-      UCX_LOG_LEVEL: info #debug
+{% if ucx_efa %}
+      UCX_RNDV_FRAG_SIZE: ${UCX_RNDV_FRAG_SIZE:-cuda:32M}
+      UCX_RNDV_FRAG_MEM_TYPES: ${UCX_RNDV_FRAG_MEM_TYPES:-cuda}
+      UCX_MAX_RNDV_RAILS: ${UCX_MAX_RNDV_RAILS:-1}
+      UCX_TLS: ${UCX_TLS:-tcp,srd,cuda_copy}
+      UCX_SOCKADDR_TLS_PRIORITY: ${UCX_SOCKADDR_TLS_PRIORITY:-tcp}
+{% for gpu_id in workers %}
+      UCX_NET_DEVICES_GPU_{{ gpu_id }}: ${UCX_NET_DEVICES_GPU_{{ gpu_id }}:-}
+{% endfor %}
+{% else %}
       UCX_RNDV_PIPELINE_ERROR_HANDLING: y
       UCX_TLS: tcp,cuda_copy,cuda_ipc
+{% endif %}
+      UCX_LOG_LEVEL: info #debug
       UCX_TCP_CM_REUSEADDR: y
       UCX_PROTO_INFO: y
-      # don't know, leave it for now
       UCX_TCP_KEEPINTVL: 1ms
       UCX_KEEPALIVE_INTERVAL: 1ms
       KVIKIO_NTHREADS: {{ kvikio_threads }}
@@ -120,12 +139,20 @@ services:
       PROFILE: ${PROFILE:-}
       PROFILE_ARGS: ${PROFILE_ARGS:-}
       SERVER_START_TIMESTAMP: ${SERVER_START_TIMESTAMP:-}
-      UCX_LOG_LEVEL: info #debug
+{% if ucx_efa %}
+      UCX_RNDV_FRAG_SIZE: ${UCX_RNDV_FRAG_SIZE:-cuda:32M}
+      UCX_RNDV_FRAG_MEM_TYPES: ${UCX_RNDV_FRAG_MEM_TYPES:-cuda}
+      UCX_MAX_RNDV_RAILS: ${UCX_MAX_RNDV_RAILS:-1}
+      UCX_TLS: ${UCX_TLS:-tcp,srd,cuda_copy}
+      UCX_NET_DEVICES: ${UCX_NET_DEVICES:-}
+      UCX_SOCKADDR_TLS_PRIORITY: ${UCX_SOCKADDR_TLS_PRIORITY:-tcp}
+{% else %}
       UCX_RNDV_PIPELINE_ERROR_HANDLING: y
       UCX_TLS: tcp,cuda_copy,cuda_ipc
+{% endif %}
+      UCX_LOG_LEVEL: info #debug
       UCX_TCP_CM_REUSEADDR: y
       UCX_PROTO_INFO: y
-      # don't know, leave it for now
       UCX_TCP_KEEPINTVL: 1ms
       UCX_KEEPALIVE_INTERVAL: 1ms
       KVIKIO_NTHREADS: {{ kvikio_threads }}

--- a/presto/docker/docker-compose/template/docker-compose.native-gpu.yml.jinja
+++ b/presto/docker/docker-compose/template/docker-compose.native-gpu.yml.jinja
@@ -77,8 +77,8 @@ services:
 {% if ucx_efa %}
       UCX_RNDV_FRAG_SIZE: ${UCX_RNDV_FRAG_SIZE:-cuda:32M}
       UCX_RNDV_FRAG_MEM_TYPES: ${UCX_RNDV_FRAG_MEM_TYPES:-cuda}
-      UCX_MAX_RNDV_RAILS: ${UCX_MAX_RNDV_RAILS:-1}
-      UCX_TLS: ${UCX_TLS:-tcp,srd,cuda_copy}
+      UCX_MAX_RNDV_RAILS: ${UCX_MAX_RNDV_RAILS:-2}
+      UCX_TLS: ${UCX_TLS:-tcp,srd,sm,cuda_copy,cuda_ipc}
       UCX_NET_DEVICES: ${UCX_NET_DEVICES_GPU_{{ gpu_id }}:-}
       UCX_SOCKADDR_TLS_PRIORITY: ${UCX_SOCKADDR_TLS_PRIORITY:-tcp}
 {% else %}
@@ -116,8 +116,8 @@ services:
 {% if ucx_efa %}
       UCX_RNDV_FRAG_SIZE: ${UCX_RNDV_FRAG_SIZE:-cuda:32M}
       UCX_RNDV_FRAG_MEM_TYPES: ${UCX_RNDV_FRAG_MEM_TYPES:-cuda}
-      UCX_MAX_RNDV_RAILS: ${UCX_MAX_RNDV_RAILS:-1}
-      UCX_TLS: ${UCX_TLS:-tcp,srd,cuda_copy}
+      UCX_MAX_RNDV_RAILS: ${UCX_MAX_RNDV_RAILS:-2}
+      UCX_TLS: ${UCX_TLS:-tcp,srd,sm,cuda_copy,cuda_ipc}
       UCX_SOCKADDR_TLS_PRIORITY: ${UCX_SOCKADDR_TLS_PRIORITY:-tcp}
 {% for gpu_id in workers %}
       UCX_NET_DEVICES_GPU_{{ gpu_id }}: ${UCX_NET_DEVICES_GPU_{{ gpu_id }}:-}
@@ -142,8 +142,8 @@ services:
 {% if ucx_efa %}
       UCX_RNDV_FRAG_SIZE: ${UCX_RNDV_FRAG_SIZE:-cuda:32M}
       UCX_RNDV_FRAG_MEM_TYPES: ${UCX_RNDV_FRAG_MEM_TYPES:-cuda}
-      UCX_MAX_RNDV_RAILS: ${UCX_MAX_RNDV_RAILS:-1}
-      UCX_TLS: ${UCX_TLS:-tcp,srd,cuda_copy}
+      UCX_MAX_RNDV_RAILS: ${UCX_MAX_RNDV_RAILS:-2}
+      UCX_TLS: ${UCX_TLS:-tcp,srd,sm,cuda_copy,cuda_ipc}
       UCX_NET_DEVICES: ${UCX_NET_DEVICES:-}
       UCX_SOCKADDR_TLS_PRIORITY: ${UCX_SOCKADDR_TLS_PRIORITY:-tcp}
 {% else %}

--- a/presto/docker/launch_presto_servers.sh
+++ b/presto/docker/launch_presto_servers.sh
@@ -49,6 +49,15 @@ launch_worker() {
     fi
 
     cuda_env=("CUDA_VISIBLE_DEVICES=$worker_id")
+    local ucx_device_env_name="UCX_NET_DEVICES_GPU_${worker_id}"
+    local ucx_device="${UCX_NET_DEVICES:-}"
+    if [[ -n "${!ucx_device_env_name:-}" ]]; then
+      ucx_device="${!ucx_device_env_name}"
+    fi
+    if [[ -n "$ucx_device" ]]; then
+      cuda_env+=("UCX_NET_DEVICES=$ucx_device")
+      echo "UCX network device: $ucx_device"
+    fi
     gpu_name="$(nvidia-smi --query-gpu=name --format=csv,noheader 2>/dev/null -i "$worker_id")"
   # No GPU: fall back to NUMA interleaving across all nodes for CPU workers.
   # Requires SYS_NICE capability in the container (set via cap_add in docker-compose).

--- a/presto/docker/native_build.dockerfile
+++ b/presto/docker/native_build.dockerfile
@@ -8,11 +8,13 @@ RUN rpm --import https://developer.download.nvidia.com/compute/cuda/repos/ubuntu
 
 ARG GPU=ON
 ARG UCX_VERSION=1.22.0
+COPY velox-testing/presto/docker/ucx-11865-rtx-ipc-bandwidth.patch /tmp/ucx-11865-rtx-ipc-bandwidth.patch
 RUN if [ "$GPU" = "ON" ]; then \
-    dnf install -y rdma-core-devel && \
+    dnf install -y patch rdma-core-devel && \
     mkdir -p /tmp/ucx-src /tmp/ucx-build && \
     wget -qO- "https://github.com/openucx/ucx/releases/download/v${UCX_VERSION}/ucx-${UCX_VERSION}.tar.gz" \
       | tar -C /tmp/ucx-src --strip-components=1 -xz && \
+    patch -d /tmp/ucx-src -p1 < /tmp/ucx-11865-rtx-ipc-bandwidth.patch && \
     cd /tmp/ucx-build && \
     /tmp/ucx-src/contrib/configure-release \
       --prefix=/usr/local \
@@ -29,7 +31,7 @@ RUN if [ "$GPU" = "ON" ]; then \
     make -j"$(nproc)" && \
     make install && \
     ldconfig && \
-    rm -rf /tmp/ucx-src /tmp/ucx-build; \
+    rm -rf /tmp/ucx-src /tmp/ucx-build /tmp/ucx-11865-rtx-ipc-bandwidth.patch; \
     fi
 
 ARG BUILD_TYPE=release

--- a/presto/docker/native_build.dockerfile
+++ b/presto/docker/native_build.dockerfile
@@ -7,6 +7,31 @@ RUN rpm --import https://developer.download.nvidia.com/compute/cuda/repos/ubuntu
     dnf install -y nsight-systems-cli-2026.3.1 numactl
 
 ARG GPU=ON
+ARG UCX_VERSION=1.22.0
+RUN if [ "$GPU" = "ON" ]; then \
+    dnf install -y rdma-core-devel && \
+    mkdir -p /tmp/ucx-src /tmp/ucx-build && \
+    wget -qO- "https://github.com/openucx/ucx/releases/download/v${UCX_VERSION}/ucx-${UCX_VERSION}.tar.gz" \
+      | tar -C /tmp/ucx-src --strip-components=1 -xz && \
+    cd /tmp/ucx-build && \
+    /tmp/ucx-src/contrib/configure-release \
+      --prefix=/usr/local \
+      --with-sysroot \
+      --enable-cma \
+      --enable-mt \
+      --with-gnu-ld \
+      --with-rdmacm \
+      --with-verbs \
+      --without-gda \
+      --without-go \
+      --without-java \
+      --with-cuda=/usr/local/cuda && \
+    make -j"$(nproc)" && \
+    make install && \
+    ldconfig && \
+    rm -rf /tmp/ucx-src /tmp/ucx-build; \
+    fi
+
 ARG BUILD_TYPE=release
 ARG BUILD_BASE_DIR=/presto_native_${BUILD_TYPE}_gpu_${GPU}_build
 ARG NUM_THREADS=12

--- a/presto/docker/ucx-11865-rtx-ipc-bandwidth.patch
+++ b/presto/docker/ucx-11865-rtx-ipc-bandwidth.patch
@@ -1,0 +1,25 @@
+diff --git a/src/uct/cuda/base/cuda_iface.h b/src/uct/cuda/base/cuda_iface.h
+index a1cb28a4e14..a7f9a3688f1 100644
+--- a/src/uct/cuda/base/cuda_iface.h
++++ b/src/uct/cuda/base/cuda_iface.h
+@@ -22,5 +22,6 @@ typedef enum uct_cuda_base_gen {
+     UCT_CUDA_BASE_GEN_V100 = 7,
+     UCT_CUDA_BASE_GEN_A100 = 8,
+     UCT_CUDA_BASE_GEN_H100 = 9,
+-    UCT_CUDA_BASE_GEN_B100 = 10
++    UCT_CUDA_BASE_GEN_B100 = 10,
++    UCT_CUDA_BASE_GEN_BRTX = 12  /* Blackwell RTX */
+ } uct_cuda_base_gen_t;
+diff --git a/src/uct/cuda/cuda_ipc/cuda_ipc_iface.c b/src/uct/cuda/cuda_ipc/cuda_ipc_iface.c
+index ed09c8fa127..a7c169cf07a 100644
+--- a/src/uct/cuda/cuda_ipc/cuda_ipc_iface.c
++++ b/src/uct/cuda/cuda_ipc/cuda_ipc_iface.c
+@@ -197,5 +197,7 @@ static double uct_cuda_ipc_iface_get_bw()
+     case UCT_CUDA_BASE_GEN_B100:
+         return 800000.0 * UCS_MBYTE;
++    case UCT_CUDA_BASE_GEN_BRTX:
++        return 50000.0 * UCS_MBYTE;
+     default:
+         return 6911.0  * UCS_MBYTE;
+     }
+ }

--- a/presto/scripts/generate_presto_config.sh
+++ b/presto/scripts/generate_presto_config.sh
@@ -60,6 +60,21 @@ function duplicate_worker_configs() {
   sed -i "s+cudf.exchange.server.port=.*+cudf.exchange.server.port=${exch_port}+g" ${worker_native_config}
   # Give each worker a unique id.
   sed -i "s+node\.id.*+node\.id=worker_${worker_id}+g" ${worker_config}/node.properties
+
+  # EFA workers use host networking. They share the host address, use unique
+  # HTTP/UCX ports, and reach the coordinator through its published host port.
+  if [[ "${PRESTO_WORKER_HOST_NETWORK:-false}" == "true" ]]; then
+    local internal_address="${PRESTO_WORKER_INTERNAL_ADDRESS:?PRESTO_WORKER_INTERNAL_ADDRESS must be set for host-network workers}"
+    sed -i "s+discovery\.uri=.*+discovery.uri=http://127.0.0.1:8080+g" \
+      "${worker_config}/config_native.properties" \
+      "${worker_config}/config_java.properties"
+    if grep -q '^node\.internal-address=' "${worker_config}/node.properties"; then
+      sed -i "s+node\.internal-address=.*+node.internal-address=${internal_address}+g" \
+        "${worker_config}/node.properties"
+    else
+      echo "node.internal-address=${internal_address}" >> "${worker_config}/node.properties"
+    fi
+  fi
 }
 
 # get host values

--- a/presto/scripts/run_g7e48_local_nvme_q18.sh
+++ b/presto/scripts/run_g7e48_local_nvme_q18.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Reproduce the compression-free, local-NVMe SF3K Q18 EFA/SRD benchmark on
+# the audited g7e.48xlarge topology. Iteration 1 warms caches; iteration 2 is
+# the reported hot result.
+set -Eeuo pipefail
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+
+: "${PRESTO_IMAGE_TAG:?set PRESTO_IMAGE_TAG to the coordinator/worker image tag}"
+: "${PRESTO_DATA_DIR:?set PRESTO_DATA_DIR to the parent of sf3k_v2_float on NVMe}"
+SCHEMA=${SCHEMA:-tianyu_nvme_sf3k_v2_float}
+RESULTS_DIR=${RESULTS_DIR:-$HOME/Development/results}
+RESULT_TAG=${RESULT_TAG:-g7e48_local_nvme_sf3k_q18_ucx_srd_no_compression_i2}
+
+if [[ -z ${PRESTO_WORKER_INTERNAL_ADDRESS:-} ]]; then
+  PRESTO_WORKER_INTERNAL_ADDRESS=$(ip -4 -o addr show dev enp135s0 | awk '{split($4, a, "/"); print a[1]; exit}')
+  export PRESTO_WORKER_INTERNAL_ADDRESS
+fi
+: "${PRESTO_WORKER_INTERNAL_ADDRESS:?could not determine the host private IPv4 address}"
+
+export UCX_NET_DEVICES_GPU_0='rdmap145s0:1,enp135s0'
+export UCX_NET_DEVICES_GPU_1='rdmap145s0:1,enp135s0'
+export UCX_NET_DEVICES_GPU_2='rdmap162s0:1,enp135s0'
+export UCX_NET_DEVICES_GPU_3='rdmap162s0:1,enp135s0'
+export UCX_NET_DEVICES_GPU_4='rdmap179s0:1,enp135s0'
+export UCX_NET_DEVICES_GPU_5='rdmap179s0:1,enp135s0'
+export UCX_NET_DEVICES_GPU_6='rdmap196s0:1,enp135s0'
+export UCX_NET_DEVICES_GPU_7='rdmap196s0:1,enp135s0'
+
+export UCX_TLS='tcp,srd,cuda_copy'
+export UCX_SOCKADDR_TLS_PRIORITY=tcp
+export UCX_RNDV_FRAG_SIZE='cuda:32M'
+export UCX_RNDV_FRAG_MEM_TYPES=cuda
+export UCX_MAX_RNDV_RAILS=1
+
+for device in rdma_cm uverbs0 uverbs1 uverbs2 uverbs3; do
+  [[ -c "/dev/infiniband/$device" ]] || {
+    echo "Missing /dev/infiniband/$device" >&2
+    exit 1
+  }
+done
+
+for nic in enp135s0 enp153s0 enp170s0 enp187s0; do
+  sudo -n ethtool -L "$nic" combined 16
+  [[ $(ethtool -l "$nic" | awk '/Current hardware settings:/{current=1; next} current && /Combined:/{print $2; exit}') == 16 ]] || {
+    echo "$nic does not have 16 combined queues" >&2
+    exit 1
+  }
+done
+
+start_args=(
+  --ucx-efa
+  --overwrite-config
+  --single-container
+  --kvikio-threads 16
+  --num-drivers 2
+  --num-workers 8
+  --gpu-ids 0,1,2,3,4,5,6,7
+)
+if [[ ${BUILD_WORKER:-false} == true ]]; then
+  start_args+=(--build worker --num-threads "$(nproc)")
+fi
+if [[ ${NO_CACHE_BUILD:-false} == true ]]; then
+  start_args+=(--no-cache)
+fi
+
+"$SCRIPT_DIR/start_native_gpu_presto.sh" "${start_args[@]}"
+
+if grep -Rqs '^cudf\.exchange_compression=' \
+    "$SCRIPT_DIR/../docker/config/generated/gpu"/etc_worker_*/config_native.properties; then
+  echo "Compression configuration unexpectedly present in generated workers" >&2
+  exit 1
+fi
+
+"$SCRIPT_DIR/run_benchmark.sh" \
+  --benchmark-type tpch \
+  --queries 18 \
+  --schema-name "$SCHEMA" \
+  --iterations 2 \
+  --output-dir "$RESULTS_DIR" \
+  --tag "$RESULT_TAG" \
+  --skip-analyze-check

--- a/presto/scripts/start_presto_helper.sh
+++ b/presto/scripts/start_presto_helper.sh
@@ -180,7 +180,7 @@ if [[ "$VARIANT_TYPE" == "gpu" ]]; then
   LOCAL_NUM_WORKERS="${NUM_WORKERS:-0}"
 
   RENDER_SCRIPT_PATH=$(readlink -f "${SCRIPT_DIR}/../../template_rendering/render_docker_compose_template.py")
-  RENDER_ARGS="--template-path $TEMPLATE_PATH --output-path $RENDERED_PATH --num-workers $NUM_WORKERS --single-container $SINGLE_CONTAINER --kvikio-threads $KVIKIO_THREADS --sccache $ENABLE_SCCACHE"
+  RENDER_ARGS="--template-path $TEMPLATE_PATH --output-path $RENDERED_PATH --num-workers $NUM_WORKERS --single-container $SINGLE_CONTAINER --kvikio-threads $KVIKIO_THREADS --sccache $ENABLE_SCCACHE --ucx-efa $UCX_EFA"
   if [[ -n $GPU_IDS ]]; then
     RENDER_ARGS="$RENDER_ARGS --gpu-ids $GPU_IDS"
   fi

--- a/presto/scripts/start_presto_helper_parse_args.sh
+++ b/presto/scripts/start_presto_helper_parse_args.sh
@@ -25,6 +25,9 @@ OPTIONS:
                          Must be used with --num-workers. If not specified, defaults to "0,1,...,N-1"
                          where N is the value from --num-workers (GPU variant only).
     --single-container   Launch multiple Presto servers in a single container (GPU variant only).
+    --ucx-efa            Enable EFA/SRD worker networking using the UCX bundled in the GPU image.
+                         Requires PRESTO_WORKER_INTERNAL_ADDRESS and per-GPU
+                         UCX_NET_DEVICES_GPU_<id> variables.
     --build-type         Build type for native CPU and GPU image builds. Possible values are "release",
                          "relwithdebinfo", or "debug". Values are case insensitive. The default value
                          is "release".
@@ -45,6 +48,8 @@ OPTIONS:
 ENVIRONMENT VARIABLES:
     SCCACHE_AUTH_DIR     Directory containing sccache auth files (default: ~/.sccache-auth/).
     PRESTO_CTAS_SCRATCH_DIR    Optional writable host scratch directory mounted for temporary CTAS benchmark results.
+    PRESTO_WORKER_INTERNAL_ADDRESS  Host private IPv4 advertised by host-network workers.
+    UCX_NET_DEVICES_GPU_<id>       UCX devices assigned to each GPU worker.
 
 EXAMPLES:
     $SCRIPT_NAME --no-cache
@@ -72,6 +77,7 @@ export PROFILE=OFF
 export NUM_WORKERS=1
 export KVIKIO_THREADS=8
 export VCPU_PER_WORKER=""
+export UCX_EFA=false
 LOGS_DIR=""
 ENABLE_SCCACHE=false
 SCCACHE_AUTH_DIR="${SCCACHE_AUTH_DIR:-$HOME/.sccache-auth}"
@@ -146,6 +152,11 @@ parse_args() {
         export SINGLE_CONTAINER=true
         shift
         ;;
+      --ucx-efa)
+        export UCX_EFA=true
+        export PRESTO_WORKER_HOST_NETWORK=true
+        shift
+        ;;
       --build-type)
         if [[ -n $2 ]]; then
           # Convert value to lowercase using the "L" transformation operator.
@@ -218,6 +229,11 @@ parse_args() {
 
 parse_args "$@"
 
+if [[ "$UCX_EFA" == true && "$VARIANT_TYPE" != gpu ]]; then
+  echo "Error: --ucx-efa is supported only for the GPU variant" >&2
+  exit 1
+fi
+
 if [[ -n "${PRESTO_CTAS_SCRATCH_DIR:-}" ]]; then
   mkdir -p "${PRESTO_CTAS_SCRATCH_DIR}"
   PRESTO_CTAS_SCRATCH_DIR="$(readlink -f "${PRESTO_CTAS_SCRATCH_DIR}")"
@@ -274,4 +290,16 @@ if [[ -n $GPU_IDS ]]; then
     echo "Error: number of GPU IDs ($GPU_ID_COUNT) must match --num-workers ($NUM_WORKERS)"
     exit 1
   fi
+fi
+
+if [[ "$UCX_EFA" == true ]]; then
+  : "${PRESTO_WORKER_INTERNAL_ADDRESS:?set PRESTO_WORKER_INTERNAL_ADDRESS for --ucx-efa}"
+  IFS=',' read -ra ucx_gpu_ids <<< "${GPU_IDS:-0}"
+  for gpu_id in "${ucx_gpu_ids[@]}"; do
+    ucx_device_var="UCX_NET_DEVICES_GPU_${gpu_id}"
+    if [[ -z ${!ucx_device_var:-} ]]; then
+      echo "Error: set $ucx_device_var for --ucx-efa" >&2
+      exit 1
+    fi
+  done
 fi

--- a/presto/testing/performance_benchmarks/common_fixtures.py
+++ b/presto/testing/performance_benchmarks/common_fixtures.py
@@ -26,6 +26,7 @@ from .ctas import (
     finalize_ctas_results,
 )
 from .metrics_collector import collect_metrics
+from .presto_api import get_cluster_tag
 from .run_context import gather_run_context
 
 
@@ -148,6 +149,12 @@ def benchmark_query(request, presto_cursor, benchmark_queries, benchmark_result_
     bench_output_dir = get_output_dir(request.config)
     hostname = request.config.getoption("--hostname")
     port = request.config.getoption("--port")
+
+    # Query-discovery and scale-factor fixtures use this cursor before this
+    # fixture is constructed. Keep those host-resident metadata exchanges on
+    # the ordinary path, then enable UCX only for the benchmark executions.
+    if get_cluster_tag(hostname, port) == "native-gpu":
+        presto_cursor.execute("SET SESSION native_cudf_exchange_enabled = true").fetchall()
 
     if profile:
         assert profile_script_path is not None

--- a/template_rendering/render_docker_compose_template.py
+++ b/template_rendering/render_docker_compose_template.py
@@ -52,6 +52,14 @@ def parse_args():
         required=False,
         help="Enable sccache build secrets in the rendered compose file.",
     )
+    parser.add_argument(
+        "--ucx-efa",
+        type=str_to_bool,
+        default=False,
+        dest="ucx_efa",
+        required=False,
+        help="Enable EFA/SRD worker networking with the UCX bundled in the image.",
+    )
     return parser.parse_args()
 
 
@@ -94,6 +102,7 @@ def main() -> int:
         single_container=parsed_args.single_container,
         kvikio_threads=parsed_args.kvikio_threads,
         sccache=parsed_args.sccache,
+        ucx_efa=parsed_args.ucx_efa,
     )
 
     os.makedirs(os.path.dirname(parsed_args.output_path), exist_ok=True)


### PR DESCRIPTION
## Summary

- backport OpenUCX PR #11865 on top of the UCX 1.22 worker build so RTX Pro 6000 Blackwell gets a realistic CUDA IPC bandwidth estimate
- enable `sm` and `cuda_ipc` alongside EFA/SRD so UCX can use PCIe P2P for reachable neighboring GPUs and SRD for the remaining pairs
- default `UCX_MAX_RNDV_RAILS` to 2 because it was the better of the two hybrid settings in the complete-suite A/B

This is a draft stacked on #412. The UCX patch should be removed once the upstream change is available in the UCX release used by the worker image.

## Validation

All query tests used local-NVMe SF3K, 8 GPU workers, 2 drivers, 3 iterations, and no exchange compression. Streaming aggregation was enabled only as an experimental config change and is not part of this PR.

| Complete TPC-H suite | Pure SRD | Hybrid, rails 1 | Hybrid, rails 2 |
| --- | ---: | ---: | ---: |
| Sum of hot-query averages | 57.302 s | 58.070 s | 57.813 s |
| Change from pure SRD | — | 1.34% slower | 0.89% slower |
| Q9 hot average | 9.108 s | 9.574 s | 9.481 s |
| Q18 hot average | 4.432 s | 4.556 s | 4.465 s |

- All 22 queries executed in all three arms.
- Rails 2 was 0.44% faster than rails 1, but neither hybrid configuration improved the complete suite over pure SRD.
- Validation passed for 21 queries. Q15 has a known float-data `MAX(total_revenue)` equality instability: pure SRD and rails 1 returned no row, while rails 2 returned one row.
- A CUDA-memory UCX pair test changed GPU 0 to GPU 1 from SRD at 30.29 GB/s to CUDA IPC at 52.41 GB/s; GPU 0 to GPU 2 remained on SRD as expected from the P2P matrix.

This remains a draft because the transport-selection mechanism works, but the full-suite data does not yet demonstrate an end-to-end performance win.
