### PR TITLE
fix(ci): force python3 symlink in Velox deps image

### DIFF
--- a/.github/workflows/velox-build.yml
+++ b/.github/workflows/velox-build.yml
@@ -78,6 +78,14 @@ jobs:
         run: |
           sed -i 's/ARM_BUILD_TARGET:-"local"/ARM_BUILD_TARGET:-"generic"/' velox/scripts/setup-helper-functions.sh
 
+      # TODO: Remove once facebookincubator/velox makes the python symlink idempotent.
+      # install_velox_deps_from_dnf now leaves /usr/bin/python in place (python-unversioned-command
+      # or a CUDA image change), so plain ln -s fails on every velox-deps matrix cell.
+      - name: Patch python symlink to overwrite if present
+        run: |
+          sed -i 's|ln -s $(which python3) /usr/bin/python|ln -sfn $(which python3) /usr/bin/python|' \
+            velox/scripts/docker/centos-multi.dockerfile
+
       - &setup_proxy_cache
         name: Setup proxy cache
         uses: nv-gha-runners/setup-proxy-cache@main  # zizmor: ignore[unpinned-uses]


### PR DESCRIPTION


## Summary
- Patch upstream centos-multi.dockerfile after checkout so `ln -s $(which python3) /usr/bin/python` becomes `ln -sfn $(which python3) /usr/bin/python`.
- Unblocks every velox-deps matrix cell; without a deps image, velox-build, tests, and benchmarks never start.

## Motivation
Nightly velox-nightly failed on all four deps jobs (`cuda12.9`/`13.1 x amd64`/`arm64`):

https://github.com/rapidsai/velox-testing/actions/runs/34085672229

```
RUN ln -s $(which python3) /usr/bin/python
ln: failed to create symbolic link '/usr/bin/python': File exists
```

That line is in `facebookincubator/velox` `scripts/docker/centos-multi.dockerfile` after `install_build_prerequisites && install_velox_deps_from_dnf`. On current CentOS Stream 9, `/usr/bin/python` can already exist (the RPM that owns it is `python-unversioned-command`, not `python3-pip` / `python3-devel`). Plain `ln -s` then fails.

`ln -sfn` creates the python -> python3 link when missing and replaces it when present. Same pattern as the existing `ARM_BUILD_TARGET` checkout patch. Drop this step once upstream makes the symlink idempotent.

## Test plan
- [x] velox-deps succeeds for cuda12.9/13.1 on amd64 and arm64
- [x] Confirm the build log shows `ln -sfn $(which python3) /usr/bin/python` rather than `ln -s`
- [x] Downstream velox-build is no longer skipped