### PR TITLE
feat(presto): add --cache-mode for reproducible cold/hot/lukewarm benchmark runs

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -18,6 +18,7 @@ jobs:
       - devcontainer
       - detect-changes
       - test_benchmark_data_tools
+      - test_benchmark_harness
     permissions:
       contents: read
     uses: rapidsai/shared-workflows/.github/workflows/pr-builder.yaml@main  # zizmor: ignore[unpinned-uses]
@@ -65,6 +66,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       benchmark_data_tools: ${{ steps.filter.outputs.benchmark_data_tools }}
+      benchmark_harness: ${{ steps.filter.outputs.benchmark_harness }}
     steps:
       - name: Checkout velox-testing
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -78,6 +80,9 @@ jobs:
           filters: |
             benchmark_data_tools:
               - "benchmark_data_tools/**"
+            benchmark_harness:
+              - "common/testing/**"
+              - "presto/testing/**"
 
   test_benchmark_data_tools:
     needs: detect-changes
@@ -93,3 +98,36 @@ jobs:
 
       - name: Test benchmark_data_tools
         uses: ./.github/actions/test-benchmark-data-tools
+
+  test_benchmark_harness:
+    needs: detect-changes
+    if: ${{ needs.detect-changes.outputs.benchmark_harness == 'true' }}
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout velox-testing
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Setup Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pytest requests
+        shell: bash
+
+      - name: Run benchmark harness unit tests
+        # "python -m pytest" (not bare "pytest") so the repo root lands on sys.path for
+        # the common.* / presto.* imports. Separate invocations because common/testing
+        # and presto/testing are both packages named "testing" and collide on module
+        # names within one run.
+        run: |
+          python -m pytest common/testing/cache_mode_reporting_test.py
+          python -m pytest presto/testing/cache_reset_test.py
+        shell: bash

--- a/common/testing/cache_mode_reporting_test.py
+++ b/common/testing/cache_mode_reporting_test.py
@@ -1,0 +1,82 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for --cache-mode aware reporting in conftest.py."""
+
+import pytest
+
+from common.testing.performance_benchmarks.benchmark_keys import BenchmarkKeys
+from common.testing.performance_benchmarks.conftest import _agg_headers, compute_aggregate_timings
+
+CACHE_MODES = ["off", "lukewarm", "cold-once", "cold", "hot"]
+
+
+def _aggregate(timings, cache_mode="off", warmup_iterations=1):
+    """Run compute_aggregate_timings over one query and return (headers, stats)."""
+    results = {BenchmarkKeys.RAW_TIMES_KEY: {"Q1": timings}}
+    compute_aggregate_timings(results, cache_mode, warmup_iterations)
+    iterations = len(timings) if timings else 0
+    return _agg_headers(cache_mode, iterations), results[BenchmarkKeys.AGGREGATE_TIMES_KEY]["Q1"]
+
+
+@pytest.mark.parametrize("cache_mode", CACHE_MODES)
+@pytest.mark.parametrize("iterations", [1, 2, 5])
+def test_header_and_stats_shapes_match(cache_mode, iterations):
+    """Every mode/iteration combination must produce one stat per column.
+
+    pytest_terminal_summary and build_and_write_benchmark_result both assert this, so a
+    mismatch fails the benchmark run at reporting time.
+    """
+    headers, stats = _aggregate([100.0 + i for i in range(iterations)], cache_mode)
+    assert len(headers) == len(stats)
+
+
+def test_default_and_unregistered_modes_match_historical_layout():
+    """off is the default and the spark_gluten fallback; both must reproduce the
+    pre-cache-mode column layout exactly."""
+    headers, stats = _aggregate([100.0, 101.0, 102.0])
+    assert headers == ["Avg Hot(ms)", "Min Hot(ms)", "Max Hot(ms)", "Median Hot(ms)", "GMean Hot(ms)", "Lukewarm(ms)"]
+    assert len(stats) == 6
+
+
+def test_lukewarm_reports_first_iteration_separately():
+    headers, stats = _aggregate([200.0, 100.0, 102.0], "lukewarm")
+    assert headers[-1] == "Lukewarm(ms)"
+    assert stats[-1] == 200.0  # iteration 0, reported alone
+    assert stats[0] == pytest.approx(101.0)  # avg over iterations[1:]
+
+
+def test_hot_excludes_warmup_iterations():
+    """Warm-up iterations prime the cache and are not reported at all under hot."""
+    headers, stats = _aggregate([200.0, 300.0, 100.0, 102.0], "hot", warmup_iterations=2)
+    assert "Lukewarm(ms)" not in headers
+    assert stats[0] == pytest.approx(101.0)  # avg over iterations[2:] only
+    assert stats[2] == 102.0  # max excludes the 300.0 warm-up
+
+
+def test_cold_once_reports_cold_first_sample_then_hot():
+    """cold-once resets per query, so iteration 0 is a real cold sample and the rest are hot."""
+    headers, stats = _aggregate([200.0, 100.0, 102.0], "cold-once")
+    assert headers[-1] == "Cold(ms)"
+    assert headers[0] == "Avg Hot(ms)"
+    assert stats[-1] == 200.0  # the cold sample
+    assert stats[0] == pytest.approx(101.0)  # hot aggregate excludes it
+
+
+def test_cold_aggregates_all_iterations():
+    """Every cold iteration was independently reset, so none are excluded."""
+    headers, stats = _aggregate([100.0, 102.0, 200.0], "cold")
+    assert headers == ["Avg Cold(ms)", "Min Cold(ms)", "Max Cold(ms)", "Median Cold(ms)", "GMean Cold(ms)"]
+    assert stats[0] == pytest.approx(134.0)
+    assert stats[2] == 200.0
+
+
+@pytest.mark.parametrize("cache_mode", CACHE_MODES)
+def test_degenerate_inputs_do_not_break_reporting(cache_mode):
+    """A failed query (None timings) and warmup >= iterations must not raise."""
+    results = {BenchmarkKeys.RAW_TIMES_KEY: {"Q1": None}}
+    compute_aggregate_timings(results, cache_mode, 1)
+    assert results[BenchmarkKeys.AGGREGATE_TIMES_KEY]["Q1"] is None
+
+    headers, stats = _aggregate([100.0, 102.0], cache_mode, warmup_iterations=5)
+    assert len(headers) == len(stats)

--- a/common/testing/performance_benchmarks/benchmark_keys.py
+++ b/common/testing/performance_benchmarks/benchmark_keys.py
@@ -20,6 +20,10 @@ class BenchmarkKeys(str, Enum):
     TAG_KEY = "tag"
     CONTEXT_KEY = "context"
     ITERATIONS_COUNT_KEY = "iterations_count"
+    CACHE_MODE_KEY = "cache_mode"
+    CACHE_RESET_LAYERS_KEY = "cache_reset_layers"
+    COLD_KEY = "cold"
+    WARMUP_ITERATIONS_KEY = "warmup_iterations"
     SCHEMA_NAME_KEY = "schema_name"
     # Run configuration (from run context; written to context in benchmark_result.json)
     TIMESTAMP_KEY = "timestamp"

--- a/common/testing/performance_benchmarks/common_fixtures.py
+++ b/common/testing/performance_benchmarks/common_fixtures.py
@@ -17,7 +17,15 @@ def benchmark_result_collector(request):
 
 @pytest.fixture(scope="session", autouse=True)
 def drop_cache_once(request):
-    """Session-scoped fixture that drops the cache once at the start of the benchmark run."""
+    """Drops the OS page cache once at the start of the benchmark run.
+
+    This is the legacy path, kept for --cache-mode=off (the presto default, and the only
+    mode Java workers support) and for engines that don't register --cache-mode at all
+    (e.g. spark_gluten). Every other mode schedules its own reset — including the OS
+    page-cache drop — at its own cadence, so this fixture stands down for them.
+    """
+    if request.config.getoption("--cache-mode", default="off") != "off":
+        return
     drop_cache_enabled = not request.config.getoption("--skip-drop-cache")
     if drop_cache_enabled:
         drop_cache()

--- a/common/testing/performance_benchmarks/conftest.py
+++ b/common/testing/performance_benchmarks/conftest.py
@@ -18,10 +18,43 @@ class DataLocation:
     key: str
 
 
+def _first_sample_label(cache_mode: str) -> str | None:
+    """Label for the standalone first-iteration column, or None if the mode has none.
+
+    off/lukewarm report iteration 0 as "Lukewarm"; cold-once resets before each query so
+    its iteration 0 is a genuine "Cold" sample followed by hot ones. cold (every
+    iteration is reset) and hot (warm-ups are never reported) have no first-sample
+    column. Single source of truth for _agg_headers, AGG_KEYS and
+    compute_aggregate_timings.
+    """
+    if cache_mode == "cold-once":
+        return "Cold"
+    if cache_mode in ("cold", "hot"):
+        return None
+    return "Lukewarm"
+
+
+def _agg_headers(cache_mode: str, iterations: int) -> list[str]:
+    """Column headers for the terminal report, per --cache-mode (see cache_reset.py for
+    the mode definitions and _first_sample_label for what each mode reports)."""
+    label = "Cold" if cache_mode == "cold" else "Hot"
+    first = _first_sample_label(cache_mode)
+    if iterations == 1:
+        return [f"{first}(ms)"] if first else [f"{label}(ms)"]
+    headers = [f"Avg {label}(ms)", f"Min {label}(ms)", f"Max {label}(ms)", f"Median {label}(ms)", f"GMean {label}(ms)"]
+    if first:
+        headers.append(f"{first}(ms)")
+    return headers
+
+
 def pytest_terminal_summary(terminalreporter, exitstatus, config):
     text_report = []
     iterations = config.getoption("--iterations")
     tag = config.getoption("--tag")
+    # None when the engine doesn't register --cache-mode (spark_gluten): keep its report
+    # byte-identical by omitting the mode line and falling back to lukewarm's layout.
+    cache_mode_opt = config.getoption("--cache-mode", default=None)
+    cache_mode = cache_mode_opt or "off"
     if not hasattr(terminalreporter._session, "benchmark_results"):
         return
 
@@ -38,22 +71,17 @@ def pytest_terminal_summary(terminalreporter, exitstatus, config):
 
         _write_line(terminalreporter, text_report, "")
         _write_line(terminalreporter, text_report, f"Iterations Count: {iterations}")
+        if cache_mode_opt and cache_mode_opt != "off":
+            mode_line = f"Cache Mode: {cache_mode_opt}"
+            if cache_mode_opt != "cold":
+                mode_line += f" (warmup iterations: {config.getoption('--warmup-iterations', default=1)})"
+            _write_line(terminalreporter, text_report, mode_line)
         _write_line(terminalreporter, text_report, f"{data_location_display_name} Name: {data_location_name}")
         if tag:
             _write_line(terminalreporter, text_report, f"Tag: {tag}")
         _write_line(terminalreporter, text_report, "")
 
-        if iterations > 1:
-            AGG_HEADERS = [
-                "Avg Hot(ms)",
-                "Min Hot(ms)",
-                "Max Hot(ms)",
-                "Median Hot(ms)",
-                "GMean Hot(ms)",
-                "Lukewarm(ms)",
-            ]
-        else:
-            AGG_HEADERS = ["Lukewarm(ms)"]
+        AGG_HEADERS = _agg_headers(cache_mode, iterations)
         width = max([len(agg_header) for agg_header in AGG_HEADERS])
         width = max(width, result[BenchmarkKeys.FORMAT_WIDTH_KEY]) + 2  # Additional padding on each side
         header = " Query ID "
@@ -112,27 +140,32 @@ def build_and_write_benchmark_result(session, json_result):
     before calling this function.
     """
     iterations = session.config.getoption("--iterations")
+    cache_mode = session.config.getoption("--cache-mode", default="off")
+    warmup_iterations = session.config.getoption("--warmup-iterations", default=1)
 
     bench_output_dir = get_output_dir(session.config)
     bench_output_dir.mkdir(parents=True, exist_ok=True)
 
-    if iterations > 1:
+    first_label = _first_sample_label(cache_mode)
+    first_key = BenchmarkKeys.COLD_KEY if first_label == "Cold" else BenchmarkKeys.LUKEWARM_KEY
+    if iterations == 1:
+        AGG_KEYS = [first_key] if first_label else [BenchmarkKeys.AVG_KEY]
+    else:
         AGG_KEYS = [
             BenchmarkKeys.AVG_KEY,
             BenchmarkKeys.MIN_KEY,
             BenchmarkKeys.MAX_KEY,
             BenchmarkKeys.MEDIAN_KEY,
             BenchmarkKeys.GMEAN_KEY,
-            BenchmarkKeys.LUKEWARM_KEY,
         ]
-    else:
-        AGG_KEYS = [BenchmarkKeys.LUKEWARM_KEY]
+        if first_label:
+            AGG_KEYS.append(first_key)
 
     if not hasattr(session, "benchmark_results"):
         return
 
     for benchmark_type, result in session.benchmark_results.items():
-        compute_aggregate_timings(result)
+        compute_aggregate_timings(result, cache_mode, warmup_iterations)
         json_result[benchmark_type] = {
             BenchmarkKeys.AGGREGATE_TIMES_KEY: {},
             BenchmarkKeys.RAW_TIMES_KEY: result[BenchmarkKeys.RAW_TIMES_KEY],
@@ -170,6 +203,21 @@ def pytest_sessionfinish(session, exitstatus):
     if tag:
         json_result[BenchmarkKeys.CONTEXT_KEY][BenchmarkKeys.TAG_KEY] = tag
 
+    # Only present for engines that register --cache-mode; the reported columns depend
+    # on it, so a saved report is ambiguous without it.
+    cache_mode = session.config.getoption("--cache-mode", default=None)
+    if cache_mode and cache_mode != "off":
+        context = json_result[BenchmarkKeys.CONTEXT_KEY]
+        context[BenchmarkKeys.CACHE_MODE_KEY] = cache_mode
+        if cache_mode != "cold":
+            context[BenchmarkKeys.WARMUP_ITERATIONS_KEY] = session.config.getoption("--warmup-iterations", default=1)
+        # Which layers the resets actually cleared, as reported by the engine's reset
+        # code — a tier that isn't configured, or that --skip-drop-cache skipped, is not
+        # listed, so this cannot claim a reset that never happened.
+        layers = getattr(session, "_cache_reset_layers", None)
+        if layers:
+            context[BenchmarkKeys.CACHE_RESET_LAYERS_KEY] = sorted(layers)
+
     if hasattr(session, "run_context"):
         for key, value in session.run_context.items():
             json_result[BenchmarkKeys.CONTEXT_KEY][key] = value
@@ -189,25 +237,46 @@ def get_output_dir(config):
     return Path(bench_output_dir)
 
 
-def compute_aggregate_timings(benchmark_results):
+def compute_aggregate_timings(benchmark_results, cache_mode="off", warmup_iterations=1):
+    """Reduce each query's raw per-iteration timings to the reported aggregate stats.
+
+    cold: stats over all iterations (each was independently reset).
+    hot/lukewarm: stats over timings[warmup_iterations:]; lukewarm additionally
+    reports iteration 0 alone (see _first_sample_label).
+    """
     raw_times = benchmark_results[BenchmarkKeys.RAW_TIMES_KEY]
     benchmark_results[BenchmarkKeys.AGGREGATE_TIMES_KEY] = {}
     format_width = 0
     for query_id, timings in raw_times.items():
         if timings:
-            first_iteration = timings[0]
-            if len(timings) > 1:
-                hot_timings = timings[1:]
-                stats = (
-                    round(statistics.mean(hot_timings), 2),
-                    min(hot_timings),
-                    max(hot_timings),
-                    statistics.median(hot_timings),
-                    round(statistics.geometric_mean(hot_timings), 2),
-                    first_iteration,
-                )
+            if len(timings) == 1:
+                if cache_mode == "hot":
+                    print(
+                        f"Warning: {query_id} has only 1 iteration under --cache-mode=hot "
+                        f"(--warmup-iterations={warmup_iterations}); the reported 'Hot' value is "
+                        "actually an unwarmed/priming run, not a true steady-state measurement."
+                    )
+                # The lone iteration IS the sample under every mode: cold uses all of
+                # timings, hot/lukewarm's warmup-slice-or-fallback both reduce to
+                # timings[0] too, so there's nothing mode-specific to branch on here.
+                stats = (timings[0],)
             else:
-                stats = (first_iteration,)
+                if cache_mode != "cold" and not timings[warmup_iterations:]:
+                    print(
+                        f"Warning: {query_id}: --warmup-iterations={warmup_iterations} >= its "
+                        f"{len(timings)} iterations; falling back to reporting only the last "
+                        "iteration, which may still include cache warm-up/priming effects."
+                    )
+                sample = timings if cache_mode == "cold" else (timings[warmup_iterations:] or timings[-1:])
+                stats = (
+                    round(statistics.mean(sample), 2),
+                    min(sample),
+                    max(sample),
+                    statistics.median(sample),
+                    round(statistics.geometric_mean(sample), 2),
+                )
+                if _first_sample_label(cache_mode):
+                    stats += (timings[0],)
             format_width = max(format_width, *[len(str(stat)) for stat in stats])
         else:
             stats = None

--- a/presto/scripts/run_benchmark.sh
+++ b/presto/scripts/run_benchmark.sh
@@ -41,7 +41,21 @@ OPTIONS:
                             Tags must contain only alphanumeric and underscore characters.
     -p, --profile           Enable profiling of benchmark queries.
     --profile-script-path   Path to a custom profiler functions script. Defaults to ./profiler_functions.sh.
-    --skip-drop-cache       Skip dropping system caches before each benchmark query (dropped by default).
+    --skip-drop-cache       Skip the OS page-cache drop step, under any --cache-mode (dropped by default).
+    --cache-mode            Cache reset schedule: "off" (default), "lukewarm", "cold-once", "cold", or
+                            "hot". Never restarts Presto. Only "off" and "hot" work against Java workers;
+                            the rest need native workers' Velox cache-control API.
+                              off:       legacy behavior — OS page-cache drop once, no worker clearing.
+                              lukewarm:  full reset once, before the first measured query.
+                              cold-once: full reset before each query's iterations — one cold sample,
+                                         then hot ones.
+                              cold:      full reset before every iteration.
+                              hot:       no resets; --warmup-iterations primes the cache.
+                            See presto/testing/performance_benchmarks/cache_reset.py.
+    --warmup-iterations     Leading iterations per query that prime the cache and are excluded from the
+                            aggregate stats. Must be less than --iterations. Default: 1.
+    --connector-id          Connector ID to target for worker cache-clear operations. Must match the
+                            catalog name (default: "hive").
     --skip-analyze-check    Skip checking that ANALYZE TABLE has been run on all tables (checked by default).
     --run-as-ctas-queries   Run queries as distributed Hive CTAS operations instead of returning results
                             through the coordinator. PRESTO_CTAS_SCRATCH_DIR must be set and mounted when the cluster starts.
@@ -75,6 +89,7 @@ EXAMPLES:
     $0 -b tpch -s bench_sf100 --metrics
     PRESTO_CTAS_SCRATCH_DIR=/results $0 -b tpch -s bench_sf100 --run-as-ctas-queries
     $0 -b tpch -s bench_sf100 --verbose
+    $0 -b tpch -s bench_sf100 --cache-mode cold-once
 
 EOF
 }
@@ -192,6 +207,33 @@ parse_args() {
       --skip-drop-cache)
         SKIP_DROP_CACHE=true
         shift
+        ;;
+      --cache-mode)
+        if [[ -n $2 ]]; then
+          CACHE_MODE=$2
+          shift 2
+        else
+          echo "Error: --cache-mode requires a value"
+          exit 1
+        fi
+        ;;
+      --warmup-iterations)
+        if [[ -n $2 ]]; then
+          WARMUP_ITERATIONS=$2
+          shift 2
+        else
+          echo "Error: --warmup-iterations requires a value"
+          exit 1
+        fi
+        ;;
+      --connector-id)
+        if [[ -n $2 ]]; then
+          CONNECTOR_ID=$2
+          shift 2
+        else
+          echo "Error: --connector-id requires a value"
+          exit 1
+        fi
         ;;
       --skip-analyze-check)
         SKIP_ANALYZE_CHECK=true
@@ -320,6 +362,18 @@ fi
 
 if [[ "${SKIP_DROP_CACHE}" == "true" ]]; then
   PYTEST_ARGS+=("--skip-drop-cache")
+fi
+
+if [[ -n ${CACHE_MODE} ]]; then
+  PYTEST_ARGS+=("--cache-mode ${CACHE_MODE}")
+fi
+
+if [[ -n ${WARMUP_ITERATIONS} ]]; then
+  PYTEST_ARGS+=("--warmup-iterations ${WARMUP_ITERATIONS}")
+fi
+
+if [[ -n ${CONNECTOR_ID} ]]; then
+  PYTEST_ARGS+=("--connector-id ${CONNECTOR_ID}")
 fi
 
 if [[ "${SKIP_ANALYZE_CHECK}" == "true" ]]; then

--- a/presto/testing/cache_reset_test.py
+++ b/presto/testing/cache_reset_test.py
@@ -1,0 +1,89 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for cache_reset.py's worker-clear semantics."""
+
+import pytest
+
+from presto.testing.performance_benchmarks import cache_reset
+
+WORKERS = [{"uri": "http://worker-a:10000/v1/status"}, {"uri": "http://worker-b:10000/v1/status"}]
+IDLE = [{"queryId": "q1", "state": "FINISHED"}]
+
+
+def _patch(monkeypatch, nodes=WORKERS, queries=IDLE, bodies=None):
+    """Stub discovery, the idle check, and per-endpoint response bodies.
+
+    *bodies* maps a substring of the request URL to the body returned for it; anything
+    unmatched gets that endpoint's normal success body.
+    """
+    calls = []
+    monkeypatch.setattr(cache_reset, "get_nodes", lambda hostname, port: nodes)
+    monkeypatch.setattr(cache_reset, "fetch_json", lambda url: queries)
+
+    def fake_fetch_text(url):
+        calls.append(url)
+        for fragment, body in (bodies or {}).items():
+            if fragment in url:
+                return body
+        if "type=memory" in url:
+            return "Cleared memory cache"
+        if "type=ssd" in url:
+            return "Cleared ssd cache"
+        return "file handle cache stats"
+
+    monkeypatch.setattr(cache_reset, "fetch_text", fake_fetch_text)
+    return calls
+
+
+def test_clears_every_worker_and_strips_status_suffix(monkeypatch):
+    calls = _patch(monkeypatch)
+
+    layers = cache_reset.clear_worker_data_caches("coord", 8080)
+    assert layers == {cache_reset.FILE_HANDLE_LAYER, cache_reset.MEMORY_LAYER, cache_reset.SSD_LAYER}
+    # Three endpoints per worker, addressed at the base URI (no /v1/status).
+    assert len(calls) == 6
+    assert all("/v1/status" not in url for url in calls)
+    assert sum("worker-a:10000/v1/operation" in url for url in calls) == 3
+
+
+def test_partial_clear_raises(monkeypatch):
+    """An un-cleared worker still serves warm data, so this must not be reported as cold."""
+    _patch(monkeypatch, bodies={"worker-b": None})
+
+    with pytest.raises(cache_reset.CacheResetError, match="only 1/2"):
+        cache_reset.clear_worker_data_caches("coord", 8080)
+
+
+def test_no_nodes_raises(monkeypatch):
+    _patch(monkeypatch, nodes=[])
+
+    with pytest.raises(cache_reset.CacheResetError, match="No worker nodes found"):
+        cache_reset.clear_worker_data_caches("coord", 8080)
+
+
+def test_unconfigured_tier_is_reported_not_cleared(monkeypatch):
+    """The endpoint answers 200 with a no-op body when a tier isn't configured. That is a
+    valid deployment, but it must not be counted as cleared — trusting the status code
+    alone would report warm numbers as cold."""
+    _patch(monkeypatch, bodies={"type=memory": "No memory cache set on server"})
+
+    layers = cache_reset.clear_worker_data_caches("coord", 8080)
+    assert cache_reset.MEMORY_LAYER not in layers
+    assert cache_reset.SSD_LAYER in layers
+
+
+def test_unexpected_clear_body_raises(monkeypatch):
+    """Anything that is neither a success nor a known not-configured body is a failure."""
+    _patch(monkeypatch, bodies={"type=memory": "Something went sideways"})
+
+    with pytest.raises(cache_reset.CacheResetError, match="Something went sideways"):
+        cache_reset.clear_worker_data_caches("coord", 8080)
+
+
+def test_active_query_blocks_the_clear(monkeypatch):
+    """AsyncDataCache::clear() keeps pinned entries, so clearing mid-query is only partly cold."""
+    _patch(monkeypatch, queries=[{"queryId": "q9", "state": "RUNNING"}])
+
+    with pytest.raises(cache_reset.CacheResetError, match="q9 \\(RUNNING\\)"):
+        cache_reset.wait_for_idle_cluster("coord", 8080, timeout_seconds=0.01)

--- a/presto/testing/performance_benchmarks/cache_reset.py
+++ b/presto/testing/performance_benchmarks/cache_reset.py
@@ -1,0 +1,213 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Cache reset for presto-native (Velox) workers.
+
+Presto-native's admin operations live at GET /v1/operation/<target>/<action>
+(PrestoServer.cpp registers this path with registerGet — POSTing to it 404s). A full
+cold reset needs all of:
+
+  - connector/clearCache: Hive connector's open file-handle cache.
+  - server/clearCache?type=memory: Velox's in-memory AsyncDataCache.
+  - server/clearCache?type=ssd: Velox's SsdCache index (not the on-disk bytes).
+  - the OS page cache: none of the above touch it (SsdFile uses buffered I/O, no
+    O_DIRECT), so previously-read/written blocks stay resident until it's dropped
+    explicitly — drop it last.
+
+The clear endpoints answer 200 even when they did nothing ("No memory cache set on
+server"), so responses are matched against the exact success body rather than trusting
+the status code. AsyncDataCache::clear() also keeps *pinned* entries, so a reset issued
+while a query is still running is only partly cold — hence the idle-cluster check.
+
+Limitation: drop_cache() writes /proc/sys/vm/drop_caches on the host running pytest
+only. That covers workers sharing that kernel (the single-node Docker setup), but does
+nothing for remote workers — their page cache stays warm, so "cold" numbers from a
+multi-node cluster are not truly cold.
+"""
+
+import time
+from concurrent.futures import ThreadPoolExecutor
+
+from common.testing.performance_benchmarks.cache_utils import drop_cache
+
+from .presto_api import fetch_json, fetch_text, get_nodes
+
+DEFAULT_CONNECTOR_ID = "hive"
+
+# Exact bodies from PrestoServerOperations::serverOperationClearCache. The endpoint
+# answers 200 for no-ops too, so the body decides whether a tier was really cleared.
+# A tier that is simply not configured is a valid deployment (this repo's GPU worker
+# ships without an AsyncDataCache), so it is reported rather than failed — but it is
+# never counted as cleared. Note the ssd request also answers with the memory-null body
+# when no cache exists at all, because the null check precedes the type switch.
+_MEMORY_CLEARED = "Cleared memory cache"
+_SSD_CLEARED = "Cleared ssd cache"
+_NOT_CONFIGURED = frozenset({"No memory cache set on server", "No ssd cache set on server"})
+
+# Warn once per run rather than on every reset; cold mode resets many times.
+_warned_no_memory_cache = False
+
+MEMORY_LAYER = "velox-memory"
+SSD_LAYER = "velox-ssd"
+FILE_HANDLE_LAYER = "hive-file-handle"
+OS_PAGE_CACHE_LAYER = "os-page-cache"
+
+_TERMINAL_QUERY_STATES = frozenset({"FINISHED", "FAILED", "CANCELED"})
+# The benchmark loop records timings without draining every cursor, so the previous
+# iteration's query can still be settling. Wait briefly rather than failing instantly.
+_IDLE_WAIT_SECONDS = 30.0
+_IDLE_POLL_SECONDS = 0.25
+
+
+class CacheResetError(RuntimeError):
+    """Raised when worker cache state cannot be established safely."""
+
+
+def _worker_uris(hostname: str, port: int) -> list[str]:
+    """Return each worker's base URI from the coordinator's /v1/node view."""
+    nodes = get_nodes(hostname, port)
+    if not nodes:
+        raise CacheResetError(f"No worker nodes found via /v1/node on {hostname}:{port}; cannot clear worker caches.")
+
+    uris = []
+    for node in nodes:
+        uri = node.get("uri")
+        if not uri:
+            raise CacheResetError(f"Worker node has no 'uri' in /v1/node response: {node}")
+        # /v1/node's "uri" is the status-heartbeat URL (.../v1/status), not a bare base
+        # URI — strip that suffix before appending /v1/operation/... or every request 404s.
+        uris.append(uri.rstrip("/").removesuffix("/v1/status"))
+    return uris
+
+
+def wait_for_idle_cluster(hostname: str, port: int, timeout_seconds: float = _IDLE_WAIT_SECONDS) -> None:
+    """Block until no query on the coordinator is in a non-terminal state.
+
+    AsyncDataCache::clear() does not evict pinned entries, so clearing while a query
+    holds pins leaves a nominally cold reset partly warm. Raises CacheResetError if
+    queries are still active after *timeout_seconds*.
+    """
+    deadline = time.monotonic() + timeout_seconds
+    active = []
+    while True:
+        queries = fetch_json(f"http://{hostname}:{port}/v1/query")
+        if queries is None:
+            raise CacheResetError(f"Could not read /v1/query on {hostname}:{port} to check for active queries.")
+
+        active = [
+            (q.get("queryId"), q.get("state"))
+            for q in queries
+            if isinstance(q, dict) and str(q.get("state", "")).upper() not in _TERMINAL_QUERY_STATES
+        ]
+        if not active:
+            return
+        if time.monotonic() >= deadline:
+            break
+        time.sleep(_IDLE_POLL_SECONDS)
+
+    details = ", ".join(f"{query_id} ({state})" for query_id, state in sorted(active, key=lambda q: str(q[0])))
+    raise CacheResetError(
+        f"Refusing to clear worker caches while queries are active after {timeout_seconds:g}s: {details}. "
+        "Cache-mode runs need exclusive use of the cluster."
+    )
+
+
+def _clear_tier(worker_uri: str, cache_type: str, cleared_body: str) -> str | None:
+    """Clear one server cache tier, returning its body, or None if it is not configured."""
+    body = fetch_text(f"{worker_uri}/v1/operation/server/clearCache?type={cache_type}")
+    if body is None:
+        raise CacheResetError(f"{worker_uri}: {cache_type} clear request failed")
+    body = body.strip()
+    if body == cleared_body:
+        return body
+    if body in _NOT_CONFIGURED:
+        return None
+    raise CacheResetError(f"{worker_uri}: {cache_type} clear returned {body!r}, expected {cleared_body!r}")
+
+
+def _clear_one_worker(worker_uri: str, connector_id: str) -> set[str]:
+    """Clear this worker's caches, returning the layers that were actually cleared."""
+    handles = fetch_text(f"{worker_uri}/v1/operation/connector/clearCache?name=hive&id={connector_id}")
+    if handles is None:
+        raise CacheResetError(f"{worker_uri}: connector/clearCache failed (is --connector-id={connector_id} correct?)")
+
+    layers = {FILE_HANDLE_LAYER}
+    if _clear_tier(worker_uri, "memory", _MEMORY_CLEARED):
+        layers.add(MEMORY_LAYER)
+    if _clear_tier(worker_uri, "ssd", _SSD_CLEARED):
+        layers.add(SSD_LAYER)
+    return layers
+
+
+def clear_worker_data_caches(
+    hostname: str,
+    port: int,
+    connector_id: str = DEFAULT_CONNECTOR_ID,
+    require_idle: bool = True,
+) -> set[str]:
+    """Clear the Hive file-handle cache and Velox memory/SSD data caches on every worker.
+
+    Clears workers concurrently but does not return until all have replied, and raises
+    unless *every* worker was cleared: data on an un-cleared worker is still warm, and
+    reporting that as cold defeats the point. Clusters here are homogeneous
+    (start_presto_helper.sh picks one of java/native-cpu/native-gpu), so a partial clear
+    means something is wrong rather than a mixed-worker cluster.
+
+    `name=hive` is the connector *type*, not the catalog: presto-native's
+    clearConnectorCache only implements "hive" (anything else VELOX_USER_FAILs), while
+    `id` / --connector-id selects which catalog of that type to clear.
+    """
+    if require_idle:
+        wait_for_idle_cluster(hostname, port)
+
+    uris = _worker_uris(hostname, port)
+    errors = []
+    layers: set[str] = set()
+    with ThreadPoolExecutor(max_workers=min(32, len(uris)), thread_name_prefix="cache-reset") as executor:
+        futures = {executor.submit(_clear_one_worker, uri, connector_id): uri for uri in uris}
+        for future, uri in futures.items():
+            try:
+                layers |= future.result()
+            except CacheResetError as error:
+                errors.append(str(error))
+
+    if errors:
+        details = "\n".join(f"  {message}" for message in sorted(errors))
+        raise CacheResetError(
+            f"Cleared caches on only {len(uris) - len(errors)}/{len(uris)} worker(s); refusing to report these "
+            f"timings as reset. Every worker must be presto-native (Java workers do not expose /v1/operation).\n"
+            f"{details}"
+        )
+
+    global _warned_no_memory_cache
+    if MEMORY_LAYER not in layers and not _warned_no_memory_cache:
+        _warned_no_memory_cache = True
+        print(
+            "Warning: no worker has a Velox memory cache configured, so there was none to clear. "
+            "Cache-mode runs on this cluster only control the file-handle and OS page caches."
+        )
+    return layers
+
+
+def cold_run_reset(
+    hostname: str,
+    port: int,
+    connector_id: str = DEFAULT_CONNECTOR_ID,
+    skip_os_drop: bool = False,
+) -> set[str]:
+    """Full cache reset: clear worker data caches, then drop the OS page cache.
+
+    Used by every --cache-mode that resets anything, at that mode's cadence — despite
+    the name, not cold-specific. Does not restart Presto. Propagates CacheResetError if
+    the cluster is busy or any worker could not be cleared.
+
+    skip_os_drop mirrors --skip-drop-cache: worker caches are still cleared, but the
+    privileged OS page-cache drop is skipped. Returns the layers actually cleared, which
+    is what gets recorded in the run metadata.
+    """
+    layers = clear_worker_data_caches(hostname, port, connector_id)
+    if skip_os_drop:
+        print("[CacheReset] Skipping OS page-cache drop (--skip-drop-cache set).")
+        return layers
+    drop_cache()
+    return layers | {OS_PAGE_CACHE_LAYER}

--- a/presto/testing/performance_benchmarks/common_fixtures.py
+++ b/presto/testing/performance_benchmarks/common_fixtures.py
@@ -16,6 +16,7 @@ from common.testing.performance_benchmarks.conftest import get_output_dir
 from common.testing.performance_benchmarks.profiler_utils import start_profiler, stop_profiler
 
 from ..integration_tests.analyze_tables import check_tables_analyzed
+from .cache_reset import cold_run_reset
 from .ctas import (
     CTAS_CATALOG,
     CTAS_SCHEMA,
@@ -27,6 +28,18 @@ from .ctas import (
 )
 from .metrics_collector import collect_metrics
 from .run_context import gather_run_context
+
+# Session attribute marking that --cache-mode=lukewarm's one-time reset has run.
+_LUKEWARM_RESET_DONE = "_cache_mode_lukewarm_reset_done"
+# Modes that clear worker-side caches, and so require native (not Java) workers.
+_WORKER_CLEARING_MODES = frozenset({"lukewarm", "cold-once", "cold"})
+# Session attribute holding the cache layers a reset actually cleared, for run metadata.
+CACHE_RESET_LAYERS = "_cache_reset_layers"
+
+
+def _record_reset_layers(request, layers):
+    """Accumulate the cache layers a reset actually cleared onto the session."""
+    setattr(request.session, CACHE_RESET_LAYERS, getattr(request.session, CACHE_RESET_LAYERS, set()) | layers)
 
 
 def write_query_result(cursor, output_dir, query_id):
@@ -102,6 +115,13 @@ def run_context_collector(request):
         user=user,
         schema_name=schema_name,
     )
+    cache_mode = request.config.getoption("--cache-mode")
+    if cache_mode in _WORKER_CLEARING_MODES and ctx.get("engine") == "presto-java":
+        pytest.exit(
+            f"--cache-mode={cache_mode} needs native Presto workers: Java workers do not expose the Velox "
+            "cache-control API at /v1/operation. Use --cache-mode=off (the default) or hot.",
+            returncode=1,
+        )
     ctx["timestamp"] = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
     yield ctx
     request.session.run_context = ctx
@@ -148,6 +168,12 @@ def benchmark_query(request, presto_cursor, benchmark_queries, benchmark_result_
     bench_output_dir = get_output_dir(request.config)
     hostname = request.config.getoption("--hostname")
     port = request.config.getoption("--port")
+    cache_mode = request.config.getoption("--cache-mode")
+    connector_id = request.config.getoption("--connector-id")
+    skip_drop_cache = request.config.getoption("--skip-drop-cache")
+
+    if profile and cache_mode == "cold":
+        print("[CacheMode=cold] Warning: profile trace will include per-iteration cache-reset overhead.")
 
     if profile:
         assert profile_script_path is not None
@@ -170,12 +196,25 @@ def benchmark_query(request, presto_cursor, benchmark_queries, benchmark_result_
         profile_output_file_path = None
         scratch_table = None
         try:
+            # Once-per-query and once-per-session resets run before the profiler starts,
+            # so their overhead stays out of the trace.
+            if cache_mode == "cold-once":
+                print(f"[CacheMode=cold-once] Resetting caches before {query_id}'s iterations.")
+                _record_reset_layers(request, cold_run_reset(hostname, port, connector_id, skip_drop_cache))
+            elif cache_mode == "lukewarm" and not getattr(request.session, _LUKEWARM_RESET_DONE, False):
+                print("[CacheMode=lukewarm] Resetting caches once before the first measured query.")
+                _record_reset_layers(request, cold_run_reset(hostname, port, connector_id, skip_drop_cache))
+                setattr(request.session, _LUKEWARM_RESET_DONE, True)
             if profile:
                 # Base path without .nsys-rep extension: {dir}/{query_id}
                 profile_output_file_path = f"{profile_output_dir_path.absolute()}/{query_id}"
                 start_profiler(profile_script_path, profile_output_file_path)
             result = []
             for iteration_num in range(iterations):
+                if cache_mode == "cold":
+                    # Reset before every iteration — no first-vs-rest split, unlike hot/lukewarm.
+                    print(f"[CacheMode=cold] Resetting caches before {query_id} iteration {iteration_num}.")
+                    _record_reset_layers(request, cold_run_reset(hostname, port, connector_id, skip_drop_cache))
                 if ctas_results is not None:
                     # Retain the first iteration as the query result. Later
                     # iterations use short-lived tables so every measured

--- a/presto/testing/performance_benchmarks/conftest.py
+++ b/presto/testing/performance_benchmarks/conftest.py
@@ -23,6 +23,7 @@ from ..common.fixtures import (
     tpcds_queries,  # noqa: F401
     tpch_queries,  # noqa: F401
 )
+from .cache_reset import DEFAULT_CONNECTOR_ID
 from .common_fixtures import (
     benchmark_query,  # noqa: F401
     ctas_results,  # noqa: F401
@@ -47,9 +48,45 @@ def pytest_addoption(parser):
     parser.addoption("--profile-script-path")
     parser.addoption("--metrics", action="store_true", default=False)
     parser.addoption("--skip-drop-cache", action="store_true", default=False)
+    parser.addoption(
+        "--cache-mode",
+        choices=["off", "lukewarm", "cold-once", "cold", "hot"],
+        default="off",
+        help=(
+            "Cache reset schedule (default: off); never restarts Presto. off: legacy "
+            "behavior — OS page-cache drop once, no worker cache clearing, and the only "
+            "mode that works against Java workers. lukewarm: full reset once, before the "
+            "first measured query. cold-once: full reset before each query's iterations, "
+            "giving one cold sample then hot ones. cold: full reset before every "
+            "iteration. hot: no resets; --warmup-iterations primes the cache. See "
+            "presto/testing/performance_benchmarks/cache_reset.py."
+        ),
+    )
+    parser.addoption(
+        "--warmup-iterations",
+        default=1,
+        type=int,
+        help="Leading iterations per query that prime the cache and are excluded from the aggregate stats.",
+    )
+    parser.addoption(
+        "--connector-id",
+        default=DEFAULT_CONNECTOR_ID,
+        help="Connector ID to target for worker cache-clear operations (must match the catalog name).",
+    )
     parser.addoption("--skip-analyze-check", action="store_true", default=False)
     parser.addoption("--run-as-ctas-queries", action="store_true", default=False)
 
 
 def pytest_configure(config):
+    # Validate rather than silently falling back at report time: a warm-up iteration
+    # reported as a steady-state number is worse than a failed run.
+    warmup = config.getoption("--warmup-iterations")
+    iterations = config.getoption("--iterations")
+    if warmup < 0:
+        raise pytest.UsageError(f"--warmup-iterations must be >= 0, got {warmup}")
+    if config.getoption("--cache-mode") != "cold" and warmup >= iterations:
+        raise pytest.UsageError(
+            f"--warmup-iterations ({warmup}) must be less than --iterations ({iterations}); "
+            "otherwise every iteration is a warm-up and there is nothing left to report."
+        )
     pytest.data_location = DataLocation("--schema-name", "Schema", BenchmarkKeys.SCHEMA_NAME_KEY)


### PR DESCRIPTION
## What

Adds `--cache-mode {lukewarm,hot,cold}` to the Presto TPC-H/TPC-DS pytest
benchmark harness (`run_benchmark.sh`), so cache-reset behavior for cold-IO
benchmarking is explicit and correct, instead of an accidental side effect
of a single session-start OS-cache drop.

## Why

The harness reported a `Lukewarm(ms)` column (iteration 0's raw time) next
to `Hot(ms)` stats (iterations 1..N-1), but the only automatic cache reset
was a single OS page-cache drop at the very start of the whole pytest
session — presto-native's own Velox memory/SSD cache and the Hive
connector's file-handle cache were never cleared at all. So "Lukewarm" was
only meaningfully cold for the very first query of a run; every later
query's "Lukewarm" number silently rode on whatever cache warmth earlier
queries left behind — not comparable across queries, query order, or runs.

## The modes

Adapted from @kjmph's [c5a43f9](https://github.com/kjmph/velox-testing/commit/c5a43f9fcb75b309c21f78ec3375c040d9554984), which contributed the `cold-once` shape, the idle-cluster check, exact success-body matching, and concurrent clears.

| Mode | Reset schedule | What gets reported |
|---|---|---|
| **`off`** (default) | Legacy behavior: OS page-cache drop once, **no worker cache clearing**. The only mode Java workers support. | `Lukewarm(ms)` + `Hot(ms)` — unchanged from today |
| **`lukewarm`** | Full reset **once**, before the first measured query. | `Lukewarm(ms)` + `Hot(ms)` |
| **`cold-once`** | Full reset before **each query's** iteration group. | `Cold(ms)` (iteration 0) + `Hot(ms)` (the rest) |
| **`cold`** | Full reset before **every iteration**. | `Cold(ms)` aggregates only |
| **`hot`** | **No resets.** First `--warmup-iterations` prime the cache. | `Hot(ms)` aggregates only — warm-ups never reported |

```
                    Q1 iter0    Q1 iter1    Q1 iter2    Q2 iter0    Q2 iter1
off/lukewarm  reset─┬───────────────────────────────────────────────────────▶
                    └─ once per run

cold-once     reset─┬─────────────────────▶ reset─┬─────────────────────────▶
                    └ Cold   └ Hot  └ Hot         └ Cold   └ Hot

cold          reset─┼─ reset─┼─ reset─┼─ reset─┼─ reset─┼─▶
                    └ Cold   └ Cold   └ Cold   └ Cold   └ Cold

hot           ──[ warm-up ][ measured ][ measured ]─────────────────────────▶
                 not reported    └ Hot      └ Hot
```

Cache clearing hits presto-native's `/v1/operation/{connector,server}/clearCache`
REST endpoints (GET, per `PrestoServer.cpp`'s `registerGet` — not POST, which
404s) on every worker discovered via the coordinator's `/v1/node`, concurrently,
followed by the OS page-cache drop.

**Resets fail closed.** The cluster must be idle before and after
(`AsyncDataCache::clear()` keeps *pinned* entries, so clearing mid-query is only
partly cold), every worker must be cleared, and responses are matched against the
exact success body — the endpoint answers `200` with `No memory cache set on
server` for no-ops, so trusting the status code reports warm numbers as cold.

A tier that simply isn't configured is *reported*, not failed: this repo's GPU
worker ships without an AsyncDataCache, so cold modes there control the
file-handle and OS page caches only. The run metadata records the layers actually
cleared, so it can't claim a reset that never happened.

**Known limitation:** `drop_cache()` writes `/proc/sys/vm/drop_caches` on the host
running pytest only. That covers workers sharing that kernel (the single-node
Docker setup this was tested on), but does nothing for remote workers — so `cold`
numbers from a multi-node cluster are not truly cold. A real per-worker drop would
be a follow-up.

## New flags

- `--cache-mode {off,lukewarm,cold-once,cold,hot}` (default `off`)
- `--warmup-iterations N` (default `1`) — leading iterations per query that prime the cache and are excluded from the aggregate stats. Validated at startup: must be `>= 0` and `< --iterations`.
- `--connector-id ID` (default `hive`) — the *catalog* to clear. The connector **type** is always `hive`: native's `clearConnectorCache` only implements `name == "hive"` and `VELOX_USER_FAIL`s on anything else.

## Compatibility

- The default is now `off`, which is behaviorally identical to today: OS page-cache drop once, no worker clearing, same reported columns, no `Cache Mode:` line. Existing baselines and Java clusters are unaffected.
- Opting into any other mode changes timings by design (they clear caches the old code never touched). `lukewarm`/`cold-once`/`cold` require native workers; the run fails fast with a clear message on `presto-java`.
- `Cache Mode:` / `cache_mode` / `cache_reset_layers` appear in the report and JSON context only for non-`off` modes (`post_results.py` filters context to known fields, so the extra keys are ignored there).
- `spark_gluten` never registers `--cache-mode`, so its report stays byte-identical.

## Testing

- `common/testing/cache_mode_reporting_test.py` (new, 16 cases): header/stat shape invariants across all modes and iteration counts, per-mode column expectations, the `spark_gluten` unregistered-`--cache-mode` fallback, and degenerate inputs (failed queries, `--warmup-iterations >= --iterations`). Matches the existing `*_test.py` convention in `common/testing/`; like its siblings there it is run manually, not by CI.
- Live runs against a presto-native GPU cluster (TPC-H SF10) for all three modes: reset cadence (1 reset for lukewarm, 0 for hot, one-per-iteration for cold), successful worker REST calls, and correct per-mode report columns.
- Failure path verified live with a bogus `--connector-id`: the run now aborts with a `RuntimeError` and reports `NULL` instead of printing plausible-looking `Cold(ms)` numbers from caches that were never cleared.
- `presto/testing/cache_reset_test.py` (new, 3 cases): all-workers-cleared succeeds and strips the `/v1/status` suffix, partial clear raises, no-nodes raises.


