### PR TITLE
Update pip devcontainers to UCX 1.21

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -4,7 +4,7 @@
 # RAPIDS build utilities and cuDF development.
 
 ARG CUDA_VERSION=12.9
-ARG BASE=rapidsai/devcontainers:latest-cpp-cuda12.9-ucx1.19.0-openmpi5.0.7
+ARG BASE=rapidsai/devcontainers:latest-cpp-cuda12.9-ucx1.21.0-openmpi5.0.7
 
 FROM ${BASE}
 

--- a/.devcontainer/cuda12.9/devcontainer.json
+++ b/.devcontainer/cuda12.9/devcontainer.json
@@ -5,7 +5,7 @@
     "dockerfile": "${localWorkspaceFolder}/.devcontainer/Dockerfile",
     "args": {
       "CUDA_VERSION": "12.9",
-      "BASE": "rapidsai/devcontainers:latest-cpp-cuda12.9-ucx1.19.0-openmpi5.0.10"
+      "BASE": "rapidsai/devcontainers:latest-cpp-cuda12.9-ucx1.21.0-openmpi5.0.10"
     }
   },
   "features": {

--- a/.devcontainer/cuda13.3/devcontainer.json
+++ b/.devcontainer/cuda13.3/devcontainer.json
@@ -5,7 +5,7 @@
     "dockerfile": "${localWorkspaceFolder}/.devcontainer/Dockerfile",
     "args": {
       "CUDA_VERSION": "13.3",
-      "BASE": "rapidsai/devcontainers:latest-cpp-cuda13.3-ucx1.19.0-openmpi5.0.10"
+      "BASE": "rapidsai/devcontainers:latest-cpp-cuda13.3-ucx1.21.0-openmpi5.0.10"
     },
     "cacheFrom": [
       "ghcr.io/rapidsai/velox-testing/devcontainer:latest-cuda13.3"


### PR DESCRIPTION
This updates pip devcontainers from UCX 1.19 to UCX 1.21.

Part of https://github.com/rapidsai/build-planning/issues/314.
