### PR TITLE
feat(ci): Auto-fetch Velox staging PRs from github project board and add nightly staging workflow

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -7,7 +7,7 @@ This directory contains GitHub Actions workflows for automated testing, benchmar
 | Workflow | Purpose | Notes |
 |----------|---------|-------|
 | **Staging Branch Management** |||
-| `staging.yml` | Creates the staging branch, then builds CI images from it | Schedule (3am UTC) + manual dispatch |
+| `staging.yml` | Nightly staging branch refresh (Velox; Presto to follow) | Schedule (3am UTC) + manual dispatch |
 | `create-staging-composite.yml` | Reusable workflow for creating staging branches | Supports additional repo merge + PR merging |
 | `velox-create-staging.yml` | Creates Velox staging branch by merging cuDF PRs | Auto-fetches PRs from the NVIDIA project board by default |
 | `presto-create-staging.yml` | Creates Presto staging branch by merging specified PRs | Requires manual PR numbers (no auto-fetch) |
@@ -213,9 +213,7 @@ Browse available tags at [ghcr.io/rapidsai/velox-testing-images](https://github.
 ```
 STAGING
 ───────
-              ┌─► velox-create-staging.yml ──► create-staging-composite.yml ──► [staging branch]
-staging.yml ──┤
-              └─► velox.yml ──► [CI images from rapidsai/velox@staging]
+staging.yml ──► velox-create-staging.yml ──► create-staging-composite.yml ──► [staging branch]
 
 velox-create-staging.yml (workflow_dispatch) ──► create-staging-composite.yml ──► [staging branch]
 presto-create-staging.yml (workflow_dispatch) ──► create-staging-composite.yml ──► [staging branch]

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -7,8 +7,9 @@ This directory contains GitHub Actions workflows for automated testing, benchmar
 | Workflow | Purpose | Notes |
 |----------|---------|-------|
 | **Staging Branch Management** |||
+| `staging.yml` | Creates the staging branch, then builds CI images from it | Schedule (3am UTC) + manual dispatch |
 | `create-staging-composite.yml` | Reusable workflow for creating staging branches | Supports additional repo merge + PR merging |
-| `velox-create-staging.yml` | Creates Velox staging branch by merging cuDF PRs | Auto-fetches PRs with `cudf` label by default |
+| `velox-create-staging.yml` | Creates Velox staging branch by merging cuDF PRs | Auto-fetches PRs from the NVIDIA project board by default |
 | `presto-create-staging.yml` | Creates Presto staging branch by merging specified PRs | Requires manual PR numbers (no auto-fetch) |
 | **CI Images** |||
 | `velox-nightly.yml` | Nightly Velox builds + tests + benchmarks (upstream) | Schedule (5am UTC) + manual dispatch |
@@ -187,6 +188,7 @@ Browse available tags at [ghcr.io/rapidsai/velox-testing-images](https://github.
 |--------|---------|
 | `VELOX_FORK_PAT` | GitHub PAT with write access to target Velox repository |
 | `PRESTO_FORK_PAT` | GitHub PAT with write access to target Presto repository |
+| `PROJECT_BOARD_TOKEN` | GitHub PAT with `read:project` + `read:org` for the staging project board; used only by the Fetch PR list step |
 | `AWS_ARN_STRING` | AWS ARN for S3 access |
 | `AWS_ACCESS_KEY_ID` | AWS access key |
 | `AWS_SECRET_ACCESS_KEY` | AWS secret key |
@@ -211,8 +213,12 @@ Browse available tags at [ghcr.io/rapidsai/velox-testing-images](https://github.
 ```
 STAGING
 ───────
-velox-create-staging.yml ──► create-staging-composite.yml ──► [staging branch]
-presto-create-staging.yml ──► create-staging-composite.yml ──► [staging branch]
+              ┌─► velox-create-staging.yml ──► create-staging-composite.yml ──► [staging branch]
+staging.yml ──┤
+              └─► velox.yml ──► [CI images from rapidsai/velox@staging]
+
+velox-create-staging.yml (workflow_dispatch) ──► create-staging-composite.yml ──► [staging branch]
+presto-create-staging.yml (workflow_dispatch) ──► create-staging-composite.yml ──► [staging branch]
 
 CI IMAGES (VELOX)
 ─────────────────

--- a/.github/workflows/create-staging-composite.yml
+++ b/.github/workflows/create-staging-composite.yml
@@ -21,7 +21,7 @@ on:
         required: true
         default: 'staging'
       auto_fetch_prs:
-        description: 'Auto-fetch non-draft PRs with specified label'
+        description: 'Auto-fetch open non-draft PRs'
         type: boolean
         required: false
         default: true

--- a/.github/workflows/create-staging-composite.yml
+++ b/.github/workflows/create-staging-composite.yml
@@ -73,7 +73,7 @@ jobs:
   create-staging:
     runs-on: linux-amd64-cpu4
     permissions:
-      contents: write
+      contents: read
     env:
       GH_TOKEN: ${{ secrets.fork_pat }}
       TARGET_REPO: ${{ inputs.target_repository }}

--- a/.github/workflows/create-staging-composite.yml
+++ b/.github/workflows/create-staging-composite.yml
@@ -63,6 +63,11 @@ on:
       fork_pat:
         description: 'GitHub PAT for target repository'
         required: true
+      project_board_pat:
+        description: >-
+          Optional PAT with read:project (and read:org) for the project board
+          used by auto-fetch. Falls back to fork_pat when unset.
+        required: false
 
 jobs:
   create-staging:
@@ -111,6 +116,10 @@ jobs:
         run: ${SCRIPT_PATH} ${BASE_ARGS} --step merge-additional
 
       - name: 📋 Fetch PR list
+        # Reading a project board needs scopes the fork PAT may not carry, so
+        # allow a dedicated token here without widening it for the git steps.
+        env:
+          GH_TOKEN: ${{ secrets.project_board_pat || secrets.fork_pat }}
         run: ${SCRIPT_PATH} ${BASE_ARGS} --step fetch-prs
 
       - name: 🧪 Test merge compatibility

--- a/.github/workflows/presto-create-staging.yml
+++ b/.github/workflows/presto-create-staging.yml
@@ -62,7 +62,7 @@ on:
 jobs:
   presto-create-staging:
     permissions:
-      contents: write
+      contents: read
     uses: ./.github/workflows/create-staging-composite.yml
     with:
       base_repository: ${{ inputs.base_repository }}
@@ -78,4 +78,4 @@ jobs:
       additional_branch: ${{ inputs.additional_branch }}
       script_path: ./velox-testing/presto/scripts/create_staging.sh
     secrets:
-      fork_pat: ${{ secrets.PRESTO_FORK_PAT || secrets.GITHUB_TOKEN }}
+      fork_pat: ${{ secrets.PRESTO_FORK_PAT }}

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -1,0 +1,45 @@
+name: staging
+
+on:
+  schedule:
+    - cron: "0 3 * * *"
+  workflow_call:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions: {}
+
+jobs:
+  velox-staging:
+    permissions:
+      contents: read
+    uses: ./.github/workflows/velox-create-staging.yml
+    with:
+      target_repository: rapidsai/velox
+      target_branch: staging
+      auto_fetch_prs: true
+      # staging is rebuilt from upstream main every run, so the push is never a
+      # fast-forward over the previous branch.
+      force_push: true
+    secrets: inherit  # zizmor: ignore[secrets-inherit]
+
+  velox-staging-images:
+    needs: [velox-staging]
+    permissions:
+      contents: read
+      id-token: write
+      packages: write
+      attestations: write
+      artifact-metadata: write
+    uses: ./.github/workflows/velox.yml
+    with:
+      variant_label: staging
+      velox_repository: rapidsai/velox
+      velox_commit: staging
+      run_tests: true
+      build_type: nightly
+      build_variant: staging
+    secrets: inherit  # zizmor: ignore[secrets-inherit]

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -4,8 +4,6 @@ on:
   # TEMPORARY: lets this branch be exercised before it reaches main, where
   # workflow_dispatch becomes available. Remove before merging.
   push:
-    branches:
-      - feat/velox-staging-from-project-board
   schedule:
     - cron: "0 3 * * *"
   workflow_call:

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -25,21 +25,3 @@ jobs:
       # fast-forward over the previous branch.
       force_push: true
     secrets: inherit  # zizmor: ignore[secrets-inherit]
-
-  velox-staging-images:
-    needs: [velox-staging]
-    permissions:
-      contents: read
-      id-token: write
-      packages: write
-      attestations: write
-      artifact-metadata: write
-    uses: ./.github/workflows/velox.yml
-    with:
-      variant_label: staging
-      velox_repository: rapidsai/velox
-      velox_commit: staging
-      run_tests: true
-      build_type: nightly
-      build_variant: staging
-    secrets: inherit  # zizmor: ignore[secrets-inherit]

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -1,9 +1,6 @@
 name: staging
 
 on:
-  # TEMPORARY: lets this branch be exercised before it reaches main, where
-  # workflow_dispatch becomes available. Remove before merging.
-  push:
   schedule:
     - cron: "0 3 * * *"
   workflow_call:

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -1,6 +1,11 @@
 name: staging
 
 on:
+  # TEMPORARY: lets this branch be exercised before it reaches main, where
+  # workflow_dispatch becomes available. Remove before merging.
+  push:
+    branches:
+      - feat/velox-staging-from-project-board
   schedule:
     - cron: "0 3 * * *"
   workflow_call:

--- a/.github/workflows/velox-create-staging.yml
+++ b/.github/workflows/velox-create-staging.yml
@@ -25,16 +25,17 @@ on:
         default: 'staging'
       auto_fetch_prs:
         description: >-
-          Auto-fetch non-draft PRs with 'cudf' label
-          from 'facebookincubator/velox' (https://github.com/facebookincubator/velox)
+          Auto-fetch open non-draft facebookincubator/velox PRs from
+          https://github.com/orgs/NVIDIA/projects/306/views/4 whose Velox Staging
+          field is Staging
         type: boolean
         required: false
         default: true
       pr_labels:
-        description: Comma-separated PR labels to auto-fetch
+        description: Comma-separated PR labels to auto-fetch (overrides the project board)
         type: string
         required: false
-        default: 'cudf'
+        default: ''
       manual_pr_numbers:
         description: "Comma-separated PR numbers to merge (e.g., '12345,12346')"
         type: string
@@ -54,12 +55,12 @@ on:
         description: 'Additional repository to merge from'
         type: string
         required: false
-        default: 'rapidsai/velox'
+        default: ''
       additional_branch:
         description: 'Branch from additional repository to merge'
         type: string
         required: false
-        default: 'cudf_exchange/rebase_latest/ibm-research-preview'
+        default: ''
 
 jobs:
   velox-create-staging:

--- a/.github/workflows/velox-create-staging.yml
+++ b/.github/workflows/velox-create-staging.yml
@@ -82,3 +82,4 @@ jobs:
       script_path: ./velox-testing/velox/scripts/create_staging.sh
     secrets:
       fork_pat: ${{ secrets.VELOX_FORK_PAT || secrets.GITHUB_TOKEN }}
+      project_board_pat: ${{ secrets.PROJECT_BOARD_TOKEN }}

--- a/.github/workflows/velox-create-staging.yml
+++ b/.github/workflows/velox-create-staging.yml
@@ -3,69 +3,81 @@ name: Velox Create Staging Branch
 on:
   workflow_dispatch:
     inputs:
-      base_repository:
+      base_repository: &base_repository
         description: Base Velox repository
         type: string
         required: false
         default: 'facebookincubator/velox'
-      base_branch:
+      base_branch: &base_branch
         description: Base Velox branch
         type: string
         required: false
         default: 'main'
-      target_repository:
+      target_repository: &target_repository
         description: Target Velox repository
         type: string
-        required: true
+        required: false
         default: 'rapidsai/velox'
-      target_branch:
+      target_branch: &target_branch
         description: Target Velox branch
         type: string
         required: false
         default: 'staging'
-      auto_fetch_prs:
+      auto_fetch_prs: &auto_fetch_prs
         description: >-
-          Auto-fetch open non-draft facebookincubator/velox PRs from
-          https://github.com/orgs/NVIDIA/projects/306/views/4 whose Velox Staging
-          field is Staging
+          Auto-fetch open non-draft facebookincubator/velox PRs from the project board.
         type: boolean
         required: false
         default: true
-      pr_labels:
+      pr_labels: &pr_labels
         description: Comma-separated PR labels to auto-fetch (overrides the project board)
         type: string
         required: false
         default: ''
-      manual_pr_numbers:
+      manual_pr_numbers: &manual_pr_numbers
         description: "Comma-separated PR numbers to merge (e.g., '12345,12346')"
         type: string
         required: false
         default: ''
-      exclude_pr_numbers:
+      exclude_pr_numbers: &exclude_pr_numbers
         description: "Comma-separated PR numbers to exclude from auto-fetch results (e.g., '12345,12346')"
         type: string
         required: false
         default: ''
-      force_push:
+      force_push: &force_push
         description: Force push to override existing target branch
         type: boolean
         required: false
         default: false
-      additional_repository:
+      additional_repository: &additional_repository
         description: 'Additional repository to merge from'
         type: string
         required: false
         default: ''
-      additional_branch:
+      additional_branch: &additional_branch
         description: 'Branch from additional repository to merge'
         type: string
         required: false
         default: ''
 
+  workflow_call:
+    inputs:
+      base_repository: *base_repository
+      base_branch: *base_branch
+      target_repository: *target_repository
+      target_branch: *target_branch
+      auto_fetch_prs: *auto_fetch_prs
+      pr_labels: *pr_labels
+      manual_pr_numbers: *manual_pr_numbers
+      exclude_pr_numbers: *exclude_pr_numbers
+      force_push: *force_push
+      additional_repository: *additional_repository
+      additional_branch: *additional_branch
+
 jobs:
   velox-create-staging:
     permissions:
-      contents: write
+      contents: read
     uses: ./.github/workflows/create-staging-composite.yml
     with:
       base_repository: ${{ inputs.base_repository }}
@@ -81,5 +93,5 @@ jobs:
       additional_branch: ${{ inputs.additional_branch }}
       script_path: ./velox-testing/velox/scripts/create_staging.sh
     secrets:
-      fork_pat: ${{ secrets.VELOX_FORK_PAT || secrets.GITHUB_TOKEN }}
+      fork_pat: ${{ secrets.VELOX_FORK_PAT }}
       project_board_pat: ${{ secrets.PROJECT_BOARD_TOKEN }}

--- a/scripts/create_staging_branch.sh
+++ b/scripts/create_staging_branch.sh
@@ -30,6 +30,12 @@ MODE="local"
 STEP_NAME=""
 declare -A PR_SHA
 
+# NVIDIA libcudf project board used by Velox auto-fetch.
+# https://github.com/orgs/NVIDIA/projects/306/views/4
+VELOX_STAGING_PROJECT_OWNER="NVIDIA"
+VELOX_STAGING_PROJECT_NUMBER="306"
+VELOX_STAGING_PROJECT_QUERY="velox-staging:Staging is:pr is:open"
+
 log() { echo "$@" >&2; }
 die() { log "ERROR: $*"; exit 1; }
 STEP=0
@@ -121,10 +127,11 @@ Options:
   --base-branch branch             Base branch (default: ${BASE_BRANCH})
   --target-branch branch           Target branch (default: ${TARGET_BRANCH})
   --work-dir path                  Directory to clone target repo (default: ${WORK_DIR})
-  --auto-fetch-prs true|false      Auto-fetch non-draft PRs with label (default: ${AUTO_FETCH_PRS})
+  --auto-fetch-prs true|false      Auto-fetch open non-draft PRs from the NVIDIA project board
+                                   (https://github.com/orgs/NVIDIA/projects/306/views/4)
   --manual-pr-numbers "1,2,3"      Comma-separated PR numbers to merge (disables auto-fetch)
   --exclude-pr-numbers "4,5,6"    Comma-separated PR numbers to exclude from auto-fetch results
-  --pr-labels labels               Comma-separated PR labels to auto-fetch (default: ${PR_LABELS})
+  --pr-labels labels               If set, auto-fetch by GitHub labels instead of the project board
   --manifest-template path         Manifest template path (default: repo template)
   --force-push true|false          Force push to target branch (default: ${FORCE_PUSH})
   --additional-repository repo     Additional repository to merge from (e.g., rapidsai/cudf)
@@ -149,8 +156,7 @@ Examples:
   ./scripts/create_staging_branch.sh \\
     --target-path ../velox \\
     --base-repository facebookincubator/velox \\
-    --base-branch main \\
-    --pr-labels "cudf"
+    --base-branch main
 
   # Manual PR list (auto-fetch disabled automatically):
   ./scripts/create_staging_branch.sh \\
@@ -162,7 +168,6 @@ Examples:
   ./scripts/create_staging_branch.sh \\
     --target-path ../velox \\
     --base-repository facebookincubator/velox \\
-    --pr-labels "cudf" \\
     --additional-repository rapidsai/cudf \\
     --additional-branch velox-exchange
 
@@ -295,24 +300,77 @@ reset_target_branch() {
   log "Base commit: ${BASE_COMMIT}"
 }
 
+# Open, non-draft PR numbers in BASE_REPO (space-separated).
+list_open_nondraft_prs() {
+  gh pr list \
+    --repo "${BASE_REPO}" \
+    --state open \
+    --limit 200 \
+    --json number,isDraft \
+    --jq '.[] | select(.isDraft == false) | .number' \
+    | tr '\n' ' ' | xargs || true
+}
+
+# PRs on https://github.com/orgs/NVIDIA/projects/306 whose "Velox Staging"
+# field is Staging, limited to BASE_REPO. Token needs the read:project scope.
+fetch_prs_from_project() {
+  local jq_filter
+  jq_filter=".items[]
+    | select((.content.type == \"PullRequest\")
+        and (.\"velox Staging\" == \"Staging\")
+        and (.content.repository == \"${BASE_REPO}\"))
+    | .content.number"
+
+  local board_prs open_prs kept skipped pr
+  board_prs="$(gh project item-list "${VELOX_STAGING_PROJECT_NUMBER}" \
+    --owner "${VELOX_STAGING_PROJECT_OWNER}" \
+    --limit 200 \
+    --query "${VELOX_STAGING_PROJECT_QUERY}" \
+    --format json \
+    -q "${jq_filter}" | tr '\n' ' ' | xargs || true)"
+  open_prs="$(list_open_nondraft_prs)"
+
+  kept=""
+  for pr in ${board_prs}; do
+    skipped=true
+    for open_pr in ${open_prs}; do
+      if [[ "${pr}" == "${open_pr}" ]]; then
+        skipped=false
+        break
+      fi
+    done
+    if [[ "${skipped}" == "true" ]]; then
+      log "Skipping project PR #${pr} (not an open non-draft PR on ${BASE_REPO})"
+      continue
+    fi
+    kept="${kept} ${pr}"
+  done
+  echo "${kept}" | xargs || true
+}
+
 fetch_pr_list() {
   local pr_list=""
   if [[ "${AUTO_FETCH_PRS}" == "true" ]]; then
-    step "Auto-fetch PRs with labels: ${PR_LABELS}"
-    local label_args=()
-    local labels=()
-    IFS=',' read -r -a labels <<< "${PR_LABELS}"
-    for label in "${labels[@]}"; do
-      label="$(echo "${label}" | xargs)"
-      [[ -z "${label}" ]] && continue
-      label_args+=(--label "${label}")
-    done
-    pr_list="$(gh pr list \
-      --repo "${BASE_REPO}" \
-      "${label_args[@]}" \
-      --state open \
-      --json number,isDraft \
-      --jq '.[] | select(.isDraft == false) | .number' | tr '\n' ' ' | xargs || true)"
+    if [[ -n "${PR_LABELS}" ]]; then
+      step "Auto-fetch PRs with labels: ${PR_LABELS}"
+      local label_args=()
+      local labels=()
+      IFS=',' read -r -a labels <<< "${PR_LABELS}"
+      for label in "${labels[@]}"; do
+        label="$(echo "${label}" | xargs)"
+        [[ -z "${label}" ]] && continue
+        label_args+=(--label "${label}")
+      done
+      pr_list="$(gh pr list \
+        --repo "${BASE_REPO}" \
+        "${label_args[@]}" \
+        --state open \
+        --json number,isDraft \
+        --jq '.[] | select(.isDraft == false) | .number' | tr '\n' ' ' | xargs || true)"
+    else
+      step "Fetch Staging PRs from Preso GPU Project Board"
+      pr_list="$(fetch_prs_from_project)"
+    fi
   else
     pr_list="$(echo "${MANUAL_PR_NUMBERS}" | tr ',' ' ' | xargs || true)"
   fi

--- a/velox/scripts/create_staging.sh
+++ b/velox/scripts/create_staging.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -9,13 +12,13 @@ usage() {
   cat << EOF
 Velox Staging Branch Creator
 
-Creates a staging branch by merging PRs with "cudf" label from facebookincubator/velox.
+Creates a staging branch by merging PRs from the NVIDIA libcudf project
+board (Velox Staging = Staging) that target facebookincubator/velox.
 Target path: ${DEFAULT_TARGET_PATH}
 
 Examples:
-  ./velox/scripts/create_staging.sh                              # Auto-fetch PRs with "cudf" label
+  ./velox/scripts/create_staging.sh                              # Auto-fetch Staging-column PRs
   ./velox/scripts/create_staging.sh --manual-pr-numbers "1,2,3"  # Merge specific PRs
-  ./velox/scripts/create_staging.sh --pr-labels "cudf,gpu"       # Multiple labels
   ./velox/scripts/create_staging.sh --force-push true            # Force push to remote
 
 Note: In local mode (default), push to remote is skipped. Use --mode ci to push.
@@ -35,5 +38,4 @@ exec "${PARENT_SCRIPT}" \
   --base-repository "facebookincubator/velox" \
   --base-branch "main" \
   --target-branch "staging" \
-  --pr-labels "cudf" \
   "$@"


### PR DESCRIPTION
## Summary

Switches staging PR auto-fetch from GitHub labels to the NVIDIA project board, and adds a `staging`
workflow that refreshes the Velox and Presto staging branches nightly.

Previously `create_staging_branch.sh` collected PRs by the `cudf` label, so staging contained whatever
happened to be labelled. There was no way to stage a PR without labelling it upstream, and no single
place to see what was queued. The board at [NVIDIA/projects/306](https://github.com/orgs/NVIDIA/projects/306/views/4) is already the team's source
of truth, so staging now reads it directly.

Image builds from the staging branch are **not** part of this PR; they live in #424.

## Where the staging branches are created

`staging.yml` runs at 03:00 UTC (plus `workflow_dispatch` / `workflow_call`) and fans out to two independent jobs with no dependency between them, so a Velox conflict does not block Presto:

| Job | Base | Target | Branches pushed | Script | Token |
|-----|------|--------|-----------------|--------|-------|
| `velox-staging` | `facebookincubator/velox@main` | `rapidsai/velox` | `staging`, `staging_MM-DD-YYYY` | `velox/scripts/create_staging.sh` | `VELOX_FORK_PAT` |
| `presto-staging` | `prestodb/presto@master` | `karthikeyann/presto` | `staging`, `staging_MM-DD-YYYY` | `presto/scripts/create_staging.sh` | `PRESTO_FORK_PAT` |

**Call chain for each job:**

```
staging.yml ──► velox-create-staging.yml ──► create-staging-composite.yml ──► [rapidsai/velox@staging]   

          └─► presto-create-staging.yml ──► create-staging-composite.yml ──► [karthikeyann/presto@staging]
```


`create-staging-composite.yml` holds the actual step sequence, and every step is one invocation of the
shared `scripts/create_staging_branch.sh`: clone the target repo, reset `staging` to the upstream base
commit, fetch the PR list from the board, test merges, merge, write `.staging-manifest.yaml`, and push.
Both `staging` and the dated snapshot go out in a single `git push` with two refspecs, so they cannot
diverge. `force_push: true` is required because `staging` is rebuilt from upstream every run and is
therefore never a fast-forward over the previous branch.

> [!IMPORTANT]
> `presto-staging` currently targets `karthikeyann/presto` for testing. This must be changed back to
> `rapidsai/presto` before merge, otherwise the nightly pushes to a personal fork — and
> `PRESTO_FORK_PAT` has no write access there, so the push step would fail.

## Changes

### PR discovery (`scripts/create_staging_branch.sh`)

- Adds `fetch_prs_from_project()`, which reads the board with a single paginated `gh api graphql` call
  and keeps items whose `Velox Staging` field is `Staging`.
- The board is addressed by its **node ID** (`PVT_kwDOABpemM4BgGAW`) rather than owner + number, per
  review feedback. The ID survives the board being renamed, moved between owners, or renumbered, and
  it skips the owner-type lookup `gh project item-list` performs — which is what required `read:org`
  on top of `read:project` and produced the misleading `unknown owner type` failure in CI.
- The GraphQL response carries `state`, `isDraft`, and `repository` per PR, so closed and draft cards
  are filtered from the same response (no second `gh pr list` call) and the skip log reports the actual
  reason, e.g. `Skipping project PR #28398 (state=OPEN, draft=true)`.
- One board serves both projects: cards for either repository share the `Velox Staging` field, so
  results are separated by `--base-repository`. Constants are named `STAGING_PROJECT_*` to reflect
  that the script is shared rather than Velox-specific.
- Keeps label-based fetching: `--pr-labels` overrides the board for one-off runs.

### Empty board is a no-op, not a failure

Auto-fetch previously aborted with `No PRs found to merge` whenever nothing was marked `Staging`, so a
quiet night failed the nightly. `fetch_pr_list` now emits `PR_COUNT=0` and returns cleanly, and the
composite skips test-merge, test-pairwise, merge, manifest, and push on that count — the target branch
is left exactly as the last successful run produced it. An explicitly supplied PR list that resolves to
empty still fails, since that is a misconfiguration.

### Token handling

- Adds an optional `project_board_pat` secret, wired from `PROJECT_BOARD_TOKEN` and applied as
  `GH_TOKEN` on the Fetch PR list step only, so board scopes stay away from the clone, merge, and push
  steps. Only `read:project` is needed now that the board is addressed by node ID.
- Drops `GITHUB_TOKEN` to `contents: read` across the staging chain. Every git operation runs with the
  fork PAT, so the write grant was unused; it had to be repeated at each level only because a called
  workflow cannot be granted more than its caller.


### Workflow plumbing

- `velox-create-staging.yml` and `presto-create-staging.yml` each gain a `workflow_call` trigger so
  `staging.yml` can call them. Inputs are declared once and aliased with YAML anchors, matching
  `velox.yml`, so there is no duplicated input block to keep in sync.
- `target_repository` moves from `required: true` to `required: false` on both; it keeps its default,
  so the dispatch forms are unchanged.
- `auto_fetch_prs` now defaults to `true` for Presto as well as Velox, and the Presto wrapper script no
  longer forces `--auto-fetch-prs false`.

## Conflict handling

Conflicts are detected up front, never auto-resolved, and abort the run before anything is pushed.
Three gates:

1. **Each PR against base** (`test-merge`) — every PR is merged with `--no-commit --no-ff`, then
   aborted and reset to `BASE_COMMIT` so tests cannot contaminate each other. All PRs are checked
   before failing, so the log lists every conflicting PR with its URL rather than just the first.
2. **Every pair together** (`test-pairwise`) — all A+B combinations are tried; on failure the log
   includes a compatibility matrix plus a table of the involved PRs with author, title, and URL.
3. **The real merge** (`merge`) — a joint conflict among three or more PRs can survive both gates
   above, so the sequential merge aborts and exits non-zero as well.

Any of these fails the step and therefore the job. "Push branches" is the last step, so it never
executes: nothing reaches the target repo and `staging` remains as the last successful run left it. The
failure propagates up through `create-staging-composite` and the per-project workflow to the
`velox-staging` or `presto-staging` job.

The trade-off is bluntness: one conflicting PR costs that project's whole nightly refresh. The escape
hatch is `exclude_pr_numbers`, reachable by dispatching the per-project workflow directly, or by
removing the card from the board.

## Deployment note

`PROJECT_BOARD_TOKEN` must exist as a repo secret (classic PAT with `read:project`, from an account
that can read project 306) before the nightly runs. 

## Testing

- Board query verified against project 306 by node ID: returns the three `Staging` cards, skips the
  draft (#28398), and keeps #27719 and #27975.
- Per-repo separation verified from the same board read: `facebookincubator/velox` resolves to `[]`
  and `prestodb/presto` to `[27719 27975]`, so neither path can see the other's cards.
- Empty-board handling verified both ways: auto-fetch exits 0 with `PR_COUNT=0`, while an empty manual
  list still exits 1.
- `staging.yml` cannot be dispatched until it is on `main`, since `workflow_dispatch` resolves workflow
  names against the default branch.